### PR TITLE
Format registry using introspection from base class

### DIFF
--- a/genie/__init__.py
+++ b/genie/__init__.py
@@ -1,4 +1,24 @@
 # Import logging last to not take in synapseclient logging
 import logging
+
+from . import bed
+from . import vcf
+from . import bedSP
+from . import workflow
+from . import clinical
+from . import seg
+from . import cbs
+from . import maf
+from . import mafSP
+from . import clinicalSP
+from . import cna
+from . import fusions
+from . import sampleRetraction
+from . import patientRetraction
+from . import patientCounts
+from . import mutationsInCis
+from . import vitalStatus
+from . import assay
+
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)

--- a/genie/config.py
+++ b/genie/config.py
@@ -1,37 +1,23 @@
-from .bed import bed
-from .bedSP import bedSP
-from .workflow import workflow
-from .clinical import clinical
-from .seg import seg
-from .cbs import cbs
-from .maf import maf
-from .mafSP import mafSP
-from .clinicalSP import clinicalSP
-from .vcf import vcf
-from .cna import cna
-from .fusions import fusions
-from .sampleRetraction import sampleRetraction
-from .patientRetraction import patientRetraction
-# from .patientCounts import patientCounts
-from .mutationsInCis import mutationsInCis
-# from .vitalStatus import vitalStatus
-from .assay import Assayinfo
+from . import example_filetype_format
 
-PROCESS_FILES = {'bed': bed,
-                 'bedSP': bedSP,
-                 'maf': maf,
-                 'mafSP': mafSP,
-                 'clinical': clinical,
-                 'clinicalSP': clinicalSP,
-                 'vcf': vcf,
-                 'cbs': cbs,
-                 'cna': cna,
-                 'fusions': fusions,
-                 'md': workflow,
-                 'seg': seg,
-                 'patientRetraction': patientRetraction,
-                 'sampleRetraction': sampleRetraction,
-                 # 'patientCounts': patientCounts,
-                 'mutationsInCis': mutationsInCis,
-                 # 'vitalStatus': vitalStatus,
-                 'assayinfo': Assayinfo}
+BASE_CLASS = example_filetype_format.FileTypeFormat
+
+def make_format_registry_dict(cls_list):
+    """Use an object's _fileType attribute to make a class lookup dictionary.
+    
+    Args:
+        cls_list: A list of Python classes.
+    Returns:
+        A dictionary mapping the class._fileType to the class.
+    """
+
+    return {cls._fileType: cls for cls in cls_list}
+
+def get_subclasses(cls):
+    for subclass in cls.__subclasses__():
+        yield from get_subclasses(subclass)
+        yield subclass
+
+PROCESS_FILES_LIST = [x for x in get_subclasses(BASE_CLASS)]
+
+PROCESS_FILES = make_format_registry_dict(cls_list=PROCESS_FILES_LIST)

--- a/genie/validate.py
+++ b/genie/validate.py
@@ -14,7 +14,8 @@ logger.setLevel(logging.INFO)
 
 class ValidationHelper(object):
 
-    def __init__(self, syn, center, filepathlist, format_registry=PROCESS_FILES):
+    def __init__(self, syn, center, filepathlist,
+                 format_registry=PROCESS_FILES):
         """A validator helper class for a center's files.
 
         Args:
@@ -40,8 +41,8 @@ class ValidationHelper(object):
         '''
         filetype = None
         # Loop through file formats
-        for file_format in self._format_registry:
-            validator = self._format_registry[file_format](self._synapse_client, self.center)
+        for cls in self._format_registry.values():
+            validator = cls(self._synapse_client, self.center)
             try:
                 filetype = validator.validateFilename(self.filepathlist)
             except AssertionError:


### PR DESCRIPTION
Determine the file types from inheritance from the base class.

This should use an ABC meta class to check that classes match the interface instead of directly inheriting, but that's a bigger change.