### PR TITLE
Remove test project logic

### DIFF
--- a/bin/input_to_database.py
+++ b/bin/input_to_database.py
@@ -12,13 +12,13 @@ logger = logging.getLogger(__name__)
 
 
 def main(process,
+         project_id,
          center=None,
          pemfile=None,
          delete_old=False,
          only_validate=False,
          oncotree_link=None,
          create_new_maf_database=False,
-         testing=False,
          debug=False,
          reference=None,
          vcf2maf_path=None,
@@ -40,11 +40,11 @@ def main(process,
             "Path to VEP data (--vepData) must be specified "
             "if `--process {vcf,maf,mafSP}` is used")
 
-    if testing:
-        database_to_synid_mapping_synid = "syn11600968"
-    else:
-        database_to_synid_mapping_synid = "syn10967259"
-
+    # Get the Synapse Project where data is stored
+    # Should have annotations to find the table lookup
+    project = syn.get(project_id)
+    database_to_synid_mapping_synid = project.annotations.get("dbMapping", "")
+    
     databaseToSynIdMapping = syn.tableQuery(
         'SELECT * FROM {}'.format(database_to_synid_mapping_synid))
     databaseToSynIdMappingDf = databaseToSynIdMapping.asDataFrame()
@@ -97,7 +97,7 @@ def main(process,
     for center in centers:
         input_to_database.center_input_to_database(
             syn, center, process,
-            testing, only_validate,
+            only_validate,
             vcf2maf_path, vep_path,
             vep_data, databaseToSynIdMappingDf,
             center_mapping_df, reference=reference,
@@ -155,9 +155,9 @@ if __name__ == "__main__":
         action='store_true',
         help="Creates a new maf database")
     parser.add_argument(
-        "--testing",
+        "--project_id",
         action='store_true',
-        help="Testing the infrastructure!")
+        help="Synapse Project ID where data is stored.")
     parser.add_argument(
         "--debug",
         action='store_true',
@@ -195,13 +195,13 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     main(args.process,
+         project_id=args.project_id,
          center=args.center,
          pemfile=args.pemFile,
          delete_old=args.deleteOld,
          only_validate=args.onlyValidate,
          oncotree_link=args.oncotree_link,
          create_new_maf_database=args.createNewMafDatabase,
-         testing=args.testing,
          debug=args.debug,
          reference=args.reference,
          vcf2maf_path=args.vcf2mafPath,

--- a/genie/__main__.py
+++ b/genie/__main__.py
@@ -75,8 +75,8 @@ def build_parser():
                                     'If specified, your valid files will be uploaded '
                                     'to this directory.')
 
-    parser_validate.add_argument("--testing", action='store_true', 
-                                 help='Put in testing mode')
+    parser_validate.add_argument("--project_id", type=str,
+                                 help='Synapse Project ID where data is stored.')
 
     parser_validate.add_argument("--nosymbol-check", action='store_true',
                                  help='Do not check hugo symbols of fusion and cna file')

--- a/genie/example_filetype_format.py
+++ b/genie/example_filetype_format.py
@@ -14,10 +14,10 @@ class FileTypeFormat(object):
 
     _validation_kwargs = []
 
-    def __init__(self, syn, center, poolSize=1, testing=False):
+    def __init__(self, syn, center, poolSize=1):
         self.syn = syn
         self.center = center
-        self.testing = testing
+
         # self.pool = multiprocessing.Pool(poolSize)
 
     def _get_dataframe(self, filePathList):

--- a/genie/input_to_database.py
+++ b/genie/input_to_database.py
@@ -51,7 +51,7 @@ def entity_date_to_timestamp(entity_date_time):
     return synapseclient.utils.to_unix_epoch_time(date_time_obj)
 
 
-def get_center_input_files(syn, synid, center, process="main"):
+def get_center_input_files(syn, synid, center, process="main", downloadFile=True):
     '''
     This function walks through each center's input directory
     to get a list of tuples of center files
@@ -83,8 +83,7 @@ def get_center_input_files(syn, synid, center, process="main"):
             if name.endswith(".vcf") and process != "vcf":
                 continue
 
-            ent = syn.get(ent_synid)
-            logger.debug(ent)
+            ent = syn.get(ent_synid, downloadFile=downloadFile)
 
             # Clinical file can come as two files.
             # The two files need to be merged together which is

--- a/genie/process_functions.py
+++ b/genie/process_functions.py
@@ -246,39 +246,34 @@ def get_syntabledf(syn, query_string):
     return(tabledf)
 
 
-def get_synid_database_mappingdf(syn, test=False, staging=False):
+def get_synid_database_mappingdf(syn, project_id):
     '''
     Get database to synapse id mapping dataframe
 
     Args:
         syn: Synapse object
-        test: Use test table. Default is False
-        staging: Use stagin table. Default is False
+        project_id: Synapse Project ID with a 'dbMapping' annotation.
 
     Returns:
         database to synapse id mapping dataframe
     '''
-    if test:
-        database_mapping_synid = "syn11600968"
-    elif staging:
-        database_mapping_synid = "syn12094210"
-    else:
-        database_mapping_synid = "syn10967259"
 
+    project = syn.get(project_id)
+    database_mapping_synid = project.annotations['dbMapping'][0]
+    
     database_map_query = "SELECT * FROM {}".format(database_mapping_synid)
     mappingdf = get_syntabledf(syn, database_map_query)
     return(mappingdf)
 
 
-def getDatabaseSynId(syn, tableName, test=False,
-                     databaseToSynIdMappingDf=None):
+def getDatabaseSynId(syn, tableName, project_id=None, databaseToSynIdMappingDf=None):
     '''
     Get database synapse id from database to synapse id mapping table
 
     Args:
         syn: Synapse object
+        project_id: Synapse Project ID with a database mapping table.
         tableName: Name of synapse table
-        test: Use test table. Default is False
         databaseToSynIdMappingDf: Avoid calling rest call to download table
                                   if the mapping table is already downloaded
 
@@ -286,7 +281,8 @@ def getDatabaseSynId(syn, tableName, test=False,
         str:  Synapse id of wanted database
     '''
     if databaseToSynIdMappingDf is None:
-        databaseToSynIdMappingDf = get_synid_database_mappingdf(syn, test=test)
+        databaseToSynIdMappingDf = get_synid_database_mappingdf(syn,
+                                                                project_id=project_id)
 
     synId = lookup_dataframe_value(databaseToSynIdMappingDf, "Id",
                                    'Database == "{}"'.format(tableName))

--- a/genie/validate.py
+++ b/genie/validate.py
@@ -22,25 +22,25 @@ class ValidationHelper(object):
     # Overload this per class
     _validate_kwargs = []
 
-    def __init__(self, syn, center, filepathlist,
-                 format_registry=config.PROCESS_FILES,
-                 testing=False):
+    def __init__(self, syn, project_id, center, filepathlist,
+                 format_registry=config.PROCESS_FILES):
 
         """A validator helper class for a center's files.
 
         Args:
             syn: a synapseclient.Synapse object
+            project_id: Synapse Project ID where files are stored and configured.
             center: The participating center name.
             filepathlist: a list of file paths.
             format_registry: A dictionary mapping file format name to the format class.
-            testing: Run in testing mode.
         """
 
         self._synapse_client = syn
+
+        self._project = syn.get(project_id)
         self.filepathlist = filepathlist
         self.center = center
         self._format_registry = format_registry
-        self.testing = testing
         self.file_type = self.determine_filetype()
 
     def determine_filetype(self):
@@ -57,8 +57,7 @@ class ValidationHelper(object):
         filetype = None
         # Loop through file formats
         for file_format in self._format_registry:
-            validator = self._format_registry[file_format](self._synapse_client, self.center,
-                                                           testing=self.testing)
+            validator = self._format_registry[file_format](self._synapse_client, self.center)
             try:
                 filetype = validator.validateFilename(self.filepathlist)
             except AssertionError:
@@ -89,8 +88,7 @@ class ValidationHelper(object):
                 mykwargs[required_parameter] = kwargs[required_parameter]
 
             validator_cls = self._format_registry[self.file_type]
-            validator = validator_cls(self._synapse_client, self.center,
-                                      testing=self.testing)
+            validator = validator_cls(self._synapse_client, self.center)
             valid, errors, warnings = validator.validate(filePathList=self.filepathlist,
                                                          **mykwargs)
 
@@ -240,9 +238,9 @@ def _perform_validate(syn, args):
 
     # Check parentid argparse
     _check_parentid_permission_container(syn, args.parentid)
-
+ 
     databasetosynid_mappingdf = process_functions.get_synid_database_mappingdf(
-        syn, test=args.testing)
+        syn, project_id=args.project_id)
 
     synid = databasetosynid_mappingdf.query('Database == "centerMapping"').Id
 
@@ -258,7 +256,8 @@ def _perform_validate(syn, args):
     format_registry = collect_format_types(args.format_registry_packages)
     logger.debug("Using {} file formats.".format(format_registry))
     
-    validator = GenieValidationHelper(syn=syn, center=args.center,
+    validator = GenieValidationHelper(syn=syn, project_id=args.project_id,
+                                      center=args.center,
                                       filepathlist=args.filepath,
                                       format_registry=format_registry)
     mykwargs = dict(oncotree_link=args.oncotree_link,

--- a/tests/test_process_functions.py
+++ b/tests/test_process_functions.py
@@ -296,7 +296,7 @@ def test_get_synid_database_mappingdf(database_map):
             "genie.process_functions.get_syntabledf",
             return_value=arg.asDataFrame()) as patch_gettabledf:
         df = genie.process_functions.get_synid_database_mappingdf(
-            syn, test=test, staging=staging)
+            syn, project_id=None)
         patch_gettabledf.assert_called_once_with(
             syn, "SELECT * FROM {}".format(synid))
         assert df.equals(arg.asDataFrame())

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -26,7 +26,7 @@ def test_perfect_determine_filetype(filename_fileformat_map):
     Parameters are passed in from filename_fileformat_map
     '''
     (filepath_list, fileformat) = filename_fileformat_map
-    validator = validate.GenieValidationHelper(syn, center, filepath_list)
+    validator = validate.GenieValidationHelper(syn, None, center, filepath_list)
 
     assert validator.determine_filetype() == fileformat
 
@@ -37,7 +37,8 @@ def test_wrongfilename_noerror_determine_filetype():
     when raise_error flag is False
     '''
     filepathlist = ['wrong.txt']
-    validator = validate.GenieValidationHelper(syn, center=center, filepathlist=filepathlist)
+    validator = validate.GenieValidationHelper(syn, project_id=None,
+                                               center=center, filepathlist=filepathlist)
 
     assert validator.file_type is None
 
@@ -101,7 +102,8 @@ def test_valid_validate_single_file():
             "genie.validate.collect_errors_and_warnings",
             return_value=expected_message) as mock_determine:
 
-        validator = validate.GenieValidationHelper(syn, center=center, filepathlist=filepathlist)
+        validator = validate.GenieValidationHelper(syn, project_id=None,
+                                                   center=center, filepathlist=filepathlist)
 
         valid, message, filetype = validator.validate_single_file(oncotree_link=None, nosymbol_check=False)
 
@@ -127,7 +129,7 @@ def test_filetype_validate_single_file():
     filepathlist = ['clinical.txt']
     center = "SAGE"
     expected_error = "----------------ERRORS----------------\nYour filename is incorrect! Please change your filename before you run the validator or specify --filetype if you are running the validator locally"
-    validator = validate.GenieValidationHelper(syn, center, filepathlist)
+    validator = validate.GenieValidationHelper(syn, None, center, filepathlist)
 
     valid, message, filetype = validator.validate_single_file()
     assert message == expected_error
@@ -145,7 +147,8 @@ def test_wrongfiletype_validate_single_file():
     with mock.patch(
             "genie.validate.GenieValidationHelper.determine_filetype",
             return_value=None) as mock_determine_filetype:
-        validator = validate.GenieValidationHelper(syn=syn, center=center, 
+        validator = validate.GenieValidationHelper(syn=syn, project_id=None,
+                                                   center=center, 
                                                    filepathlist=filepathlist)
         valid, message, filetype = validator.validate_single_file()
         
@@ -213,7 +216,7 @@ class argparser:
     oncotree_link = "link"
     parentid = None
     filetype = None
-    testing = False
+    project_id = None
     center = "try"
     filepath = "path.csv"
     nosymbol_check = False
@@ -290,7 +293,7 @@ def test_perform_validate():
             upload_to_syn_call) as patch_syn_upload:
         validate._perform_validate(syn, arg)
         patch_check_parentid.assert_called_once_with(syn, arg.parentid)
-        patch_getdb.assert_called_once_with(syn, test=arg.testing)
+        patch_getdb.assert_called_once_with(syn, project_id=arg.project_id)
         patch_syn_tablequery.assert_called_once_with('select * from syn123')
         patch_check_center.assert_called_once_with(arg.center, ["try", "foo"])
         patch_get_onco.assert_called_once()


### PR DESCRIPTION
This PR removes logic in the file format, input, and validation functions to get configuration for a production or testing/staging Synapse project. It instead relies on receiving as input a Synapse Project ID. This Synapse project must be configured according to GENIE infrastructure standards, including having a database mapping table, and having an annotation at the Project level where `dbMapping` points to the Synapse ID of that table.

The tests were fixed for `input_to_database`, `validate`, and `process_functions` (except for one `process_functions` test that is failing that I cannot figure out).

The tests for individual file formats largely fail because they still take a 'test' parameter, which was removed from the `example_file_format.FileFormat` class.