### PR TITLE
URGENT: Remove maf header

### DIFF
--- a/genie/consortium_to_public.py
+++ b/genie/consortium_to_public.py
@@ -142,16 +142,13 @@ def consortiumToPublic(syn, processingDate, genie_version, releaseId, databaseSy
 
         elif "mutation" in entName:
             mutation = syn.get(entId, followLink=True)
-            with open(mutation.path, 'r') as f:
-                sequenced_samples = f.readline()
             mutationDf = pd.read_csv(mutation.path, sep="\t", comment="#")
             mutationDf = commonVariantFilter(mutationDf)
             mutationDf['FILTER'] = "PASS"
             mutationDf = mutationDf[mutationDf['Tumor_Sample_Barcode'].isin(publicReleaseSamples)]
             text = process.removeFloat(mutationDf)
             with open(MUTATIONS_PATH, 'w') as f:
-                f.write(sequenced_samples) 
-                f.write(text) 
+                f.write(text)
             storeFile(syn, MUTATIONS_PATH, PUBLIC_RELEASE_PREVIEW, ANONYMIZE_CENTER_DF, genie_version, name="data_mutations_extended.txt")
 
         elif "fusion" in entName:


### PR DESCRIPTION
Must remove header from maf file because some samples are removed from the maf file.