### PR TITLE
Batch error while processing vcf/maf, need to change path_to_genie

### DIFF
--- a/genie/input_to_database.py
+++ b/genie/input_to_database.py
@@ -312,7 +312,11 @@ def input_to_database(syn, center, process, testing, only_validate, vcf2maf_path
 	# ----------------------------------------
 	# Start input to staging process
 	# ----------------------------------------
-	path_to_genie = os.path.realpath(os.path.join(process_functions.SCRIPT_DIR,"../"))
+
+	#path_to_genie = os.path.realpath(os.path.join(process_functions.SCRIPT_DIR,"../"))
+	#Make the synapsecache dir the genie input folder for now
+	#The main reason for this is because the .synaspecache dir is mounted by batch
+	path_to_genie = os.path.expanduser("~/.synapseCache")
 	#Create input and staging folders
 	if not os.path.exists(os.path.join(path_to_genie,center,"input")):
 		os.makedirs(os.path.join(path_to_genie,center,"input"))


### PR DESCRIPTION
```
ERROR: Could not write to output file /root/Genie/MSK/*_vs_NORMAL.vep.vcf
```
This error makes me believe that for whatever reason, vep is not able to write to inside of the docker container, and this makes sense because VEP is mounted into the container while running.

Although can't explain why the bottom works.
```
STATUS: Running VEP and writing to: /root/Genie/JHU/data_mutations_extended_JHU.vep.vcf
```

This PR is a POSSIBLE TEMPORARY FIX- 

This issue will be revisited in the input_to_database refactor by adding a `workdir` parameter