### PR TITLE
remove all references to threads.

### DIFF
--- a/bin/input_to_database.py
+++ b/bin/input_to_database.py
@@ -23,8 +23,7 @@ def main(process,
          reference=None,
          vcf2maf_path=None,
          vep_path=None,
-         vep_data=None,
-         thread=1):
+         vep_data=None):
 
     syn = process_functions.synLogin(pemfile, debug=debug)
     # Must specify correct paths to vcf2maf, VEP and VEP data
@@ -102,8 +101,7 @@ def main(process,
             vep_data, databaseToSynIdMappingDf,
             center_mapping_df, reference=reference,
             delete_old=delete_old,
-            oncotree_link=oncotree_link,
-            thread=thread)
+            oncotree_link=oncotree_link)
 
     # To ensure that this is the new entity
     center_mapping_ent = syn.get(center_mapping_id)
@@ -183,14 +181,6 @@ if __name__ == "__main__":
         type=str,
         help="Path to VEP data",
         default=os.path.expanduser("~/.vep"))
-    '''
-    TODO: Remove thread
-    '''
-    parser.add_argument(
-        '--thread',
-        type=int,
-        help="Number of threads to use for validation",
-        default=1)
 
     args = parser.parse_args()
 
@@ -206,5 +196,4 @@ if __name__ == "__main__":
          reference=args.reference,
          vcf2maf_path=args.vcf2mafPath,
          vep_path=args.vepPath,
-         vep_data=args.vepData,
-         thread=args.thread)
+         vep_data=args.vepData)

--- a/genie/input_to_database.py
+++ b/genie/input_to_database.py
@@ -223,7 +223,7 @@ def _get_status_and_error_list(valid, message, entities):
 
 
 def validatefile(syn, entities, validation_status_table, error_tracker_table,
-                 center, threads, testing, oncotree_link,
+                 center, testing, oncotree_link,
                  format_registry=PROCESS_FILES):
     '''Validate a list of entities.
 
@@ -292,7 +292,7 @@ def validatefile(syn, entities, validation_status_table, error_tracker_table,
     return input_status_list, invalid_errors_list, messages_to_send
 
 
-def processfiles(syn, validfiles, center, path_to_genie, threads,
+def processfiles(syn, validfiles, center, path_to_genie,
                  center_mapping_df, oncotree_link, databaseToSynIdMappingDf,
                  validVCF=None, vcf2mafPath=None,
                  veppath=None, vepdata=None,
@@ -306,7 +306,6 @@ def processfiles(syn, validfiles, center, path_to_genie, threads,
                     has 'id', 'path', and 'fileType' column
         center: GENIE center name
         path_to_genie: Path to GENIE workdir
-        threads: Threads used
         center_mapping_df: Center mapping dataframe
         oncotree_link: Link to oncotree
         databaseToSynIdMappingDf: Database to synapse id mapping dataframe
@@ -340,7 +339,7 @@ def processfiles(syn, validfiles, center, path_to_genie, threads,
             else:
                 synId = synId[0]
             if fileType is not None and (processing == "main" or processing == fileType):
-                processor = PROCESS_FILES[fileType](syn, center, threads)
+                processor = PROCESS_FILES[fileType](syn, center)
                 processor.process(
                     filePath=filePath, newPath=newPath,
                     parentId=center_staging_synid, databaseSynId=synId,
@@ -359,7 +358,7 @@ def processfiles(syn, validfiles, center, path_to_genie, threads,
         synId = databaseToSynIdMappingDf.Id[
             databaseToSynIdMappingDf['Database'] == processing][0]
         fileSynId = None
-        processor = PROCESS_FILES[processing](syn, center, threads)
+        processor = PROCESS_FILES[processing](syn, center)
         processor.process(
             filePath=filePath, newPath=newPath,
             parentId=center_staging_synid, databaseSynId=synId,
@@ -599,7 +598,7 @@ def update_status_and_error_tables(syn,
 
 def validation(syn, center, process,
                center_mapping_df, database_synid_mappingdf,
-               thread, testing, oncotree_link, format_registry):
+               testing, oncotree_link, format_registry):
     '''
     Validation of all center files
 
