### PR TITLE
allow for unknown interval but known year

### DIFF
--- a/genie_registry/clinical.py
+++ b/genie_registry/clinical.py
@@ -140,8 +140,14 @@ def _check_int_year_consistency(
     for str_val in string_vals:
         # n string values per row
         n_str = (clinicaldf[cols] == str_val).sum(axis=1)
-        if n_str.between(0, len(cols), inclusive="neither").any():
-            is_text_inconsistent = True
+        # year can be known with unknown interval value
+        # otherwise must be all numeric or the same text value
+        if str_val == "Unknown":
+            if ((n_str == 1) & (clinicaldf[interval_col] != "Unknown")).any():
+                is_text_inconsistent = True
+        else:
+            if n_str.between(0, len(cols), inclusive="neither").any():
+                is_text_inconsistent = True
 
     is_redaction_inconsistent = False
     # Check that the redacted values are consistent

--- a/tests/test_clinical.py
+++ b/tests/test_clinical.py
@@ -727,13 +727,13 @@ def test_remap_clinical_values(col):
 def test__check_int_year_consistency_valid():
     """Test valid vital status consistency"""
     testdf = pd.DataFrame(
-        {"INT_2": [1, 2, "Unknown"],
-         "YEAR_1": [1, 4, "Unknown"],
-         "FOO_3": [1, 3, "Unknown"]}
+        {"INT_2": [1, 2, "Unknown", "Unknown"],
+         "YEAR_1": [1, 4, "Unknown", 1],
+         "FOO_3": [1, 3, "Unknown", 1]}
     )
     error = genie_registry.clinical._check_int_year_consistency(
         clinicaldf=testdf,
-        cols=['INT_2', "YEAR_1"],
+        cols=["INT_2", "YEAR_1"],
         string_vals=["Unknown"]
     )
     assert error == ""
@@ -759,7 +759,7 @@ def test__check_int_year_consistency_valid():
         (
             pd.DataFrame(
                 {"INT_2": [1, "Unknown", "Unknown"],
-                 "YEAR_1": [1, 4, "Unknown"]}
+                 "YEAR_1": [1, "Not Applicable", "Unknown"]}
             ),
             "Patient: you have inconsistent text values in INT_2, YEAR_1.\n"
         ),
@@ -780,10 +780,17 @@ def test__check_int_year_consistency_valid():
         (
             pd.DataFrame(
                 {"INT_2": ["<6570", "Unknown", "Unknown"],
-                 "YEAR_1": [1, 3, "Unknown"]}
+                 "YEAR_1": [1, "Not Applicable", "Unknown"]}
             ),
             "Patient: you have inconsistent redaction and text values in "
             "INT_2, YEAR_1.\n"
+        ),
+        (
+            pd.DataFrame(
+                {"INT_2": ["12345", "Unknown", "Unknown"],
+                 "YEAR_1": ["Unknown", "Unknown", "Unknown"]}
+            ),
+            "Patient: you have inconsistent text values in INT_2, YEAR_1.\n"
         )
     ]
 )


### PR DESCRIPTION
Fixes #463 

One site said they have YEAR_DEATH but not INT_DOD.  To make the file pass the current validation checks, this would mean removing data in the YEAR_DEATH column and setting it to unknown.  To avoid the unnecessary removal of data, modify the clinical vital status check to allow for the INT_* to be `Unknown` if the YEAR_* is a number.