### PR TITLE
Standardize adding of filetype and center to validation and error status lists

### DIFF
--- a/genie/input_to_database.py
+++ b/genie/input_to_database.py
@@ -545,8 +545,6 @@ def update_status_and_error_tables(syn,
     # Append duplicated file errors
     invalid_errorsdf = invalid_errorsdf.append(
         duplicated_filesdf[error_table_columns])
-    # invalid_errorsdf['center'] = center
-    # error_table_columns.append('center')
     invalidIds = input_valid_statusdf['id'][input_valid_statusdf['status'] == "INVALID"]
     invalid_errorsdf = invalid_errorsdf[invalid_errorsdf['id'].isin(invalidIds)]
     process_functions.updateDatabase(syn, error_tracker_table.asDataFrame(),
@@ -555,8 +553,6 @@ def update_status_and_error_tables(syn,
                                      ["id"], to_delete=True)
 
     logger.info("UPDATE VALIDATION STATUS DATABASE")
-    # input_valid_statusdf['center'] = center
-    # status_table_columns.append('center')
     # Remove fixed duplicated files
     input_valid_statusdf = input_valid_statusdf[
         ~input_valid_statusdf['id'].isin(remove_ids)]

--- a/genie/input_to_database.py
+++ b/genie/input_to_database.py
@@ -462,7 +462,8 @@ def get_duplicated_files(validation_statusdf, duplicated_error_message):
         duplicated_error_message: Error message for duplicated files
 
     Returns:
-        dataframe with 'id', 'name', 'errors', and 'fileType' of duplicated files
+        dataframe with 'id', 'name', 'errors', 'center', 'fileType' of
+        duplicated files
     '''
     logger.info("CHECK FOR DUPLICATED FILES")
     duplicated_filesdf = validation_statusdf[
@@ -564,8 +565,8 @@ def update_status_and_error_tables(syn,
     # Append duplicated file errors
     invalid_errorsdf = invalid_errorsdf.append(
         duplicated_filesdf[invalid_errorsdf.columns])
-    invalidIds = input_valid_statusdf['id'][input_valid_statusdf['status'] == "INVALID"]
-    invalid_errorsdf = invalid_errorsdf[invalid_errorsdf['id'].isin(invalidIds)]
+    invalid_ids = input_valid_statusdf['id'][input_valid_statusdf['status'] == "INVALID"]
+    invalid_errorsdf = invalid_errorsdf[invalid_errorsdf['id'].isin(invalid_ids)]
     process_functions.updateDatabase(syn, error_tracker_table.asDataFrame(),
                                      invalid_errorsdf,
                                      error_tracker_table.tableId,

--- a/genie/input_to_database.py
+++ b/genie/input_to_database.py
@@ -270,7 +270,7 @@ def validatefile(syn, entities, validation_status_table, error_tracker_table,
         input_status_list, invalid_errors_list = _get_status_and_error_list(
             valid, message, entities)
         # Send email the first time the file is invalid
-        if not invalid_errors_list:
+        if invalid_errors_list:
             _send_validation_error_email(syn, filenames, message, file_users)
     else:
         input_status_list = [

--- a/genie/input_to_database.py
+++ b/genie/input_to_database.py
@@ -284,7 +284,8 @@ def validatefile(syn, entities, validation_status_table, error_tracker_table,
     # add in static filetype and center information
     for input_status in input_status_list:
         input_status.extend([filetype, center])
-    # If there are actually invalid errors
+    # An empty list is returned if there are no errors,
+    # so nothing will be appended
     for invalid_errors in invalid_errors_list:
         invalid_errors.extend([filetype, center])
     return(input_status_list, invalid_errors_list)

--- a/genie/input_to_database.py
+++ b/genie/input_to_database.py
@@ -270,7 +270,7 @@ def validatefile(syn, entities, validation_status_table, error_tracker_table,
         input_status_list, invalid_errors_list = _get_status_and_error_list(
             valid, message, entities)
         # Send email the first time the file is invalid
-        if invalid_errors_list:
+        if not invalid_errors_list:
             _send_validation_error_email(syn, filenames, message, file_users)
     else:
         input_status_list = [

--- a/genie/input_to_database.py
+++ b/genie/input_to_database.py
@@ -543,6 +543,7 @@ def update_status_and_error_tables(syn,
     invalid_errorsdf = invalid_errorsdf.append(
         duplicated_filesdf[error_table_columns])
     invalid_errorsdf['center'] = center
+    error_table_columns.append('center')
     invalidIds = input_valid_statusdf['id'][input_valid_statusdf['status'] == "INVALID"]
     invalid_errorsdf = invalid_errorsdf[invalid_errorsdf['id'].isin(invalidIds)]
     process_functions.updateDatabase(syn, error_tracker_table.asDataFrame(),
@@ -552,6 +553,7 @@ def update_status_and_error_tables(syn,
 
     logger.info("UPDATE VALIDATION STATUS DATABASE")
     input_valid_statusdf['center'] = center
+    status_table_columns.append('center')
     # Remove fixed duplicated files
     input_valid_statusdf = input_valid_statusdf[
         ~input_valid_statusdf['id'].isin(remove_ids)]

--- a/genie/input_to_database.py
+++ b/genie/input_to_database.py
@@ -510,7 +510,6 @@ def update_status_and_error_tables(syn,
     status_table_columns = ["id", 'path', 'md5', 'status', 'name',
                             'modifiedOn', 'fileType', 'center']
 
-
     input_status_rows = []
     for input_status in input_valid_statuses:
         entity = input_status['entity']
@@ -520,7 +519,7 @@ def update_status_and_error_tables(syn,
                'status': input_status['status'],
                'name': entity.name,
                'modifiedOn': entity_date_to_timestamp(entity.properties.modifiedOn),
-               'fileType': input_status['filetype'],
+               'fileType': input_status['fileType'],
                'center': input_status['center']}
         input_status_rows.append(row)
 
@@ -530,12 +529,14 @@ def update_status_and_error_tables(syn,
         row = {'id': entity.id,
                'errors': invalid_error['errors'],
                'name': entity.name,
-               'fileType': invalid_error['filetype'],
+               'fileType': invalid_error['fileType'],
                'center': invalid_error['center']}
         invalid_error_rows.append(row)
-
-    input_valid_statusdf = pd.DataFrame(input_status_rows)
-
+    if input_status_rows:
+        input_valid_statusdf = pd.DataFrame(input_status_rows)
+    else:
+        input_valid_statusdf = pd.DataFrame(input_status_rows,
+                                            columns=status_table_columns)
     duplicated_file_error = (
         "DUPLICATED FILENAME! FILES SHOULD BE UPLOADED AS NEW VERSIONS "
         "AND THE ENTIRE DATASET SHOULD BE UPLOADED EVERYTIME")
@@ -548,7 +549,11 @@ def update_status_and_error_tables(syn,
     input_valid_statusdf['status'][duplicated_idx] = "INVALID"
     # Create invalid error synapse table
     logger.info("UPDATE INVALID FILE REASON DATABASE")
-    invalid_errorsdf = pd.DataFrame(invalid_error_rows)
+    if invalid_error_rows:
+        invalid_errorsdf = pd.DataFrame(invalid_error_rows)
+    else:
+        invalid_errorsdf = pd.DataFrame(invalid_error_rows,
+                                        columns=error_table_columns)
     # Remove fixed duplicated files
     # This makes sure that the files removed actually had duplicated file
     # errors and not some other error

--- a/tests/test_input_to_database.py
+++ b/tests/test_input_to_database.py
@@ -391,7 +391,7 @@ def test_valid_validatefile():
                         [])
     with patch.object(GenieValidationHelper, "determine_filetype",
                       return_value=filetype) as patch_determine_filetype,\
-         patch.object(input_to_database,"check_existing_file_status",
+         patch.object(input_to_database, "check_existing_file_status",
                       return_value={'status_list': [],
                                     'error_list': [],
                                     'to_validate': True}) as patch_check, \


### PR DESCRIPTION
Appending the center name is a hacky solution.  The way to do this is to actually add it in `validatefile` and `_get_status_and_error_list`. 