@@ -608,7 +607,6 @@ def validation(syn, center, process,
         center: Center name
         process: main, vcf, maf
         center_mapping_df: center mapping dataframe
-        thread: Unused parameter for now
         testing: True if testing
         oncotree_link: Link to oncotree
 
@@ -666,7 +664,7 @@ def validation(syn, center, process,
                 syn, ents,
                 validation_status_table,
                 error_tracker_table,
-                center=center, threads=1,
+                center=center,
                 testing=testing,
                 oncotree_link=oncotree_link,
                 format_registry=format_registry)
@@ -706,7 +704,7 @@ def center_input_to_database(
         only_validate, vcf2maf_path, vep_path,
         vep_data, database_to_synid_mappingdf,
         center_mapping_df, reference=None,
-        delete_old=False, oncotree_link=None, thread=1):
+        delete_old=False, oncotree_link=None):
     if only_validate:
         log_path = os.path.join(
             process_functions.SCRIPT_DIR,
@@ -749,7 +747,7 @@ def center_input_to_database(
 
     validFiles = validation(
         syn, center, process, center_mapping_df,
-        database_to_synid_mappingdf, thread,
+        database_to_synid_mappingdf,
         testing, oncotree_link, PROCESS_FILES)
 
     if len(validFiles) > 0 and not only_validate:
@@ -789,7 +787,7 @@ def center_input_to_database(
             syn.store(synapseclient.Table(
                 processTrackerSynId, processTrackerDf))
 
-        processfiles(syn, validFiles, center, path_to_genie, thread,
+        processfiles(syn, validFiles, center, path_to_genie,
                      center_mapping_df, oncotree_link,
                      database_to_synid_mappingdf,
                      validVCF=validVCF,

--- a/tests/test_input_to_database.py
+++ b/tests/test_input_to_database.py
@@ -378,7 +378,6 @@ def test_valid_validatefile():
     entity.modifiedBy = '333'
     entity.createdBy = '444'
     entities = [entity]
-    threads = 0
     testing = False
     valid = True
     message = "Is valid"
@@ -406,7 +405,7 @@ def test_valid_validatefile():
 
         validate_results = input_to_database.validatefile(
             syn, entities, validation_statusdf,
-            error_trackerdf, center, threads, testing, oncotree_link)
+            error_trackerdf, center, testing, oncotree_link)
 
         assert expected_results == validate_results
         patch_validate.assert_called_once_with(
@@ -434,7 +433,6 @@ def test_invalid_validatefile():
     entity.modifiedBy = '333'
     entity.createdBy = '444'
     entities = [entity]
-    threads = 0
     testing = False
     valid = False
     message = "Is invalid"
@@ -461,7 +459,7 @@ def test_invalid_validatefile():
 
         validate_results = input_to_database.validatefile(
             syn, entities, validation_statusdf,
-            error_trackerdf, center, threads, testing, oncotree_link)
+            error_trackerdf, center, testing, oncotree_link)
 
         assert expected_results == validate_results
         patch_validate.assert_called_once_with(
@@ -487,7 +485,6 @@ def test_already_validated_validatefile():
     entity.modifiedBy = '333'
     entity.createdBy = '444'
     entities = [entity]
-    threads = 0
     testing = False
     valid = False
     errors = "Invalid file"
@@ -518,7 +515,7 @@ def test_already_validated_validatefile():
 
         validate_results = input_to_database.validatefile(
             syn, entities, validation_statusdf,
-            error_trackerdf, center, threads, testing, oncotree_link)
+            error_trackerdf, center, testing, oncotree_link)
 
         assert expected_results == validate_results
         patch_validate.assert_not_called()
@@ -741,7 +738,6 @@ def test_validation():
         'path': ["/path/to/file"],
         'fileType': ['clinical']})
 
-    thread = 2
     testing = False
     modified_on = 1561143558000
     process = "main"
@@ -775,7 +771,7 @@ def test_validation():
         valid_filedf = input_to_database.validation(
             syn, center, process,
             center_mapping_df, databaseToSynIdMappingDf,
-            thread, testing, oncotree_link, genie.config.PROCESS_FILES)
+            testing, oncotree_link, genie.config.PROCESS_FILES)
         patch_get_center.assert_called_once_with(
             syn, center_input_synid, center, process)
         assert patch_tablequery.call_count == 2
@@ -783,7 +779,7 @@ def test_validation():
             syn, entity,
             validationstatus_mock,
             errortracking_mock,
-            center='SAGE', threads=1,
+            center='SAGE',
             testing=False,
             oncotree_link=oncotree_link,
             format_registry=genie.config.PROCESS_FILES)
@@ -811,7 +807,6 @@ def test_main_processfile(process, genieclass, filetype):
     validfilesdf = pd.DataFrame(validfiles)
     center = "SAGE"
     path_to_genie = "./"
-    threads = 2
     oncotree_link = "www.google.com"
     center_mapping = {'stagingSynId': ["syn123"],
                       'center': [center]}
@@ -822,7 +817,7 @@ def test_main_processfile(process, genieclass, filetype):
 
     with patch.object(genieclass, "process") as patch_class:
         input_to_database.processfiles(
-            syn, validfilesdf, center, path_to_genie, threads,
+            syn, validfilesdf, center, path_to_genie,
             center_mapping_df, oncotree_link, databaseToSynIdMappingDf,
             validVCF=None, vcf2mafPath=None,
             veppath=None, vepdata=None,
@@ -840,7 +835,6 @@ def test_mainnone_processfile():
     validfilesdf = pd.DataFrame(validfiles)
     center = "SAGE"
     path_to_genie = "./"
-    threads = 2
     oncotree_link = "www.google.com"
     center_mapping = {'stagingSynId': ["syn123"],
                       'center': [center]}
@@ -851,7 +845,7 @@ def test_mainnone_processfile():
 
     with patch.object(clinical, "process") as patch_clin:
         input_to_database.processfiles(
-            syn, validfilesdf, center, path_to_genie, threads,
+            syn, validfilesdf, center, path_to_genie,
             center_mapping_df, oncotree_link, databaseToSynIdMappingDf,
             validVCF=None, vcf2mafPath=None,
             veppath=None, vepdata=None,
@@ -869,7 +863,6 @@ def test_notvcf_processfile():
     validfilesdf = pd.DataFrame(validfiles)
     center = "SAGE"
     path_to_genie = "./"
-    threads = 2
     oncotree_link = "www.google.com"
     center_mapping = {'stagingSynId': ["syn123"],
                       'center': [center]}
@@ -880,7 +873,7 @@ def test_notvcf_processfile():
 
     with patch.object(vcf, "process") as patch_process:
         input_to_database.processfiles(
-            syn, validfilesdf, center, path_to_genie, threads,
+            syn, validfilesdf, center, path_to_genie,
             center_mapping_df, oncotree_link, databaseToSynIdMappingDf,
             validVCF=None, vcf2mafPath=None,
             veppath=None, vepdata=None,


### PR DESCRIPTION
Threading is unused, and the references are just littering the function definitions. Parallelization in the general case should be handled at the batch job level (e.g., AWS Batch). For the few cases where multiple files are consumed at once, they can locally configure threading options.