### PR TITLE
[GEN-76] No longer need to include the release version in the release files

### DIFF
--- a/bin/consortium_to_public.py
+++ b/bin/consortium_to_public.py
@@ -161,7 +161,7 @@ def main(args):
     )
 
     database_to_staging.revise_metadata_files(
-        syn, args.staging, public_synid, args.genieVersion
+        syn, public_synid, args.genieVersion
     )
 
     logger.info("CBIO VALIDATION")

--- a/bin/consortium_to_public.py
+++ b/bin/consortium_to_public.py
@@ -163,9 +163,7 @@ def main(args):
         publicReleaseCutOff=args.publicReleaseCutOff,
     )
 
-    database_to_staging.revise_metadata_files(
-        syn, public_synid, args.genieVersion
-    )
+    database_to_staging.revise_metadata_files(syn, public_synid, args.genieVersion)
 
     logger.info("CBIO VALIDATION")
     # Must be exit 0 because the validator sometimes fails,

--- a/bin/consortium_to_public.py
+++ b/bin/consortium_to_public.py
@@ -127,7 +127,7 @@ def main(args):
     # TEST run of the infrastructure will always
     # Map to a specific folder
     if args.test:
-        officialPublic = {"TESTPublic": "syn12299959"}
+        officialPublic = {"TESTpublic": "syn12299959"}
     else:
         officialPublic = consortium_to_public.get_public_to_consortium_synid_mapping(
             syn, releaseSynId

--- a/bin/consortium_to_public.py
+++ b/bin/consortium_to_public.py
@@ -85,6 +85,9 @@ def generate_data_guide(
 
 
 def main(args):
+    # HACK: Delete all existing files first
+    process_functions.rmFiles(database_to_staging.GENIE_RELEASE_DIR)
+
     cbioValidatorPath = os.path.join(
         args.cbioportalPath, "core/src/main/scripts/importer/validateData.py"
     )
@@ -187,13 +190,13 @@ def main(args):
             cbioLog.write(cbio_decoded_output)
         syn.store(synapseclient.File(cbio_log_file, parentId=log_folder_synid))
         os.remove(cbio_log_file)
-    logger.info("REMOVING OLD FILES")
-    process_functions.rmFiles(database_to_staging.CASE_LIST_PATH)
-    seg_meta_file = "{}/genie_public_meta_cna_hg19_seg.txt".format(
-        database_to_staging.GENIE_RELEASE_DIR
-    )
-    if os.path.exists(seg_meta_file):
-        os.unlink(seg_meta_file)
+    # logger.info("REMOVING OLD FILES")
+    # process_functions.rmFiles(database_to_staging.CASE_LIST_PATH)
+    # seg_meta_file = "{}/genie_public_meta_cna_hg19_seg.txt".format(
+    #     database_to_staging.GENIE_RELEASE_DIR
+    # )
+    # if os.path.exists(seg_meta_file):
+    #     os.unlink(seg_meta_file)
 
     logger.info("CREATING LINK VERSION")
     folders = database_to_staging.create_link_version(

--- a/bin/database_to_staging.py
+++ b/bin/database_to_staging.py
@@ -249,7 +249,7 @@ def main(
 
     logger.info("REVISE METADATA FILES")
     database_to_staging.revise_metadata_files(
-        syn, staging, consortiumSynId, genie_version
+        syn, consortiumSynId, genie_version
     )
 
     logger.info("CBIO VALIDATION")

--- a/bin/database_to_staging.py
+++ b/bin/database_to_staging.py
@@ -129,7 +129,7 @@ def main(
         genie_pass = process_functions.get_password(pemfile)
     else:
         genie_pass = None
-
+    # HACK: Use project id instead of this...
     if test:
         databaseSynIdMappingId = "syn11600968"
         genie_version = "TESTING"
@@ -279,7 +279,7 @@ def main(
             cbio_log.write(cbioOutput.decode("utf-8"))
         syn.store(synapseclient.File(cbio_validator_log, parentId=log_folder_synid))
         os.remove(cbio_validator_log)
-    # Instead of doing this, files should be written to a tempdir...
+    # HACK: Instead of doing this, files should be written to a tempdir...
     # logger.info("REMOVING OLD FILES")
 
     # process_functions.rmFiles(database_to_staging.CASE_LIST_PATH)

--- a/bin/database_to_staging.py
+++ b/bin/database_to_staging.py
@@ -214,11 +214,11 @@ def main(
         os.remove(os.path.join(database_to_staging.CASE_LIST_PATH, caselist))
     clinical_path = os.path.join(
         database_to_staging.GENIE_RELEASE_DIR,
-        "data_clinical_{}.txt".format(genie_version),
+        "data_clinical.txt",
     )
     assay_information_path = os.path.join(
         database_to_staging.GENIE_RELEASE_DIR,
-        "assay_information_{}.txt".format(genie_version),
+        "assay_information.txt",
     )
     create_case_lists.main(
         clinical_path,

--- a/bin/database_to_staging.py
+++ b/bin/database_to_staging.py
@@ -240,8 +240,7 @@ def main(
     genie_files = os.listdir(database_to_staging.GENIE_RELEASE_DIR)
     for genie_file in genie_files:
         if (
-            genie_version not in genie_file
-            and "meta" not in genie_file
+            "meta" not in genie_file
             and "case_lists" not in genie_file
         ):
             os.remove(os.path.join(database_to_staging.GENIE_RELEASE_DIR, genie_file))

--- a/bin/database_to_staging.py
+++ b/bin/database_to_staging.py
@@ -237,7 +237,7 @@ def main(
         )
 
     logger.info("REMOVING UNNECESSARY FILES")
-    genie_files = os.listdir(database_to_staging.GENIE_RELEASE_DIR)
+    # genie_files = os.listdir(database_to_staging.GENIE_RELEASE_DIR)
     # for genie_file in genie_files:
     #     if (
     #         genie_version not in genie_file
@@ -276,14 +276,15 @@ def main(
             cbio_log.write(cbioOutput.decode("utf-8"))
         syn.store(synapseclient.File(cbio_validator_log, parentId=log_folder_synid))
         os.remove(cbio_validator_log)
-    logger.info("REMOVING OLD FILES")
+    # Instead of doing this, files should be written to a tempdir...
+    # logger.info("REMOVING OLD FILES")
 
-    process_functions.rmFiles(database_to_staging.CASE_LIST_PATH)
-    private_cna_meta_path = os.path.join(
-        database_to_staging.GENIE_RELEASE_DIR, "genie_private_meta_cna_hg19_seg.txt"
-    )
-    if os.path.exists(private_cna_meta_path):
-        os.unlink(private_cna_meta_path)
+    # process_functions.rmFiles(database_to_staging.CASE_LIST_PATH)
+    # private_cna_meta_path = os.path.join(
+    #     database_to_staging.GENIE_RELEASE_DIR, "genie_private_meta_cna_hg19_seg.txt"
+    # )
+    # if os.path.exists(private_cna_meta_path):
+    #     os.unlink(private_cna_meta_path)
 
     logger.info("CREATING LINK VERSION")
     # Returns release and case list folder

--- a/bin/database_to_staging.py
+++ b/bin/database_to_staging.py
@@ -251,9 +251,7 @@ def main(
     # os.remove(clinical_path)
 
     logger.info("REVISE METADATA FILES")
-    database_to_staging.revise_metadata_files(
-        syn, consortiumSynId, genie_version
-    )
+    database_to_staging.revise_metadata_files(syn, consortiumSynId, genie_version)
 
     logger.info("CBIO VALIDATION")
 

--- a/bin/database_to_staging.py
+++ b/bin/database_to_staging.py
@@ -238,13 +238,14 @@ def main(
 
     logger.info("REMOVING UNNECESSARY FILES")
     genie_files = os.listdir(database_to_staging.GENIE_RELEASE_DIR)
-    for genie_file in genie_files:
-        if (
-            "meta" not in genie_file
-            and "case_lists" not in genie_file
-        ):
-            os.remove(os.path.join(database_to_staging.GENIE_RELEASE_DIR, genie_file))
-    os.remove(clinical_path)
+    # for genie_file in genie_files:
+    #     if (
+    #         genie_version not in genie_file
+    #         and "meta" not in genie_file
+    #         and "case_lists" not in genie_file
+    #     ):
+    #         os.remove(os.path.join(database_to_staging.GENIE_RELEASE_DIR, genie_file))
+    # os.remove(clinical_path)
 
     logger.info("REVISE METADATA FILES")
     database_to_staging.revise_metadata_files(

--- a/bin/database_to_staging.py
+++ b/bin/database_to_staging.py
@@ -120,6 +120,9 @@ def main(
         debug:  Synapse debug flag
         skip_mutationsincis: Skip mutation in cis filter
     """
+    # HACK: Delete all existing files first
+    process_functions.rmFiles(database_to_staging.GENIE_RELEASE_DIR)
+
     syn = process_functions.synLogin(pemfile, debug=debug)
     genie_user = os.environ.get("GENIE_USER")
     if pemfile is not None:

--- a/genie/consortium_to_public.py
+++ b/genie/consortium_to_public.py
@@ -80,7 +80,7 @@ def consortiumToPublic(
     )
     seg_path = os.path.join(
         database_to_staging.GENIE_RELEASE_DIR,
-        "genie_public_data_cna_hg19.seg",
+        "data_cna_hg19.seg",
     )
     combined_bed_path = os.path.join(
         database_to_staging.GENIE_RELEASE_DIR, "genie_combined.bed"
@@ -329,7 +329,7 @@ def consortiumToPublic(
                 seg_path,
                 public_release_preview,
                 genie_version,
-                name="genie_public_data_cna_hg19.seg",
+                name="data_cna_hg19.seg",
             )
         elif entName == "genomic_information.txt":
             bed = syn.get(entId, followLink=True)

--- a/genie/consortium_to_public.py
+++ b/genie/consortium_to_public.py
@@ -56,9 +56,7 @@ def consortiumToPublic(
     databaseSynIdMappingDf,
     publicReleaseCutOff=365,
 ):
-    cna_path = os.path.join(
-        database_to_staging.GENIE_RELEASE_DIR, "data_CNA.txt"
-    )
+    cna_path = os.path.join(database_to_staging.GENIE_RELEASE_DIR, "data_CNA.txt")
     clinical_path = os.path.join(
         database_to_staging.GENIE_RELEASE_DIR, "data_clinical.txt"
     )

--- a/genie/consortium_to_public.py
+++ b/genie/consortium_to_public.py
@@ -57,35 +57,35 @@ def consortiumToPublic(
     publicReleaseCutOff=365,
 ):
     cna_path = os.path.join(
-        database_to_staging.GENIE_RELEASE_DIR, "data_CNA_%s.txt" % genie_version
+        database_to_staging.GENIE_RELEASE_DIR, "data_CNA.txt"
     )
     clinical_path = os.path.join(
-        database_to_staging.GENIE_RELEASE_DIR, "data_clinical_%s.txt" % genie_version
+        database_to_staging.GENIE_RELEASE_DIR, "data_clinical.txt"
     )
     clinical_sample_path = os.path.join(
         database_to_staging.GENIE_RELEASE_DIR,
-        "data_clinical_sample_%s.txt" % genie_version,
+        "data_clinical_sample.txt",
     )
     clinicl_patient_path = os.path.join(
         database_to_staging.GENIE_RELEASE_DIR,
-        "data_clinical_patient_%s.txt" % genie_version,
+        "data_clinical_patient.txt",
     )
     data_gene_panel_path = os.path.join(
-        database_to_staging.GENIE_RELEASE_DIR, "data_gene_matrix_%s.txt" % genie_version
+        database_to_staging.GENIE_RELEASE_DIR, "data_gene_matrix.txt"
     )
     mutations_path = os.path.join(
         database_to_staging.GENIE_RELEASE_DIR,
-        "data_mutations_extended_%s.txt" % genie_version,
+        "data_mutations_extended.txt",
     )
     fusions_path = os.path.join(
-        database_to_staging.GENIE_RELEASE_DIR, "data_fusions_%s.txt" % genie_version
+        database_to_staging.GENIE_RELEASE_DIR, "data_fusions.txt"
     )
     seg_path = os.path.join(
         database_to_staging.GENIE_RELEASE_DIR,
-        "genie_public_data_cna_hg19_%s.seg" % genie_version,
+        "genie_public_data_cna_hg19.seg",
     )
     combined_bed_path = os.path.join(
-        database_to_staging.GENIE_RELEASE_DIR, "genie_combined_%s.bed" % genie_version
+        database_to_staging.GENIE_RELEASE_DIR, "genie_combined.bed"
     )
 
     if not os.path.exists(database_to_staging.GENIE_RELEASE_DIR):
@@ -345,24 +345,24 @@ def consortiumToPublic(
                 genie_version,
                 name="genomic_information.txt",
             )
-        elif entName.startswith("data_gene_panel"):
-            genePanel = syn.get(entId, followLink=True)
-            # Create new gene panel naming and store
-            fileName = os.path.basename(genePanel.path)
-            newFileList = fileName.split("_")
-            newFileList[-1] = genie_version + ".txt"
-            newFileName = "_".join(newFileList)
-            genePanelPath = os.path.join(
-                database_to_staging.GENIE_RELEASE_DIR, newFileName
-            )
-            shutil.copy(genePanel.path, genePanelPath)
-            del newFileList[-1]
-            entName = "_".join(newFileList)
-            entName = entName + ".txt"
-            genepanel_ent = storeFile(
-                syn, genePanelPath, public_release_preview, genie_version, name=entName
-            )
-            genePanelEntities.append(genepanel_ent)
+        # elif entName.startswith("data_gene_panel"):
+        #     genePanel = syn.get(entId, followLink=True)
+        #     # Create new gene panel naming and store
+        #     fileName = os.path.basename(genePanel.path)
+        #     # newFileList = fileName.split("_")
+        #     # newFileList[-1] = genie_version + ".txt"
+        #     # newFileName = "_".join(newFileList)
+        #     genePanelPath = os.path.join(
+        #         database_to_staging.GENIE_RELEASE_DIR, fileName
+        #     )
+        #     shutil.copy(genePanel.path, genePanelPath)
+        #     # del newFileList[-1]
+        #     # entName = "_".join(newFileList)
+        #     # entName = entName + ".txt"
+        #     genepanel_ent = storeFile(
+        #         syn, genePanelPath, public_release_preview, genie_version, name=entName
+        #     )
+        #     genePanelEntities.append(genepanel_ent)
         else:
             ent = syn.get(entId, followLink=True, downloadFile=False)
             copiedId = synapseutils.copy(
@@ -377,7 +377,14 @@ def consortiumToPublic(
             copiedEnt = syn.get(copiedId[ent.id], downloadFile=False)
             # Set version comment
             copiedEnt.versionComment = genie_version
-            syn.store(copiedEnt, forceVersion=False)
+            copiedEnt = syn.store(copiedEnt, forceVersion=False)
+            # There was a time when gene panel files had to be renamed
+            # with an appended genie version. But... GEN-76
+            # No longer appending genie verison to release files
+            # So just need to track gene panel entities
+            if entName.startswith("data_gene_panel"):
+                genePanelEntities.append(copiedEnt)
+
     return caseListEntities, genePanelEntities
 
 

--- a/genie/database_to_staging.py
+++ b/genie/database_to_staging.py
@@ -704,13 +704,11 @@ def store_gene_panel_files(
         genePanel = syn.get(synId)
         genePanelName = os.path.basename(genePanel.path)
         newGenePanelPath = os.path.join(
-            GENIE_RELEASE_DIR, genePanelName.replace(".txt", f"_{genieVersion}.txt")
+            GENIE_RELEASE_DIR, genePanelName
         )
-        print(genePanelName.replace(".txt", "").replace("data_gene_panel_", ""))
-        if (
-            genePanelName.replace(".txt", "").replace("data_gene_panel_", "")
-            in panelNames
-        ):
+        gene_panel = genePanelName.replace(".txt", "").replace("data_gene_panel_", "")
+        print(gene_panel)
+        if gene_panel in panelNames:
             os.rename(genePanel.path, newGenePanelPath)
             genePanelEntities.append(
                 store_file(
@@ -802,7 +800,7 @@ def store_fusion_files(
     ]
     # FusionsDf.to_csv(FUSIONS_PATH, sep="\t", index=False)
     fusionText = process_functions.removePandasDfFloat(FusionsDf)
-    fusions_path = os.path.join(GENIE_RELEASE_DIR, f"data_fusions_{genie_version}.txt")
+    fusions_path = os.path.join(GENIE_RELEASE_DIR, "data_fusions.txt")
     with open(fusions_path, "w") as fusion_file:
         fusion_file.write(fusionText)
     store_file(
@@ -869,7 +867,7 @@ def store_maf_files(
     )
     centerMafSynIdsDf = centerMafSynIds.asDataFrame()
     mutations_path = os.path.join(
-        GENIE_RELEASE_DIR, "data_mutations_extended_%s.txt" % genie_version
+        GENIE_RELEASE_DIR, "data_mutations_extended.txt"
     )
     with open(mutations_path, "w"):
         pass
@@ -1048,7 +1046,7 @@ def store_assay_info_files(
     """
     logger.info("Creates assay information file")
     assay_info_path = os.path.join(
-        GENIE_RELEASE_DIR, f"assay_information_{genie_version}.txt"
+        GENIE_RELEASE_DIR, "assay_information.txt"
     )
     seq_assay_str = "','".join(clinicaldf["SEQ_ASSAY_ID"].unique())
     version = syn.create_snapshot_version(assay_info_synid, comment=genie_version)
@@ -1217,13 +1215,13 @@ def store_clinical_files(
     mapping_table = syn.tableQuery("SELECT * FROM syn9621600")
     mapping = mapping_table.asDataFrame()
     clinical_path = os.path.join(
-        GENIE_RELEASE_DIR, "data_clinical_%s.txt" % genie_version
+        GENIE_RELEASE_DIR, "data_clinical.txt"
     )
     clinical_sample_path = os.path.join(
-        GENIE_RELEASE_DIR, "data_clinical_sample_%s.txt" % genie_version
+        GENIE_RELEASE_DIR, "data_clinical_sample.txt"
     )
     clinical_patient_path = os.path.join(
-        GENIE_RELEASE_DIR, "data_clinical_patient_%s.txt" % genie_version
+        GENIE_RELEASE_DIR, "data_clinical_patient.txt"
     )
     process_functions.addClinicalHeaders(
         clinicaldf,
@@ -1284,7 +1282,7 @@ def store_cna_files(
         list: CNA samples
     """
     logger.info("MERING, FILTERING, STORING CNA FILES")
-    cna_path = os.path.join(GENIE_RELEASE_DIR, f"data_CNA_{genie_version}.txt")
+    cna_path = os.path.join(GENIE_RELEASE_DIR, "data_CNA.txt")
     query_str = ("select id from {} " "where name like 'data_CNA%'").format(
         flatfiles_view_synid
     )
@@ -1405,7 +1403,7 @@ def store_seg_files(
     """
     logger.info("MERING, FILTERING, STORING SEG FILES")
     seg_path = os.path.join(
-        GENIE_RELEASE_DIR, f"genie_private_data_cna_hg19_{genie_version}.seg"
+        GENIE_RELEASE_DIR, "genie_private_data_cna_hg19.seg"
     )
     version = syn.create_snapshot_version(seg_synid, comment=genie_version)
 
@@ -1478,7 +1476,7 @@ def store_data_gene_matrix(
     """
     logger.info("STORING DATA GENE MATRIX FILE")
     data_gene_matrix_path = os.path.join(
-        GENIE_RELEASE_DIR, "data_gene_matrix_%s.txt" % genie_version
+        GENIE_RELEASE_DIR, "data_gene_matrix.txt"
     )
     # Samples have already been removed
     data_gene_matrix = pd.DataFrame(columns=["SAMPLE_ID", "SEQ_ASSAY_ID"])
@@ -1537,7 +1535,7 @@ def store_bed_files(
     """
     logger.info("STORING COMBINED BED FILE")
     combined_bed_path = os.path.join(
-        GENIE_RELEASE_DIR, f"genomic_information_{genie_version}.txt"
+        GENIE_RELEASE_DIR, "genomic_information.txt"
     )
     if not current_release_staging:
         for seq_assay in beddf["SEQ_ASSAY_ID"].unique():

--- a/genie/database_to_staging.py
+++ b/genie/database_to_staging.py
@@ -703,9 +703,7 @@ def store_gene_panel_files(
     for synId in genePanelDf["id"]:
         genePanel = syn.get(synId)
         genePanelName = os.path.basename(genePanel.path)
-        newGenePanelPath = os.path.join(
-            GENIE_RELEASE_DIR, genePanelName
-        )
+        newGenePanelPath = os.path.join(GENIE_RELEASE_DIR, genePanelName)
         gene_panel = genePanelName.replace(".txt", "").replace("data_gene_panel_", "")
         print(gene_panel)
         if gene_panel in panelNames:
@@ -866,9 +864,7 @@ def store_maf_files(
         "select id from {} where name like '%mutation%'".format(flatfiles_view_synid)
     )
     centerMafSynIdsDf = centerMafSynIds.asDataFrame()
-    mutations_path = os.path.join(
-        GENIE_RELEASE_DIR, "data_mutations_extended.txt"
-    )
+    mutations_path = os.path.join(GENIE_RELEASE_DIR, "data_mutations_extended.txt")
     with open(mutations_path, "w"):
         pass
     # Create maf file per center for their staging directory
@@ -1045,9 +1041,7 @@ def store_assay_info_files(
         List of whole exome sequencing SEQ_ASSAY_IDs
     """
     logger.info("Creates assay information file")
-    assay_info_path = os.path.join(
-        GENIE_RELEASE_DIR, "assay_information.txt"
-    )
+    assay_info_path = os.path.join(GENIE_RELEASE_DIR, "assay_information.txt")
     seq_assay_str = "','".join(clinicaldf["SEQ_ASSAY_ID"].unique())
     version = syn.create_snapshot_version(assay_info_synid, comment=genie_version)
     assay_infodf = process_functions.get_syntabledf(
@@ -1214,15 +1208,9 @@ def store_clinical_files(
     # mapping to generate the headers of the clinical file
     mapping_table = syn.tableQuery("SELECT * FROM syn9621600")
     mapping = mapping_table.asDataFrame()
-    clinical_path = os.path.join(
-        GENIE_RELEASE_DIR, "data_clinical.txt"
-    )
-    clinical_sample_path = os.path.join(
-        GENIE_RELEASE_DIR, "data_clinical_sample.txt"
-    )
-    clinical_patient_path = os.path.join(
-        GENIE_RELEASE_DIR, "data_clinical_patient.txt"
-    )
+    clinical_path = os.path.join(GENIE_RELEASE_DIR, "data_clinical.txt")
+    clinical_sample_path = os.path.join(GENIE_RELEASE_DIR, "data_clinical_sample.txt")
+    clinical_patient_path = os.path.join(GENIE_RELEASE_DIR, "data_clinical_patient.txt")
     process_functions.addClinicalHeaders(
         clinicaldf,
         mapping,
@@ -1402,9 +1390,7 @@ def store_seg_files(
         current_release_staging: Staging flag
     """
     logger.info("MERING, FILTERING, STORING SEG FILES")
-    seg_path = os.path.join(
-        GENIE_RELEASE_DIR, "genie_private_data_cna_hg19.seg"
-    )
+    seg_path = os.path.join(GENIE_RELEASE_DIR, "genie_private_data_cna_hg19.seg")
     version = syn.create_snapshot_version(seg_synid, comment=genie_version)
 
     seg = syn.tableQuery(
@@ -1475,9 +1461,7 @@ def store_data_gene_matrix(
         pandas.DataFrame: data gene matrix dataframe
     """
     logger.info("STORING DATA GENE MATRIX FILE")
-    data_gene_matrix_path = os.path.join(
-        GENIE_RELEASE_DIR, "data_gene_matrix.txt"
-    )
+    data_gene_matrix_path = os.path.join(GENIE_RELEASE_DIR, "data_gene_matrix.txt")
     # Samples have already been removed
     data_gene_matrix = pd.DataFrame(columns=["SAMPLE_ID", "SEQ_ASSAY_ID"])
     data_gene_matrix = pd.concat(
@@ -1534,9 +1518,7 @@ def store_bed_files(
         release_synid: Synapse id to store release file
     """
     logger.info("STORING COMBINED BED FILE")
-    combined_bed_path = os.path.join(
-        GENIE_RELEASE_DIR, "genomic_information.txt"
-    )
+    combined_bed_path = os.path.join(GENIE_RELEASE_DIR, "genomic_information.txt")
     if not current_release_staging:
         for seq_assay in beddf["SEQ_ASSAY_ID"].unique():
             bed_seq_df = beddf[beddf["SEQ_ASSAY_ID"] == seq_assay]
@@ -1880,9 +1862,7 @@ def revise_metadata_files(syn, consortiumid, genie_version=None):
                 meta.seek(0)
                 meta.write(meta_text)
                 meta.truncate()
-        store_file(
-            syn, meta_ent.path, parent=consortiumid, genieVersion=genie_version
-        )
+        store_file(syn, meta_ent.path, parent=consortiumid, genieVersion=genie_version)
 
 
 def search_and_create_folder(syn, parentid, folder_name):

--- a/genie/database_to_staging.py
+++ b/genie/database_to_staging.py
@@ -1839,13 +1839,12 @@ def update_process_trackingdf(
     syn.store(synapseclient.Table(process_trackerdb_synid, process_trackerdf))
 
 
-def revise_metadata_files(syn, staging, consortiumid, genie_version=None):
+def revise_metadata_files(syn, consortiumid, genie_version=None):
     """
     Rewrite metadata files with the correct GENIE version
 
     Args:
         syn: Synapse object
-        staging: staging flag
         consortiumid: Synapse id of consortium release folder
         genie_version: GENIE version, Default to None
     """
@@ -1867,11 +1866,6 @@ def revise_metadata_files(syn, staging, consortiumid, genie_version=None):
                 version = re.search(".+GENIE.+v(.+)", meta_text).group(1)
             # Fix this line
             genie_version = version if genie_version is None else genie_version
-            version_on_file = re.search(".+data_(.+)[.]txt", meta_text)
-            if version_on_file is None:
-                version_on_file = re.search(".+data_(.+)[.]seg", meta_text)
-            if version_on_file is not None:
-                version_on_file = version_on_file.group(1).split("_")[-1]
 
             if version != genie_version:
                 meta_text = meta_text.replace(
@@ -1883,9 +1877,6 @@ def revise_metadata_files(syn, staging, consortiumid, genie_version=None):
                     "GENIE v{}".format(version), "GENIE v{}".format(genie_version)
                 )
 
-                if version_on_file is not None:
-                    meta_text = meta_text.replace(version_on_file, genie_version)
-                    meta_text = meta_text.replace(version_on_file, genie_version)
                 meta.seek(0)
                 meta.write(meta_text)
                 meta.truncate()

--- a/genie/database_to_staging.py
+++ b/genie/database_to_staging.py
@@ -33,7 +33,7 @@ MUTATIONS_CENTER_PATH = os.path.join(
     GENIE_RELEASE_DIR, "data_mutations_extended_%s.txt"
 )
 FUSIONS_CENTER_PATH = os.path.join(GENIE_RELEASE_DIR, "data_fusions_%s.txt")
-SEG_CENTER_PATH = os.path.join(GENIE_RELEASE_DIR, "genie_data_cna_hg19_%s.seg")
+SEG_CENTER_PATH = os.path.join(GENIE_RELEASE_DIR, "data_cna_hg19_%s.seg")
 BED_DIFFS_SEQASSAY_PATH = os.path.join(GENIE_RELEASE_DIR, "diff_%s.csv")
 
 
@@ -1390,7 +1390,7 @@ def store_seg_files(
         current_release_staging: Staging flag
     """
     logger.info("MERING, FILTERING, STORING SEG FILES")
-    seg_path = os.path.join(GENIE_RELEASE_DIR, "genie_private_data_cna_hg19.seg")
+    seg_path = os.path.join(GENIE_RELEASE_DIR, "data_cna_hg19.seg")
     version = syn.create_snapshot_version(seg_synid, comment=genie_version)
 
     seg = syn.tableQuery(
@@ -1433,7 +1433,7 @@ def store_seg_files(
         seg_path,
         parent=release_synid,
         genieVersion=genie_version,
-        name="genie_private_data_cna_hg19.seg",
+        name="data_cna_hg19.seg",
         used=f"{seg_synid}.{version}",
     )
 

--- a/genie/database_to_staging.py
+++ b/genie/database_to_staging.py
@@ -1880,9 +1880,9 @@ def revise_metadata_files(syn, consortiumid, genie_version=None):
                 meta.seek(0)
                 meta.write(meta_text)
                 meta.truncate()
-                store_file(
-                    syn, meta_ent.path, parent=consortiumid, genieVersion=genie_version
-                )
+        store_file(
+            syn, meta_ent.path, parent=consortiumid, genieVersion=genie_version
+        )
 
 
 def search_and_create_folder(syn, parentid, folder_name):

--- a/tests/test_database_to_staging.py
+++ b/tests/test_database_to_staging.py
@@ -81,9 +81,7 @@ def test_store_assay_info_files():
     assay_infodf = pd.DataFrame({"library_strategy": ["WXS"], "SEQ_ASSAY_ID": ["A"]})
     clinicaldf = pd.DataFrame({"SEQ_ASSAY_ID": ["A"]})
     database_to_staging.GENIE_RELEASE_DIR = "./"
-    path = os.path.join(
-        database_to_staging.GENIE_RELEASE_DIR, "assay_information.txt"
-    )
+    path = os.path.join(database_to_staging.GENIE_RELEASE_DIR, "assay_information.txt")
     with patch.object(
         SYN, "create_snapshot_version", return_value=2
     ) as patch_create_version, patch.object(

--- a/tests/test_database_to_staging.py
+++ b/tests/test_database_to_staging.py
@@ -61,7 +61,7 @@ def test_store_gene_panel_files():
         assert patch_syn_table_query.call_count == 2
         patch_storefile.assert_called_once_with(
             SYN,
-            os.path.join(database_to_staging.GENIE_RELEASE_DIR, "PANEL1_vTEST.txt"),
+            os.path.join(database_to_staging.GENIE_RELEASE_DIR, "PANEL1.txt"),
             parent=CONSORTIUM_SYNID,
             genieVersion=GENIE_VERSION,
             name="PANEL1.txt",
@@ -72,7 +72,7 @@ def test_store_gene_panel_files():
         patch_syn_get.assert_called_once_with("syn3333")
         patch_os_rename.assert_called_once_with(
             "/foo/bar/PANEL1.txt",
-            os.path.join(database_to_staging.GENIE_RELEASE_DIR, "PANEL1_vTEST.txt"),
+            os.path.join(database_to_staging.GENIE_RELEASE_DIR, "PANEL1.txt"),
         )
 
 
@@ -82,7 +82,7 @@ def test_store_assay_info_files():
     clinicaldf = pd.DataFrame({"SEQ_ASSAY_ID": ["A"]})
     database_to_staging.GENIE_RELEASE_DIR = "./"
     path = os.path.join(
-        database_to_staging.GENIE_RELEASE_DIR, "assay_information_vTEST.txt"
+        database_to_staging.GENIE_RELEASE_DIR, "assay_information.txt"
     )
     with patch.object(
         SYN, "create_snapshot_version", return_value=2


### PR DESCRIPTION
There was a time when we required the release name to be part of the release files.  We have since decided this was unnecessary and actually a hindrance.