### PR TITLE
Refactor validate command line

### DIFF
--- a/genie/__main__.py
+++ b/genie/__main__.py
@@ -78,7 +78,7 @@ def build_parser():
     parser_validate.add_argument("--nosymbol-check", action='store_true',
                                  help='Do not check hugo symbols of fusion and cna file')
 
-    parser_validate.set_defaults(func=genie.validate.perform_validate)
+    parser_validate.set_defaults(func=genie.validate._perform_validate)
     return(parser)
 
 

--- a/genie/__main__.py
+++ b/genie/__main__.py
@@ -36,74 +36,47 @@ def build_parser():
     import argparse
     parser = argparse.ArgumentParser(description='GENIE processing')
 
-    parser.add_argument(
-        "--syn_user",
-        type=str,
-        help='Synapse username')
+    parser.add_argument("--syn_user", type=str, help='Synapse username')
 
-    parser.add_argument(
-        "--syn_pass",
-        type=str,
-        help='Synapse password')
+    parser.add_argument("--syn_pass", type=str, help='Synapse password')
 
-    subparsers = parser.add_subparsers(
-        title='commands',
-        description='The following commands are available:',
-        help='For additional help: "genie <COMMAND> -h"')
+    subparsers = parser.add_subparsers(title='commands', 
+                                       description='The following commands are available:',
+                                       help='For additional help: "genie <COMMAND> -h"')
 
-    parser_validate = subparsers.add_parser(
-        'validate',
-        help='Validates GENIE file formats')
+    parser_validate = subparsers.add_parser('validate', help='Validates GENIE file formats')
 
-    parser_validate.add_argument(
-        "filepath",
-        type=str,
-        nargs="+",
-        help='File(s) that you are validating.  \
-        If you validation your clinical files and you have both sample and \
-        patient files, you must provide both')
+    parser_validate.add_argument("filepath", type=str, nargs="+",
+                                 help='File(s) that you are validating.  \
+                                       If you validation your clinical files and you have both sample and \
+                                       patient files, you must provide both')
 
-    parser_validate.add_argument(
-        "center",
-        type=str,
-        help='Contributing Centers')
+    parser_validate.add_argument("center", type=str, help='Contributing Centers')
 
-    parser_validate.add_argument(
-        "--oncotreelink",
-        type=str,
-        help="Link to oncotree code")
+    parser_validate.add_argument("--oncotreelink", type=str, help="Link to oncotree code")
 
     validate_group = parser_validate.add_mutually_exclusive_group()
 
-    validate_group.add_argument(
-        "--filetype",
-        type=str,
-        choices=genie.config.PROCESS_FILES.keys(),
-        help='By default, the validator uses the filename to match '
-             'the file format.  If your filename is incorrectly named, '
-             'it will be invalid.  If you know the file format you are '
-             'validating, you can ignore the filename validation and skip '
-             'to file content validation. '
-             'Note, the filetypes with SP at '
-             'the end are for special sponsored projects')
+    validate_group.add_argument("--filetype", type=str,
+                                choices=genie.config.PROCESS_FILES.keys(),
+                                help='By default, the validator uses the filename to match '
+                                    'the file format.  If your filename is incorrectly named, '
+                                    'it will be invalid.  If you know the file format you are '
+                                    'validating, you can ignore the filename validation and skip '
+                                    'to file content validation. '
+                                    'Note, the filetypes with SP at '
+                                    'the end are for special sponsored projects')
 
-    validate_group.add_argument(
-        "--parentid",
-        type=str,
-        default=None,
-        help='Synapse id of center input folder. '
-             'If specified, your valid files will be uploaded '
-             'to this directory.')
+    validate_group.add_argument("--parentid", type=str, default=None,
+                                help='Synapse id of center input folder. '
+                                    'If specified, your valid files will be uploaded '
+                                    'to this directory.')
 
-    parser_validate.add_argument(
-        "--testing",
-        action='store_true',
-        help='Put in testing mode')
+    parser_validate.add_argument("--testing", action='store_true', 
+                                 help='Put in testing mode')
 
