### PR TITLE
Pass along entity name

### DIFF
--- a/genie/input_to_database.py
+++ b/genie/input_to_database.py
@@ -326,11 +326,12 @@ def processfiles(syn, validfiles, center, path_to_genie,
         os.makedirs(center_staging_folder)
 
     if processing != 'vcf':
-        for fileSynId, filePath, fileType in zip(validfiles['id'],
-                                                 validfiles['path'],
-                                                 validfiles['fileType']):
-            filename = os.path.basename(filePath)
-            newPath = os.path.join(center_staging_folder, filename)
+        for fileSynId, filePath, name, fileType in zip(validfiles['id'],
+                                                       validfiles['path'],
+                                                       validfiles['name'],
+                                                       validfiles['fileType']):
+            # filename = os.path.basename(filePath)
+            newPath = os.path.join(center_staging_folder, name)
             # store = True
             synId = databaseToSynIdMappingDf.Id[
                 databaseToSynIdMappingDf['Database'] == fileType]
@@ -696,7 +697,7 @@ def validation(syn, center, process,
 
         valid_filesdf = input_valid_statusdf.query('status == "VALIDATED"')
 
-        return(valid_filesdf[['id', 'path', 'fileType']])
+        return(valid_filesdf[['id', 'path', 'fileType', 'name']])
 
 
 def center_input_to_database(

--- a/tests/test_input_to_database.py
+++ b/tests/test_input_to_database.py
@@ -734,6 +734,7 @@ def test_validation():
         'id': ['syn1234'],
         'status': ['VALIDATED'],
         'path': ["/path/to/file"],
+        'name': ['filename'],
         'fileType': ['clinical']})
 
     testing = False
@@ -788,7 +789,7 @@ def test_validation():
             validationstatus_mock,
             errortracking_mock)
 
-        assert valid_filedf.equals(validation_statusdf[['id', 'path', 'fileType']])
+        assert valid_filedf.equals(validation_statusdf[['id', 'path', 'fileType', 'name']])
 
 
 @pytest.mark.parametrize(
@@ -800,8 +801,9 @@ def test_validation():
 )
 def test_main_processfile(process, genieclass, filetype):
     validfiles = {'id': ['syn1'],
-                  'path': ['/path/to/data_clinical_supp_SAGE.txt'],
-                  'fileType': [filetype]}
+                  'path': ['/path/to/data_clinical_supp.txt'],
+                  'fileType': [filetype],
+                  'name': ['data_clinical_supp_SAGE.txt']}
     validfilesdf = pd.DataFrame(validfiles)
     center = "SAGE"
     path_to_genie = "./"
@@ -829,7 +831,8 @@ def test_mainnone_processfile():
     '''
     validfiles = {'id': ['syn1'],
                   'path': ['/path/to/data_clinical_supp_SAGE.txt'],
-                  'fileType': [None]}
+                  'fileType': [None],
+                  'name': ['data_clinical_supp_SAGE.txt']}
     validfilesdf = pd.DataFrame(validfiles)
     center = "SAGE"
     path_to_genie = "./"


### PR DESCRIPTION
At one point, the file downloaded were renamed with `entity` names, but since the refactor, the file is no longer renamed, because the entity name is passed along.