### PR TITLE
Remove white space lines

### DIFF
--- a/genie/vcf.py
+++ b/genie/vcf.py
@@ -71,6 +71,9 @@ class vcf(maf):
             # which is not allowed in VCF specs. Replace that with a comma
             command = ['sed', '-i', "'s/ p\./,p./'", newVCFPath]
             subprocess.check_call(" ".join(command), shell=True)
+            # Remove empty white space lines (VCF2MAF fails)
+            command = ['sed', '-i', "'/^\s*$/d'", newVCFPath]
+            subprocess.check_call(" ".join(command), shell=True)
             # Strips out windows indentations \r
             command = ['dos2unix', newVCFPath]
             subprocess.check_call(command)


### PR DESCRIPTION
vcf2maf fails when there is more than one white space line in the vcf.   It could be added to the validator but csv reader and vcf readers just see it as an empty vcf.