### PR TITLE
[GEN-177] HOTFIX - Lock down pandas version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 synapseclient>=2.3.0
-pandas>=1.0
+pandas>=1.0,<1.5.0
 httplib2>=0.11.3
 pycryptodome>=3.12.0
 PyYAML>=5.1


### PR DESCRIPTION
The latest pandas version is not backwards compatible and causes an error like:

```
  Traceback (most recent call last):
    File "/root/Genie/bin/input_to_database.py", line 190, in <module>
      main(
    File "/root/Genie/bin/input_to_database.py", line 118, in main
      input_to_database.center_input_to_database(
    File "/root/Genie/genie/input_to_database.py", line 854, in center_input_to_database
      processfiles(
    File "/root/Genie/genie/input_to_database.py", line 360, in processfiles
      processor.process(
    File "/root/Genie/genie/example_filetype_format.py", line 152, in process
      preprocess_args = self.preprocess(kwargs.get("newPath"))
    File "/root/Genie/genie_registry/clinical.py", line 394, in preprocess
      clinicalTemplate = pd.DataFrame(columns=set(patient_cols + sample_cols))
    File "/usr/local/lib/python3.8/dist-packages/pandas/core/frame.py", line 639, in __init__
      raise ValueError("columns cannot be a set")
  ValueError: columns cannot be a set

```

This is a temporary remediation to the problem...