### PR TITLE
No need to check symbols for fusions

### DIFF
--- a/genie/fusions.py
+++ b/genie/fusions.py
@@ -117,10 +117,10 @@ class fusions(FileTypeFormat):
             bed = self.syn.tableQuery("select Hugo_Symbol, ID from %s where CENTER = '%s'" % (bedSynId, self.center))
             bedDf = bed.asDataFrame()
             #invalidated_genes = self.pool.map(process_functions.validateSymbol, fusionDF["HUGO_SYMBOL"].drop_duplicates())
-            fusionDF = fusionDF.drop_duplicates("HUGO_SYMBOL").apply(lambda x: validateSymbol(x, bedDf), axis=1)
             if fusionDF["HUGO_SYMBOL"].isnull().any():
                 total_error += "Your fusion file should not have any NA/blank Hugo Symbols.\n"
-        
+            # fusionDF = fusionDF.drop_duplicates("HUGO_SYMBOL").apply(lambda x: validateSymbol(x, bedDf), axis=1)
+
         # if process_functions.checkColExist(fusionDF, "DNA_SUPPORT"):
         #     if not fusionDF.DNA_SUPPORT.isin(["yes","no","unknown"]).all():
         #         total_error += "Your fusion file's DNA_SUPPORT column must be 'yes', 'no', or 'unknown'"


### PR DESCRIPTION
Fusion symbols were being remapped prior to validating to see if any null hugo symbols were submitted.  

Should not penalize centers that submit no null hugo symbols, even if it might be mapped to null value later on.