### PR TITLE
get rid of try/catch to find one specific error.

### DIFF
--- a/genie/example_filetype_format.py
+++ b/genie/example_filetype_format.py
@@ -132,10 +132,10 @@ class FileTypeFormat(object):
             tuple: The errors and warnings as a file from validation.
                    Defaults to blank strings
         '''
-        total_error = ""
-        warning = ""
+        errors = ""
+        warnings = ""
         logger.info("NO VALIDATION for %s files" % self._fileType)
-        return(total_error, warning)
+        return(errors, warnings)
 
     def validate(self, filePathList, **kwargs):
         '''

--- a/genie/example_filetype_format.py
+++ b/genie/example_filetype_format.py
@@ -153,7 +153,18 @@ class FileTypeFormat(object):
         for required_parameter in self._validation_kwargs:
             assert required_parameter in kwargs.keys(), "%s not in parameter list" % required_parameter
             mykwargs[required_parameter] = kwargs[required_parameter]
-        logger.info("VALIDATING %s" % os.path.basename(",".join(filePathList)))
-        df = self.read_file(filePathList)
-        total_error, warning = self._validate(df, **mykwargs)
-        return(total_error, warning)
+
+        errors = ""
+
+        try:
+            df = self.read_file(filePathList)
+        except Exception as e:
+            errors = "The file(s) ({filePathList}) cannot be read. Original error: {exception}".format(filePathList=filePathList,
+                                                                                                       exception=str(e))
+            warnings = ""
+
+        if not errors:
+            logger.info("VALIDATING %s" % os.path.basename(",".join(filePathList)))
+            errors, warnings = self._validate(df, **mykwargs)
+
+        return(errors, warnings)

--- a/genie/example_filetype_format.py
+++ b/genie/example_filetype_format.py
@@ -166,5 +166,7 @@ class FileTypeFormat(object):
         if not errors:
             logger.info("VALIDATING %s" % os.path.basename(",".join(filePathList)))
             errors, warnings = self._validate(df, **mykwargs)
-
-        return(errors, warnings)
+        
+        valid = (errors == '')
+        
+        return valid, errors, warnings

