### PR TITLE
[GEN-424, GEN-423] Allow MT chromosome to be specified

### DIFF
--- a/genie/validate.py
+++ b/genie/validate.py
@@ -166,12 +166,13 @@ def _check_center_input(center, center_list):
         )
 
 
-def _validate_chromosome(df: pd.DataFrame, col: str) -> tuple:
+def _validate_chromosome(df: pd.DataFrame, col: str, fileformat: str) -> tuple:
     """Validate chromosome values
 
     Args:
         df (pd.DataFrame): Dataframe
         col (str): Column header for column containing chromosome values
+        fileformat (str): GENIE supported file format
 
     Returns:
         tuple: errors and warnings
@@ -180,7 +181,7 @@ def _validate_chromosome(df: pd.DataFrame, col: str) -> tuple:
     errors = ""
     warnings = ""
     if have_column:
-        nochr = ["chr" in i for i in df["#CHROM"] if isinstance(i, str)]
+        nochr = ["chr" in i for i in df[col] if isinstance(i, str)]
         if sum(nochr) > 0:
             warnings += "vcf: Should not have the chr prefix in front of chromosomes.\n"
         # Get accepted chromosomes
@@ -190,10 +191,10 @@ def _validate_chromosome(df: pd.DataFrame, col: str) -> tuple:
         #     str(chrom).replace("chr", "") in accepted_chromosomes
         #     for chrom in df[col]
         # ]
-        correct_chromosomes = df[col].str.replace("chr", "")
+        correct_chromosomes = df[col].astype(str).str.replace("chr", "")
         df[col] = correct_chromosomes
         warning, error = process_functions.check_col_and_values(
-            df=df, col=col, possible_values=accepted_chromosomes, filename="vcf"
+            df=df, col=col, possible_values=accepted_chromosomes, filename=fileformat
         )
         errors += error
         warnings += warning

--- a/genie/validate.py
+++ b/genie/validate.py
@@ -183,7 +183,7 @@ def _validate_chromosome(df: pd.DataFrame, col: str, fileformat: str) -> tuple:
     if have_column:
         nochr = ["chr" in i for i in df[col] if isinstance(i, str)]
         if sum(nochr) > 0:
-            warnings += "vcf: Should not have the chr prefix in front of chromosomes.\n"
+            warnings += f"{fileformat}: Should not have the chr prefix in front of chromosomes.\n"
         # Get accepted chromosomes
         accepted_chromosomes = list(map(str, range(1, 23)))
         accepted_chromosomes.extend(["X", "Y", "MT"])

--- a/genie_registry/vcf.py
+++ b/genie_registry/vcf.py
@@ -131,7 +131,9 @@ class vcf(FileTypeFormat):
         # Require that they report variants mapped to
         # either GRCh37 or hg19 without
         # the chr-prefix.
-        error, warn = validate._validate_chromosome(df=vcfdf, col="#CHROM", fileformat="vcf")
+        error, warn = validate._validate_chromosome(
+            df=vcfdf, col="#CHROM", fileformat="vcf"
+        )
         total_error += error
         warning += warn
 

--- a/genie_registry/vcf.py
+++ b/genie_registry/vcf.py
@@ -140,7 +140,7 @@ class vcf(FileTypeFormat):
                 )
             # Get accepted chromosomes
             accepted_chromosomes = list(map(str, range(1, 23)))
-            accepted_chromosomes.extend(["X", "Y"])
+            accepted_chromosomes.extend(["X", "Y", "MT"])
             correct_chromosomes = [
                 str(chrom).replace("chr", "") in accepted_chromosomes
                 for chrom in vcfdf["#CHROM"]

--- a/genie_registry/vcf.py
+++ b/genie_registry/vcf.py
@@ -131,7 +131,7 @@ class vcf(FileTypeFormat):
         # Require that they report variants mapped to
         # either GRCh37 or hg19 without
         # the chr-prefix.
-        error, warn = validate._validate_chromosome(df=vcfdf, col="#CHROM")
+        error, warn = validate._validate_chromosome(df=vcfdf, col="#CHROM", fileformat="vcf")
         total_error += error
         warning += warn
 

--- a/tests/test_vcf.py
+++ b/tests/test_vcf.py
@@ -229,8 +229,8 @@ def test_validation_invalid_content(vcf_class):
         "vcf: Must not have duplicate variants.\n"
         "vcf: May contain rows that are "
         "space delimited instead of tab delimited.\n"
-        "vcf: Chromsomes must be part of this list: 1,2,3,4,5,6,7,8,9,10,"
-        "11,12,13,14,15,16,17,18,19,20,21,22,X,Y,MT.\n"
+        "vcf: Please double check your #CHROM column.  This column must only be these values: "
+        "1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, X, Y, MT\n"
     )
     expectedWarning = "vcf: Should not have the chr prefix in front of chromosomes.\n"
     assert error == expectedError

--- a/tests/test_vcf.py
+++ b/tests/test_vcf.py
@@ -230,7 +230,7 @@ def test_validation_invalid_content(vcf_class):
         "vcf: May contain rows that are "
         "space delimited instead of tab delimited.\n"
         "vcf: Chromsomes must be part of this list: 1,2,3,4,5,6,7,8,9,10,"
-        "11,12,13,14,15,16,17,18,19,20,21,22,X,Y.\n"
+        "11,12,13,14,15,16,17,18,19,20,21,22,X,Y,MT.\n"
     )
     expectedWarning = "vcf: Should not have the chr prefix in front of chromosomes.\n"
     assert error == expectedError


### PR DESCRIPTION
One of the sites have `MT` specified in hundreds of their vcfs and it seems to process just fine via genome nexus.  Adding to the list of accepted chromosomes.