### PR TITLE
simplify validating single file return

### DIFF
--- a/genie/input_to_database.py
+++ b/genie/input_to_database.py
@@ -269,7 +269,7 @@ def validatefile(syn, entities, validation_status_table, error_tracker_table,
                                                testing=testing)
     filetype = validator.file_type
     if check_file_status['to_validate']:
-        valid, message, filetype = validator.validate_single_file(
+        valid, message = validator.validate_single_file(
             oncotree_link=oncotree_link, nosymbol_check=False)
         logger.info("VALIDATION COMPLETE")
         input_status_list, invalid_errors_list = _get_status_and_error_list(

--- a/genie/validate.py
+++ b/genie/validate.py
@@ -74,7 +74,6 @@ class ValidationHelper(object):
         Returns:
             message: errors and warnings
             valid: Boolean value of validation status
-            filetype: String of the type of the file
         """
 
         if self.file_type not in self._format_registry:
@@ -97,7 +96,7 @@ class ValidationHelper(object):
         # Complete error message
         message = collect_errors_and_warnings(errors, warnings)
 
-        return(valid, message, self.file_type)
+        return (valid, message)
 
 
 class GenieValidationHelper(ValidationHelper):
@@ -263,7 +262,7 @@ def _perform_validate(syn, args):
                                       format_registry=format_registry)
     mykwargs = dict(oncotree_link=args.oncotree_link,
                     nosymbol_check=args.nosymbol_check)
-    valid, message, filetype = validator.validate_single_file(**mykwargs)
+    valid, message = validator.validate_single_file(**mykwargs)
 
     # Upload to synapse if parentid is specified and valid
     _upload_to_synapse(syn, args.filepath, valid, parentid=args.parentid)

--- a/tests/test_input_to_database.py
+++ b/tests/test_input_to_database.py
@@ -397,8 +397,7 @@ def test_valid_validatefile():
                                     'error_list': [],
                                     'to_validate': True}) as patch_check, \
          patch.object(GenieValidationHelper,"validate_single_file",
-                      return_value=(valid, message,
-                                    filetype)) as patch_validate,\
+                      return_value=(valid, message)) as patch_validate,\
          patch.object(input_to_database, "_get_status_and_error_list",
                       return_value=status_error_list_results) as patch_get_staterror_list,\
          patch.object(input_to_database,
@@ -454,8 +453,7 @@ def test_invalid_validatefile():
                                     'error_list': [],
                                     'to_validate': True}) as patch_check, \
          patch.object(GenieValidationHelper, "validate_single_file",
-                      return_value=(valid, message,
-                                    filetype)) as patch_validate,\
+                      return_value=(valid, message)) as patch_validate,\
          patch.object(input_to_database, "_get_status_and_error_list",
                       return_value=status_error_list_results) as patch_get_staterror_list:
 
@@ -510,7 +508,7 @@ def test_already_validated_validatefile():
          patch.object(input_to_database, "check_existing_file_status",
                       return_value=check_file_status_dict) as patch_check, \
          patch.object(GenieValidationHelper, "validate_single_file",
-                      return_value=(valid, errors, filetype)) as patch_validate,\
+                      return_value=(valid, errors)) as patch_validate,\
          patch.object(input_to_database, "_get_status_and_error_list",
                       return_value=status_error_list_results) as patch_get_staterror_list,\
          patch.object(input_to_database,

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -103,11 +103,11 @@ def test_valid_validate_single_file():
 
         validator = validate.GenieValidationHelper(syn, center=center, filepathlist=filepathlist)
 
-        valid, message, filetype = validator.validate_single_file(oncotree_link=None, nosymbol_check=False)
+        valid, message = validator.validate_single_file(oncotree_link=None, nosymbol_check=False)
 
         assert valid == expected_valid
         assert message == expected_message
-        assert filetype == expected_filetype
+        assert validator.file_type == expected_filetype
 
         mock_determine_filetype.assert_called_once_with()
 
@@ -129,7 +129,7 @@ def test_filetype_validate_single_file():
     expected_error = "----------------ERRORS----------------\nYour filename is incorrect! Please change your filename before you run the validator or specify --filetype if you are running the validator locally"
     validator = validate.GenieValidationHelper(syn, center, filepathlist)
 
-    valid, message, filetype = validator.validate_single_file()
+    valid, message = validator.validate_single_file()
     assert message == expected_error
 
 
@@ -147,7 +147,7 @@ def test_wrongfiletype_validate_single_file():
             return_value=None) as mock_determine_filetype:
         validator = validate.GenieValidationHelper(syn=syn, center=center, 
                                                    filepathlist=filepathlist)
-        valid, message, filetype = validator.validate_single_file()
+        valid, message = validator.validate_single_file()
         
         assert message == expected_error
         mock_determine_filetype.assert_called_once_with()
@@ -285,7 +285,7 @@ def test_perform_validate():
         mock.patch(get_oncotree_call) as patch_get_onco,\
         mock.patch(
             validate_file_call,
-            return_value=(valid, 'foo', 'foo')) as patch_validate,\
+            return_value=(valid, 'foo')) as patch_validate,\
         mock.patch(
             upload_to_syn_call) as patch_syn_upload:
         validate._perform_validate(syn, arg)


### PR DESCRIPTION
Validating a single file no longer is responsible for keeping track of the file type. The validation helper class has an attribute that stores the file type. The function no longer needs to return that value.