--- a/genie/input_to_database.py
+++ b/genie/input_to_database.py
@@ -166,21 +166,16 @@ def _check_valid(syn, filepaths, center, filetype, filenames,
     Function to validate a file
     '''
     # If no filetype set, means the file was named incorrectly
-    try:
-        valid, message, filetype = validate.validate_single_file(
-            syn,
-            filepaths,
-            center,
-            oncotreelink=oncotree_link,
-            testing=testing)
-        logger.info("VALIDATION COMPLETE")
-    except ValueError as e:
-        # Specify this as None for the single case where filename
-        # validation fails
-        filetype = None
-        message = str(e)
-        logger.error(message)
-        valid = False
+    valid, message, filetype = validate.validate_single_file(
+        syn,
+        filepaths,
+        center,
+        oncotreelink=oncotree_link,
+        testing=testing)
+    logger.info("VALIDATION COMPLETE")
+
+    valid, message = determine_validity_and_log(total_error, warning)
+
     return(valid, filetype, message)
 
 
@@ -285,22 +280,14 @@ def validatefile(syn, entities, validation_statusdf, error_trackerdf,
     # Not by actual path of file
     filetype = validate.determine_filetype(syn, filenames, center)
     if check_file_status['to_validate']:
-        try:
-            valid, message, filetype = validate.validate_single_file(
-                syn,
-                filepaths,
-                center,
-                filetype=filetype,
-                oncotreelink=oncotree_link,
-                testing=testing)
-            logger.info("VALIDATION COMPLETE")
-        except ValueError as e:
-            # Specify this as None for the single case where filename
-            # validation fails
-            filetype = None
-            message = str(e)
-            logger.error(message)
-            valid = False
+        valid, message, filetype = validate.validate_single_file(
+            syn,
+            filepaths,
+            center,
+            filetype=filetype,
+            oncotreelink=oncotree_link,
+            testing=testing)
+        logger.info("VALIDATION COMPLETE")
         input_status_list, invalid_errors_list = _get_status_and_error_list(
             syn, valid, message, filetype,
             entities)

--- a/genie/input_to_database.py
+++ b/genie/input_to_database.py
@@ -160,25 +160,6 @@ def check_existing_file_status(validation_statusdf, error_trackerdf, entities):
         'to_validate': to_validate})
 
 
-def _check_valid(syn, filepaths, center, filetype, filenames,
-                 oncotree_link, threads, testing):
-    '''
-    Function to validate a file
-    '''
-    # If no filetype set, means the file was named incorrectly
-    valid, message, filetype = validate.validate_single_file(
-        syn,
-        filepaths,
-        center,
-        oncotreelink=oncotree_link,
-        testing=testing)
-    logger.info("VALIDATION COMPLETE")
-
-    valid, message = determine_validity_and_log(total_error, warning)
-
-    return(valid, filetype, message)
-
-
 def _send_validation_error_email(syn, filenames, message, file_users):
     '''
     Sends validation error email

--- a/genie/validate.py
+++ b/genie/validate.py
@@ -39,14 +39,14 @@ def determine_filetype(syn, filepathlist, center):
     return(filetype)
 
 
-def determine_validity_and_log(total_error, warning):
+def determine_validity_and_log(errors, warnings):
     '''
     Determines the validity of the file based on the
     the error message
 
     Args:
-        total_error: string of file errors
-        warning: string of file warnings
+        errors: string of file errors, separated by new lines.
+        warning: string of file warnings, separated by new lines.
 
     Returns:
         valid - Boolean value of validation status
@@ -54,21 +54,21 @@ def determine_validity_and_log(total_error, warning):
     '''
     # Complete error message
     message = "----------------ERRORS----------------\n"
-    if total_error == "":
+    if errors == "":
         message = "YOUR FILE IS VALIDATED!\n"
         logger.info(message)
         valid = True
     else:
-        for errors in total_error.split("\n"):
-            if errors != '':
-                logger.error(errors)
-        message += total_error
+        for error in errors.split("\n"):
+            if error != '':
+                logger.error(error)
+        message += errors
         valid = False
-    if warning != "":
-        for warn in warning.split("\n"):
-            if warn != '':
-                logger.warning(warn)
-        message += "-------------WARNINGS-------------\n" + warning
+    if warnings != "":
+        for warning in warnings.split("\n"):
+            if warning != '':
+                logger.warning(warning)
+        message += "-------------WARNINGS-------------\n" + warnings
     return(valid, message)
 
 
@@ -101,17 +101,17 @@ def validate_single_file(syn, filepathlist, center, filetype=None,
         filetype = determine_filetype(syn, filepathlist, center)
 
     if filetype not in PROCESS_FILES:
-        total_error = "Your filename is incorrect! Please change your filename before you run the validator or specify --filetype if you are running the validator locally"
-        warning = ""
+        errors = "Your filename is incorrect! Please change your filename before you run the validator or specify --filetype if you are running the validator locally"
+        warnings = ""
     else:
         validator = PROCESS_FILES[filetype](syn, center)
-        total_error, warning = validator.validate(filePathList=filepathlist, 
-                                                  oncotreeLink=oncotreelink,
-                                                  testing=testing,
-                                                  noSymbolCheck=nosymbol_check)
+        errors, warnings = validator.validate(filePathList=filepathlist, 
+                                              oncotreeLink=oncotreelink,
+                                              testing=testing,
+                                              noSymbolCheck=nosymbol_check)
 
     # Complete error message
-    valid, message = determine_validity_and_log(total_error, warning)
+    valid, message = determine_validity_and_log(errors, warnings)
 
     return(valid, message, filetype)
 

--- a/genie/validate.py
+++ b/genie/validate.py
@@ -116,7 +116,6 @@ def validate_single_file(syn, filepathlist, center, filetype=None,
     return(valid, message, filetype)
 
 
-
 def get_config(syn, synid):
     '''
     Get Synapse database to Table mapping in dict

--- a/genie/validate.py
+++ b/genie/validate.py
@@ -39,37 +39,32 @@ def determine_filetype(syn, filepathlist, center):
     return(filetype)
 
 
-def determine_validity_and_log(errors, warnings):
-    '''
-    Determines the validity of the file based on the
-    the error message
+def collect_errors_and_warnings(errors, warnings):
+    '''Aggregates error and warnings into a string.
 
     Args:
         errors: string of file errors, separated by new lines.
-        warning: string of file warnings, separated by new lines.
+        warnings: string of file warnings, separated by new lines.
 
     Returns:
-        valid - Boolean value of validation status
-        message - error + warning
+        message - errors + warnings
     '''
     # Complete error message
     message = "----------------ERRORS----------------\n"
     if errors == "":
         message = "YOUR FILE IS VALIDATED!\n"
         logger.info(message)
-        valid = True
     else:
         for error in errors.split("\n"):
             if error != '':
                 logger.error(error)
         message += errors
-        valid = False
     if warnings != "":
         for warning in warnings.split("\n"):
             if warning != '':
                 logger.warning(warning)
         message += "-------------WARNINGS-------------\n" + warnings
-    return(valid, message)
+    return message
 
 
 def validate_single_file(syn, filepathlist, center, filetype=None,
@@ -101,17 +96,18 @@ def validate_single_file(syn, filepathlist, center, filetype=None,
         filetype = determine_filetype(syn, filepathlist, center)
 
     if filetype not in PROCESS_FILES:
+        valid = False
         errors = "Your filename is incorrect! Please change your filename before you run the validator or specify --filetype if you are running the validator locally"
         warnings = ""
     else:
         validator = PROCESS_FILES[filetype](syn, center)
-        errors, warnings = validator.validate(filePathList=filepathlist, 
-                                              oncotreeLink=oncotreelink,
-                                              testing=testing,
-                                              noSymbolCheck=nosymbol_check)
+        valid, errors, warnings = validator.validate(filePathList=filepathlist, 
+                                                     oncotreeLink=oncotreelink,
+                                                     testing=testing,
+                                                     noSymbolCheck=nosymbol_check)
 
     # Complete error message
-    valid, message = determine_validity_and_log(errors, warnings)
+    message = collect_errors_and_warnings(errors, warnings)
 
     return(valid, message, filetype)
 

--- a/genie/validate.py
+++ b/genie/validate.py
@@ -72,13 +72,8 @@ def determine_validity_and_log(total_error, warning):
     return(valid, message)
 
 
-def validate_single_file(syn,
-                         filepathlist,
-                         center,
-                         filetype=None,
-                         oncotreelink=None,
-                         testing=False,
-                         nosymbol_check=False):
+def validate_single_file(syn, filepathlist, center, filetype=None, oncotreelink=None,
+                         testing=False, nosymbol_check=False):
     """
     This function determines the filetype of a file
     if filetype is not specified and logs the validation errors and
@@ -101,22 +96,22 @@ def validate_single_file(syn,
     """
     if filetype is None:
         filetype = determine_filetype(syn, filepathlist, center)
-    if filetype not in PROCESS_FILES:
-        raise ValueError(
-            "Your filename is incorrect! "
-            "Please change your filename before you run "
-            "the validator or specify --filetype if you are "
-            "running the validator locally")
 
-    validator = PROCESS_FILES[filetype](syn, center)
-    total_error, warning = validator.validate(
-        filePathList=filepathlist, oncotreeLink=oncotreelink,
-        testing=testing, noSymbolCheck=nosymbol_check)
+    if filetype not in PROCESS_FILES:
+        total_error = "Your filename is incorrect! Please change your filename before you run the validator or specify --filetype if you are running the validator locally"
+        warning = ""
+    else:
+        validator = PROCESS_FILES[filetype](syn, center)
+        total_error, warning = validator.validate(filePathList=filepathlist, 
+                                                  oncotreeLink=oncotreelink,
+                                                  testing=testing,
+                                                  noSymbolCheck=nosymbol_check)
 
     # Complete error message
     valid, message = determine_validity_and_log(total_error, warning)
 
     return(valid, message, filetype)
+
 
 
 def get_config(syn, synid):

--- a/tests/unit/test_validate.py
+++ b/tests/unit/test_validate.py
@@ -131,17 +131,12 @@ def test_filetype_validate_single_file():
     '''
     filepathlist = ['clinical.txt']
     center = "SAGE"
-    with pytest.raises(
-            ValueError,
-            match="Your filename is incorrect! "
-                  "Please change your filename before you run "
-                  "the validator or specify --filetype if you are "
-                  "running the validator locally"):
-        validate.validate_single_file(
-            syn,
-            filepathlist,
-            center,
-            filetype="foobar")
+    expected_error = "----------------ERRORS----------------\nYour filename is incorrect! Please change your filename before you run the validator or specify --filetype if you are running the validator locally"
+    valid, message, filetype = validate.validate_single_file(syn,
+                                                             filepathlist,
+                                                             center,
+                                                             filetype="foobar")
+    assert message == expected_error
 
 
 def test_wrongfiletype_validate_single_file():
@@ -151,19 +146,16 @@ def test_wrongfiletype_validate_single_file():
     '''
     filepathlist = ['clinical.txt']
     center = "SAGE"
+    expected_error = '----------------ERRORS----------------\nYour filename is incorrect! Please change your filename before you run the validator or specify --filetype if you are running the validator locally'
+
     with mock.patch(
             "genie.validate.determine_filetype",
-            return_value=None) as mock_determine_filetype,\
-        pytest.raises(
-            ValueError,
-            match="Your filename is incorrect! "
-                  "Please change your filename before you run "
-                  "the validator or specify --filetype if you are "
-                  "running the validator locally"):
-        validate.validate_single_file(
-            syn,
-            filepathlist,
-            center)
+            return_value=None) as mock_determine_filetype:
+        valid, message, filetype = validate.validate_single_file(syn,
+                                                                 filepathlist,
+                                                                 center)
+        
+        assert message == expected_error
         mock_determine_filetype.assert_called_once_with(
             syn, filepathlist, center)
 

--- a/tests/unit/test_validate.py
+++ b/tests/unit/test_validate.py
@@ -41,25 +41,21 @@ def test_wrongfilename_noerror_determine_filetype():
     assert filetype is None
 
 
-def test_valid_determine_validity_and_log():
+def test_valid_collect_errors_and_warnings():
     '''
     Tests if no error and warning strings are passed that
     returned valid and message is correct
     '''
-    valid, message = \
-        validate.determine_validity_and_log('', '')
-    assert valid
+    message = validate.collect_errors_and_warnings('', '')
     assert message == "YOUR FILE IS VALIDATED!\n"
 
 
-def test_invalid_determine_validity_and_log():
+def test_invalid_collect_errors_and_warnings():
     '''
     Tests if error and warnings strings are passed that
     returned valid and message is correct
     '''
-    valid, message = \
-        validate.determine_validity_and_log("error\nnow", 'warning\nnow')
-    assert not valid
+    message = validate.collect_errors_and_warnings("error\nnow", 'warning\nnow')
     assert message == (
         "----------------ERRORS----------------\n"
         "error\nnow"
@@ -67,14 +63,13 @@ def test_invalid_determine_validity_and_log():
         'warning\nnow')
 
 
-def test_warning_determine_validity_and_log():
+def test_warning_collect_errors_and_warnings():
     '''
     Tests if no error but warnings strings are passed that
     returned valid and message is correct
     '''
-    valid, message = \
-        validate.determine_validity_and_log('', 'warning\nnow')
-    assert valid
+    message = \
+        validate.collect_errors_and_warnings('', 'warning\nnow')
     assert message == (
         "YOUR FILE IS VALIDATED!\n"
         "-------------WARNINGS-------------\n"
@@ -98,10 +93,10 @@ def test_valid_validate_single_file():
             return_value=expected_filetype) as mock_determine_filetype,\
         mock.patch(
             "genie.clinical.clinical.validate",
-            return_value=(error_string, warning_string)) as mock_genie_class,\
+            return_value=(expected_valid, error_string, warning_string)) as mock_genie_class,\
         mock.patch(
-            "genie.validate.determine_validity_and_log",
-            return_value=(expected_valid, expected_message)) as mock_determine:
+            "genie.validate.collect_errors_and_warnings",
+            return_value=expected_message) as mock_determine:
 
         valid, message, filetype = validate.validate_single_file(
             syn,


### PR DESCRIPTION
Just append errors to be handled by the warning and error log handler.

This is a starting point - I think that the `FileTypeFormat` could return `(valid, message, warning)` to simplify further.