-    parser_validate.add_argument(
-        "--nosymbol-check",
-        action='store_true',
-        help='Do not check hugo symbols of fusion and cna file')
+    parser_validate.add_argument("--nosymbol-check", action='store_true',
+                                 help='Do not check hugo symbols of fusion and cna file')
 
     parser_validate.set_defaults(func=genie.validate.perform_validate)
     return(parser)

--- a/genie/validate.py
+++ b/genie/validate.py
@@ -100,8 +100,7 @@ def validate_single_file(syn, filepathlist, center, filetype=None,
     if filetype is None:
         filetype = determine_filetype(syn, filepathlist, center)
     if filetype not in PROCESS_FILES:
-        raise ValueError(
-            "Your filename is incorrect! "
+        raise ValueError("Your filename is incorrect! "
             "Please change your filename before you run "
             "the validator or specify --filetype if you are "
             "running the validator locally")

--- a/genie/validate.py
+++ b/genie/validate.py
@@ -72,12 +72,8 @@ def determine_validity_and_log(total_error, warning):
     return(valid, message)
 
 
-def validate_single_file(syn,
-                         filepathlist,
-                         center,
-                         filetype=None,
-                         oncotreelink=None,
-                         testing=False,
+def validate_single_file(syn, filepathlist, center, filetype=None,
+                         oncotreelink=None, testing=False, 
                          nosymbol_check=False):
     """
     This function determines the filetype of a file

--- a/genie/validate.py
+++ b/genie/validate.py
@@ -195,7 +195,10 @@ def _upload_to_synapse(syn, filepaths, valid, parentid=None):
             logger.info("Stored to {}".format(ent.id))
 
 
-def perform_validate(syn, args):
+def _perform_validate(syn, args):
+    """This is the main entry point to the genie command line tool.
+    """
+
     # Check parentid argparse
     _check_parentid_permission_container(syn, args.parentid)
 

--- a/genie/validate.py
+++ b/genie/validate.py
@@ -76,24 +76,26 @@ def validate_single_file(syn, filepathlist, center, filetype=None,
                          oncotreelink=None, testing=False, 
                          nosymbol_check=False):
     """
-    This function determines the filetype of a file
+    This function determines the filetype of a single submitted 'file'.
+    The 'file' should be one of those defined in config.PROCESS_FILES and 
+    may actually be composed of multiple files.
     if filetype is not specified and logs the validation errors and
     warnings of a file.
 
     Args:
-        syn: Synapse object
-        filepathlist: List of files (only a list because of clinical file)
+        syn: A synapseclient.Synapse object.
+        filepathlist: List of local paths to files.
         center: Center name
-        filetype: By default, filetype is determined from the filename.
-                  filetype can be specified to avoid filename validation
+        filetype: If None, filetype is determined from the filename.
+                  If specified, filetype determination is skipped.
         oncotreelink: Oncotree URL.
-        testing:  Specify to invoke testing environment
+        testing: Specify to invoke testing environment
         nosymbol_check: Do not check hugo symbols of fusion and cna file.
-                        Default is False.
 
     Returns:
-        message - errors and warnings
-        valid - Boolean value of validation status
+        message: errors and warnings
+        valid: Boolean value of validation status
+        filetype: String of the type of the file
     """
     if filetype is None:
         filetype = determine_filetype(syn, filepathlist, center)

--- a/tests/unit/test_validate.py
+++ b/tests/unit/test_validate.py
@@ -302,7 +302,7 @@ def test_perform_validate():
             return_value=(valid, 'foo', 'foo')) as patch_validate,\
         mock.patch(
             upload_to_syn_call) as patch_syn_upload:
-        validate.perform_validate(syn, arg)
+        validate._perform_validate(syn, arg)
         patch_check_parentid.assert_called_once_with(syn, arg.parentid)
         patch_getdb.assert_called_once_with(syn, test=arg.testing)
         patch_syn_tablequery.assert_called_once_with('select * from syn123')


### PR DESCRIPTION
Not really refactor, but format, lint, and make `perform_validate` that is used by the CLI a private function so it's not exposed to end user.