### PR TITLE
URGENT: Update synapseclient to fix sendMessage error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,4 +51,5 @@ WORKDIR /root/
 # because must update cbioportal
 RUN git clone https://github.com/cBioPortal/cbioportal.git
 
+RUN pip install synapseclient --upgrade
 WORKDIR /root/Genie/genie

--- a/Dockerfile.vcf2maf
+++ b/Dockerfile.vcf2maf
@@ -84,4 +84,5 @@ WORKDIR /root
 # because must update cbioportal
 RUN git clone https://github.com/cBioPortal/cbioportal.git
 
+RUN pip install synapseclient --upgrade
 WORKDIR /root/Genie/genie


### PR DESCRIPTION
synapseclient sendMessage function was poorly implemented causing an error when filehandle restriction was added in the backend.  This is to update the docker images so that sendMessages doesn't fail.