### PR TITLE
Dashboard code should support multiple major public releases, but always new the latest

### DIFF
--- a/templates/dashboardTemplate.Rmd
+++ b/templates/dashboardTemplate.Rmd
@@ -227,13 +227,19 @@ get_latest_public_release <- function(release) {
   public_rel = synTableQuery(paste0(
     "select * from syn22233011 where ",
     sprintf("name like 'Release %s.", public_major_release),
-    "%-public'"
+    "%-public' order by name DESC"
   ))
   public_reldf = public_rel$asDataFrame()
-  if (nrow(public_reldf) == 0) {
+  nrow_df = nrow(public_reldf)
+  if (nrow_df == 0) {
     stop(sprintf("Could not find public release for: %s", public_major_release))
+  } else if (nrow_df == 1) {
+    public_reldf$id
+  } else {
+    # The releases are ordered by latest first, so
+    # always take the first element
+    public_reldf$id[1]
   }
-  public_reldf$id
 }
 ```
 


### PR DESCRIPTION
This was a bug I discovered when I was creating the patch releases.  Moving forward, we will 'lock down' old public releases instead of writing over them for provenance reasons, due to this sometimes public releases will have two releases.  This caused the original dashboard code to return a list of public release folder synapse ids linked to a major release and...

```
synGetChildren(public_release_synid)
```

^ that function is not meant to support a list of Synapse Ids.