### PR TITLE
[GEN-564] Add support for more values for site1 site2 col in SV file

### DIFF
--- a/genie_registry/structural_variant.py
+++ b/genie_registry/structural_variant.py
@@ -159,6 +159,14 @@ class StructuralVariant(FileTypeFormat):
             "Intron",
             "5'UTR",
             "3'UTR",
+            "5-UTR",
+            "3-UTR",
+            "5_Prime_UTR Intron",
+            "3_Prime_UTR Intron",
+            "Downstream",
+            "Upstream",
+            "Intergenic",
+            "IGR",
         ]
         warn, error = process_functions.check_col_and_values(
             df=sv_df,

--- a/tests/test_sv.py
+++ b/tests/test_sv.py
@@ -122,6 +122,8 @@ class TestSv:
                 "RNA_Support": ["Yes", "No"],
                 "SITE1_CHROMOSOME": [1, 22],
                 "SITE2_CHROMOSOME": ["X", "2"],
+                "SITE1_REGION": ["IGR", "Upstream"],
+                "SITE2_REGION": ["3-UTR", "3_Prime_UTR Intron"],
             }
         )
         error, warning = self.sv_cls._validate(sv_df)


### PR DESCRIPTION
**Purpose**: Adds support for more values (see JIRA ticket) in the following columns in the `cases_sv.txt` file:

- SITE1_REGION
- SITE2_REGION

Merging blocked by #514 as they modify the same test case
