### PR TITLE
[GEN-562] Cross-validate maf with clinical sample files

### DIFF
--- a/genie/example_filetype_format.py
+++ b/genie/example_filetype_format.py
@@ -276,7 +276,7 @@ class FileTypeFormat(metaclass=ABCMeta):
         """
         errors = ""
         warnings = ""
-        logger.info("NO VALIDATION for %s files" % self._fileType)
+        logger.info("NO CROSS-VALIDATION for %s files" % self._fileType)
         return errors, warnings
 
     def validate(self, filePathList, **kwargs) -> ValidationResults:
@@ -310,13 +310,15 @@ class FileTypeFormat(metaclass=ABCMeta):
 
         if not errors:
             logger.info("VALIDATING %s" % os.path.basename(",".join(filePathList)))
-            errors_validate, warnings_validate = self._validate(df, **mykwargs)
+            errors, warnings = self._validate(df, **mykwargs)
             logger.info(
                 "CROSS-VALIDATING %s" % os.path.basename(",".join(filePathList))
             )
-            errors_cross_validate, warnings_cross_validate = self._cross_validate(df)
-            errors = f"{errors_validate}\n{errors_cross_validate}"
-            warnings = f"{warnings_validate}\n{warnings_cross_validate}"
+            # only cross-validate if validation passes
+            if not errors:
+                errors_cross_validate, warnings_cross_validate = self._cross_validate(df)
+                errors = f"{errors}\n{errors_cross_validate}"
+                warnings = f"{warnings}\n{warnings_cross_validate}"
             
 
         result_cls = ValidationResults(errors=errors, warnings=warnings)

--- a/genie/example_filetype_format.py
+++ b/genie/example_filetype_format.py
@@ -265,8 +265,8 @@ class FileTypeFormat(metaclass=ABCMeta):
                 errors_cross_validate, warnings_cross_validate = self._cross_validate(
                     df
                 )
-                errors = f"{errors_cross_validate}\n"
-                warnings = f"{warnings}\n{warnings_cross_validate}\n"
+                errors += errors_cross_validate
+                warnings += warnings_cross_validate
 
         result_cls = ValidationResults(errors=errors, warnings=warnings)
         return result_cls

--- a/genie/example_filetype_format.py
+++ b/genie/example_filetype_format.py
@@ -265,8 +265,8 @@ class FileTypeFormat(metaclass=ABCMeta):
                 errors_cross_validate, warnings_cross_validate = self._cross_validate(
                     df
                 )
-                errors = f"{errors_cross_validate}"
-                warnings = f"{warnings}\n{warnings_cross_validate}"
+                errors = f"{errors_cross_validate}\n"
+                warnings = f"{warnings}\n{warnings_cross_validate}\n"
 
         result_cls = ValidationResults(errors=errors, warnings=warnings)
         return result_cls

--- a/genie/example_filetype_format.py
+++ b/genie/example_filetype_format.py
@@ -257,11 +257,11 @@ class FileTypeFormat(metaclass=ABCMeta):
         if not errors:
             logger.info("VALIDATING %s" % os.path.basename(",".join(filePathList)))
             errors, warnings = self._validate(df, **mykwargs)
-            logger.info(
-                "CROSS-VALIDATING %s" % os.path.basename(",".join(filePathList))
-            )
             # only cross-validate if validation passes
             if not errors:
+                logger.info(
+                    "CROSS-VALIDATING %s" % os.path.basename(",".join(filePathList))
+                )
                 errors_cross_validate, warnings_cross_validate = self._cross_validate(
                     df
                 )

--- a/genie/example_filetype_format.py
+++ b/genie/example_filetype_format.py
@@ -208,47 +208,6 @@ class FileTypeFormat(metaclass=ABCMeta):
         logger.info("NO VALIDATION for %s files" % self._fileType)
         return errors, warnings
 
-    def cross_validate_ids_between_two_files(
-        self,
-        df1: pd.DataFrame,
-        df1_filename: str,
-        df2: pd.DataFrame,
-        df2_filename: str,
-        id_to_check: str,
-    ) -> tuple:
-        """Check that all the identifier(s) (ids) in one
-        file exists in the other file
-
-        Args:
-            df1 (pd.DataFrame): file to use as base of check
-            df1_filename (str): filename of file to use as base of check
-            df2 (pd.DataFrame): file to cross-validate against
-            df2_filename (str): filename of file to cross-validate against
-            id_to_check (str): name of column to check values for
-
-        Returns:
-            tuple: The errors and warnings as a file from cross-validation.
-                   Defaults to blank strings
-        """
-        errors = ""
-        warnings = ""
-
-        # standardize case
-        df2.columns = [col.upper() for col in df2.columns]
-
-        if id_to_check in df2.columns and id_to_check in df1.columns:
-            # check to see if the ids are equal
-            if set(df1[id_to_check]) != set(df2[id_to_check]):
-                errors = (
-                    f"The {id_to_check}s between {df1_filename} and "
-                    f"{df2_filename} are not equal."
-                )
-                warnings = ""
-        else:
-            errors = ""
-            warnings = f"{id_to_check} doesn't exist in {df1_filename} or {df2_filename}. No cross-validation will be done."
-        return errors, warnings
-
     def _cross_validate(self, df: pd.DataFrame) -> tuple:
         """
         This is the base cross-validation function.
@@ -306,7 +265,7 @@ class FileTypeFormat(metaclass=ABCMeta):
                 errors_cross_validate, warnings_cross_validate = self._cross_validate(
                     df
                 )
-                errors = f"{errors}\n{errors_cross_validate}"
+                errors = f"{errors_cross_validate}"
                 warnings = f"{warnings}\n{warnings_cross_validate}"
 
         result_cls = ValidationResults(errors=errors, warnings=warnings)

--- a/genie/input_to_database.py
+++ b/genie/input_to_database.py
@@ -235,9 +235,9 @@ def get_ancillary_files(
                 ancillary_files=None,
             )
 
-            prepared_center_files[filetype] = {}
-            prepared_center_files[filetype]["entity"] = ent
-            prepared_center_files[filetype][
+            prepared_center_files[name] = {}
+            prepared_center_files[name]["entity"] = ent
+            prepared_center_files[name][
                 "filetypeformat_object"
             ] = fileformat_validator
 
@@ -262,10 +262,9 @@ def get_ancillary_files(
             ancillary_files=None,
         )
 
-        prepared_center_files[filetype] = {}
-        prepared_center_files[filetype]["entity"] = clinicalpair_entities
-        prepared_center_files[filetype]["filetypeformat_object"] = cli_fileformat_validator
-
+        prepared_center_files[name] = {}
+        prepared_center_files[name]["entity"] = clinicalpair_entities
+        prepared_center_files[name]["filetypeformat_object"] = cli_fileformat_validator
     return prepared_center_files
 
 
@@ -862,15 +861,15 @@ def center_input_to_database(
     center_files = extract.get_center_input_files(
         syn, center_input_synid, center, process
     )
-    ancillary_files = get_ancillary_files(
-        syn=syn,
-        synid=center_input_synid,
-        project_id=project_id,
-        center=center,
-        process=process,
-        format_registry=format_registry,
-        genie_config=genie_config,
-    )
+    #ancillary_files = get_ancillary_files(
+    #    syn=syn,
+    #    synid=center_input_synid,
+    #    project_id=project_id,
+    #    center=center,
+    #    process=process,
+    #    format_registry=format_registry,
+    #    genie_config=genie_config,
+    #)
 
     # only validate if there are center files
     if center_files:
@@ -882,7 +881,7 @@ def center_input_to_database(
             center_files=center_files,
             format_registry=format_registry,
             genie_config=genie_config,
-            ancillary_files=ancillary_files,
+            ancillary_files=center_files,
         )
     else:
         logger.info(f"{center} has not uploaded any files")

--- a/genie/input_to_database.py
+++ b/genie/input_to_database.py
@@ -237,9 +237,7 @@ def get_ancillary_files(
 
             prepared_center_files[name] = {}
             prepared_center_files[name]["entity"] = ent
-            prepared_center_files[name][
-                "filetypeformat_object"
-            ] = fileformat_validator
+            prepared_center_files[name]["filetypeformat_object"] = fileformat_validator
 
     # if the clinical files exist
     if clinicalpair_entities:
@@ -333,6 +331,7 @@ def validatefile(
         ancillary_files=ancillary_files,
     )
     filetype = validator.file_type
+
     if check_file_status["to_validate"]:
         valid_cls, message = validator.validate_single_file(
             oncotree_link=genie_config["oncotreeLink"], nosymbol_check=False
@@ -861,7 +860,8 @@ def center_input_to_database(
     center_files = extract.get_center_input_files(
         syn, center_input_synid, center, process
     )
-    #ancillary_files = get_ancillary_files(
+
+    # ancillary_files = get_ancillary_files(
     #    syn=syn,
     #    synid=center_input_synid,
     #    project_id=project_id,
@@ -869,7 +869,7 @@ def center_input_to_database(
     #    process=process,
     #    format_registry=format_registry,
     #    genie_config=genie_config,
-    #)
+    # )
 
     # only validate if there are center files
     if center_files:

--- a/genie/process_functions.py
+++ b/genie/process_functions.py
@@ -22,7 +22,20 @@ logger = logging.getLogger(__name__)
 SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 
 
-def get_clinical_dataframe(filePathList):
+def get_clinical_dataframe(filePathList : list) -> pd.DataFrame:
+    """Gets the clinical file(s) and reads them in as a 
+    dataframe
+
+    Args:
+        filePathList (list): List of clinical files
+
+    Raises:
+        ValueError: when PATIENT_ID column doesn't exist
+        ValueError: When PATIENT_IDs in sample file doesn't exist in patient file
+
+    Returns:
+        pd.DataFrame: clinical file as a dataframe
+    """
     clinicaldf = pd.read_csv(filePathList[0], sep="\t", comment="#")
     clinicaldf.columns = [col.upper() for col in clinicaldf.columns]
 

--- a/genie/process_functions.py
+++ b/genie/process_functions.py
@@ -22,6 +22,42 @@ logger = logging.getLogger(__name__)
 SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 
 
+def get_clinical_dataframe(filePathList):
+    clinicaldf = pd.read_csv(filePathList[0], sep="\t", comment="#")
+    clinicaldf.columns = [col.upper() for col in clinicaldf.columns]
+
+    if len(filePathList) > 1:
+        other_clinicaldf = pd.read_csv(filePathList[1], sep="\t", comment="#")
+        other_clinicaldf.columns = [col.upper() for col in other_clinicaldf.columns]
+
+        try:
+            clinicaldf = clinicaldf.merge(other_clinicaldf, on="PATIENT_ID")
+        except Exception:
+            raise ValueError(
+                (
+                    "If submitting separate patient and sample files, "
+                    "they both must have the PATIENT_ID column"
+                )
+            )
+        # Must figure out which is sample and which is patient
+        if "sample" in filePathList[0]:
+            sample = clinicaldf
+            patient = other_clinicaldf
+        else:
+            sample = other_clinicaldf
+            patient = clinicaldf
+
+        if not all(sample["PATIENT_ID"].isin(patient["PATIENT_ID"])):
+            raise ValueError(
+                (
+                    "Patient Clinical File: All samples must have associated "
+                    "patient information"
+                )
+            )
+
+    return clinicaldf
+
+
 def retry_get_url(url):
     """
     Implement retry logic when getting urls.

--- a/genie/process_functions.py
+++ b/genie/process_functions.py
@@ -22,8 +22,8 @@ logger = logging.getLogger(__name__)
 SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 
 
-def get_clinical_dataframe(filePathList : list) -> pd.DataFrame:
-    """Gets the clinical file(s) and reads them in as a 
+def get_clinical_dataframe(filePathList: list) -> pd.DataFrame:
+    """Gets the clinical file(s) and reads them in as a
     dataframe
 
     Args:

--- a/genie/validate.py
+++ b/genie/validate.py
@@ -309,9 +309,9 @@ def check_values_between_two_df(
     # check to see if df1 ids are present in df2
     if not set(df1[df1_id_to_check]) <= set(df2[df2_id_to_check]):
         errors = (
-            f"Not all values for {df1_id_to_check} in {df1_filename} "
-            f"can be found in {df2_id_to_check} in {df2_filename}."
+            f"At least one {df1_id_to_check} in your {df1_filename} file "
+            f"does not exist as a {df2_id_to_check} in your {df2_filename} file. "
+            "Please update your file(s) to be consistent.\n"
         )
-        warnings = ""
 
     return errors, warnings

--- a/genie/validate.py
+++ b/genie/validate.py
@@ -285,7 +285,7 @@ def check_values_between_two_df(
     df2_id_to_check: str,
 ) -> tuple:
     """Check that all the identifier(s) (ids) in one
-    file exists in the other file
+    file (df1) exists in the other file (df1)
 
     Args:
         df1 (pd.DataFrame): file to use as base of check
@@ -305,11 +305,11 @@ def check_values_between_two_df(
     # standardize case
     df2.columns = [col.upper() for col in df2.columns]
 
-    # check to see if the ids are equal
-    if set(df1[df1_id_to_check]) != set(df2[df2_id_to_check]):
+    # check to see if df1 ids are present in df2
+    if not set(df1[df1_id_to_check]) <= set(df2[df2_id_to_check]):
         errors = (
-            f"The values between {df1_id_to_check} in {df1_filename} and "
-            f"{df2_id_to_check} in {df2_filename} are not exactly the same."
+            f"Not all values for {df1_id_to_check} in {df1_filename} "
+            f"can be found in {df2_id_to_check} in {df2_filename}."
         )
         warnings = ""
 

--- a/genie/validate.py
+++ b/genie/validate.py
@@ -253,9 +253,7 @@ def _perform_validate(syn, args):
         load.store_files(syn=syn, filepaths=args.filepath, parentid=args.parentid)
 
 
-def parse_file_info_in_nested_list(
-    nested_list: list, search_str: str
-) -> dict:
+def parse_file_info_in_nested_list(nested_list: list, search_str: str) -> dict:
     """Parses for a name and filepath in a nested list of Synapse entity objects
 
     Args:

--- a/genie/validate.py
+++ b/genie/validate.py
@@ -303,6 +303,7 @@ def check_values_between_two_df(
     warnings = ""
 
     # standardize case
+    df1.columns = [col.upper() for col in df1.columns]
     df2.columns = [col.upper() for col in df2.columns]
 
     # check to see if df1 ids are present in df2

--- a/genie_registry/clinical.py
+++ b/genie_registry/clinical.py
@@ -15,41 +15,6 @@ from genie.database_to_staging import redact_phi
 logger = logging.getLogger(__name__)
 
 
-def get_dataframe(self, filePathList):
-        clinicaldf = pd.read_csv(filePathList[0], sep="\t", comment="#")
-        clinicaldf.columns = [col.upper() for col in clinicaldf.columns]
-
-        if len(filePathList) > 1:
-            other_clinicaldf = pd.read_csv(filePathList[1], sep="\t", comment="#")
-            other_clinicaldf.columns = [col.upper() for col in other_clinicaldf.columns]
-
-            try:
-                clinicaldf = clinicaldf.merge(other_clinicaldf, on="PATIENT_ID")
-            except Exception:
-                raise ValueError(
-                    (
-                        "If submitting separate patient and sample files, "
-                        "they both must have the PATIENT_ID column"
-                    )
-                )
-            # Must figure out which is sample and which is patient
-            if "sample" in filePathList[0]:
-                sample = clinicaldf
-                patient = other_clinicaldf
-            else:
-                sample = other_clinicaldf
-                patient = clinicaldf
-
-            if not all(sample["PATIENT_ID"].isin(patient["PATIENT_ID"])):
-                raise ValueError(
-                    (
-                        "Patient Clinical File: All samples must have associated "
-                        "patient information"
-                    )
-                )
-
-        return clinicaldf
-
 def _check_year(
     clinicaldf: pd.DataFrame,
     year_col: int,

--- a/genie_registry/maf.py
+++ b/genie_registry/maf.py
@@ -308,23 +308,19 @@ class maf(FileTypeFormat):
                 warnings = ""
 
             if not errors:
-                if process_functions.checkColExist(
-                    mutationDF, "SAMPLE_ID"
-                ) and process_functions.checkColExist(
-                    clinical_sample_df, "TUMOR_SAMPLE_BARCODE"
-                ):
+                if process_functions.checkColExist(clinical_sample_df, "SAMPLE_ID"):
                     errors, warnings = validate.check_values_between_two_df(
                         df1=mutationDF,
                         df1_filename=maf_filename,
-                        df1_id_to_check="SAMPLE_ID",
+                        df1_id_to_check="TUMOR_SAMPLE_BARCODE",
                         df2=clinical_sample_df,
                         df2_filename=clinical_file_names,
-                        df2_id_to_check="TUMOR_SAMPLE_BARCODE",
+                        df2_id_to_check="SAMPLE_ID",
                     )
                 else:
                     errors = ""
                     warnings = (
-                        "SAMPLE_ID doesn't exist in the maf or TUMOR_SAMPLE_BARCODE doesn't exist clinical file(s)."
+                        "SAMPLE_ID doesn't exist in the clinical file(s)."
                         "No cross-validation will be done."
                     )
         else:

--- a/genie_registry/maf.py
+++ b/genie_registry/maf.py
@@ -303,11 +303,11 @@ class maf(FileTypeFormat):
                 clinical_sample_df = process_functions.get_clinical_dataframe(
                     filePathList=clinical_file_paths
                 )
+                has_file_read_error = False
             except Exception as e:
-                errors = f"The clinical file(s) cannot be read. No cross-validation will be done. Original error: {str(e)}"
-                warnings = ""
+                has_file_read_error = True
 
-            if not errors:
+            if not has_file_read_error:
                 if process_functions.checkColExist(clinical_sample_df, "SAMPLE_ID"):
                     errors, warnings = validate.check_values_between_two_df(
                         df1=mutationDF,
@@ -317,17 +317,6 @@ class maf(FileTypeFormat):
                         df2_filename=clinical_file_names,
                         df2_id_to_check="SAMPLE_ID",
                     )
-                else:
-                    errors = ""
-                    warnings = (
-                        "SAMPLE_ID doesn't exist in the clinical file(s)."
-                        "No cross-validation will be done."
-                    )
-        else:
-            errors = (
-                "The clinical file(s) doesn't exist. No cross-validation will be done."
-            )
-            warnings = ""
         return errors, warnings
 
     def _get_dataframe(self, filePathList):

--- a/genie_registry/maf.py
+++ b/genie_registry/maf.py
@@ -289,13 +289,11 @@ class maf(FileTypeFormat):
         """
         errors = ""
         warnings = ""
-        maf_filename = f"data_mutations_extended_{self.center}.txt"
 
         # This section can be removed once we remove the list of lists
         clinical_files = validate.parse_file_info_in_nested_list(
             nested_list=self.ancillary_files, search_str="data_clinical_supp"
         )
-        clinical_file_names = clinical_files["file_info"]["name"]
         clinical_file_paths = clinical_files["file_info"]["path"]
 
         if clinical_files["files"]:
@@ -311,10 +309,10 @@ class maf(FileTypeFormat):
                 if process_functions.checkColExist(clinical_sample_df, "SAMPLE_ID"):
                     errors, warnings = validate.check_values_between_two_df(
                         df1=mutationDF,
-                        df1_filename=maf_filename,
+                        df1_filename="MAF",
                         df1_id_to_check="TUMOR_SAMPLE_BARCODE",
                         df2=clinical_sample_df,
-                        df2_filename=clinical_file_names,
+                        df2_filename="sample clinical",
                         df2_id_to_check="SAMPLE_ID",
                     )
         return errors, warnings

--- a/genie_registry/maf.py
+++ b/genie_registry/maf.py
@@ -277,6 +277,25 @@ class maf(FileTypeFormat):
 
         return total_error.getvalue(), warning.getvalue()
 
+
+    def _cross_validate(self, mutationDF: pd.DataFrame) -> tuple:
+        """This function cross-validates the mutation file to make sure it
+        adheres to the mutation SOP.
+
+        Args:
+            mutationDF (pd.DataFrame): mutation dataframe
+
+        Returns:
+            Text with all the errors in the mutation file
+        """
+        errors, warnings = self.cross_validate_ids_between_two_files(
+            df1 = mutationDF,
+            df2_file_name = f"data_clinical_supp_sample_{self.center}.txt",
+            id_to_check = "SAMPLE_ID",
+        )
+        return errors, warnings
+
+
     def _get_dataframe(self, filePathList):
         """Get mutation dataframe"""
         # Must do this because pandas.read_csv will allow for a file to

--- a/tests/test_example_filetype_format.py
+++ b/tests/test_example_filetype_format.py
@@ -1,0 +1,76 @@
+from unittest.mock import patch
+
+import pandas as pd
+import pytest
+
+from genie import process_functions, validate
+import genie.example_filetype_format
+from genie.example_filetype_format import FileTypeFormat
+
+
+@pytest.fixture
+def filetype_format_class(syn):
+    yield FileTypeFormat(syn, "SAGE")
+
+
+def test_that_validate_returns_expected_msg_if__validate_fails(filetype_format_class):
+    with patch.object(
+        FileTypeFormat,
+        "_validate",
+        return_value=("some_error", ""),
+    ) as patch_validate, patch.object(
+        FileTypeFormat,
+        "read_file",
+        return_value=pd.DataFrame(),
+    ) as patch_read_file, patch.object(
+        FileTypeFormat,
+        "_cross_validate",
+        return_value=("some_cross_error", "some_cross_warning"),
+    ) as patch_cross_validate:
+
+        result_cls = filetype_format_class.validate(filePathList=["something.txt"])
+        patch_validate.assert_called_once()
+        patch_cross_validate.assert_not_called()
+        assert result_cls.warnings == ""
+        assert result_cls.errors == "some_error"
+
+
+def test_that_validate_returns_expected_msg_if__validate_passes(filetype_format_class):
+    with patch.object(
+        FileTypeFormat,
+        "_validate",
+        return_value=("", "some_warning"),
+    ) as patch_validate, patch.object(
+        FileTypeFormat,
+        "read_file",
+        return_value=pd.DataFrame(),
+    ) as patch_read_file, patch.object(
+        FileTypeFormat,
+        "_cross_validate",
+        return_value=("some_cross_error", "some_cross_warning"),
+    ) as patch_cross_validate:
+
+        result_cls = filetype_format_class.validate(filePathList=["something.txt"])
+        patch_validate.assert_called_once()
+        patch_cross_validate.assert_called_once()
+        assert result_cls.warnings == "some_warning\nsome_cross_warning"
+        assert result_cls.errors == "some_cross_error"
+
+
+def test_that_validate_throws_exception_if_file_read_error(filetype_format_class):
+    with patch.object(FileTypeFormat, "_validate",) as patch_validate, patch.object(
+        FileTypeFormat,
+        "read_file",
+        side_effect=Exception("mocked error"),
+    ) as patch_read_file, patch.object(
+        FileTypeFormat, "_cross_validate"
+    ) as patch_cross_validate:
+
+        result_cls = filetype_format_class.validate(filePathList=["something.txt"])
+        assert result_cls.warnings == ""
+        assert result_cls.errors == (
+            "The file(s) (['something.txt']) cannot be read. "
+            "Original error: mocked error"
+        )
+        patch_validate.assert_not_called()
+        patch_cross_validate.assert_not_called()

--- a/tests/test_example_filetype_format.py
+++ b/tests/test_example_filetype_format.py
@@ -36,7 +36,7 @@ def test_that_validate_returns_expected_msg_if__validate_passes(filetype_format_
     with patch.object(
         FileTypeFormat,
         "_validate",
-        return_value=("", "some_warning"),
+        return_value=("", "some_warning\n"),
     ) as patch_validate, patch.object(
         FileTypeFormat,
         "read_file",
@@ -49,8 +49,8 @@ def test_that_validate_returns_expected_msg_if__validate_passes(filetype_format_
         result_cls = filetype_format_class.validate(filePathList=["something.txt"])
         patch_validate.assert_called_once()
         patch_cross_validate.assert_called_once()
-        assert result_cls.warnings == "some_warning\nsome_cross_warning\n"
-        assert result_cls.errors == "some_cross_error\n"
+        assert result_cls.warnings == "some_warning\nsome_cross_warning"
+        assert result_cls.errors == "some_cross_error"
 
 
 def test_that_validate_throws_exception_if_file_read_error(filetype_format_class):

--- a/tests/test_example_filetype_format.py
+++ b/tests/test_example_filetype_format.py
@@ -3,8 +3,6 @@ from unittest.mock import patch
 import pandas as pd
 import pytest
 
-from genie import process_functions, validate
-import genie.example_filetype_format
 from genie.example_filetype_format import FileTypeFormat
 
 
@@ -27,7 +25,6 @@ def test_that_validate_returns_expected_msg_if__validate_fails(filetype_format_c
         "_cross_validate",
         return_value=("some_cross_error", "some_cross_warning"),
     ) as patch_cross_validate:
-
         result_cls = filetype_format_class.validate(filePathList=["something.txt"])
         patch_validate.assert_called_once()
         patch_cross_validate.assert_not_called()
@@ -49,7 +46,6 @@ def test_that_validate_returns_expected_msg_if__validate_passes(filetype_format_
         "_cross_validate",
         return_value=("some_cross_error", "some_cross_warning"),
     ) as patch_cross_validate:
-
         result_cls = filetype_format_class.validate(filePathList=["something.txt"])
         patch_validate.assert_called_once()
         patch_cross_validate.assert_called_once()
@@ -58,14 +54,16 @@ def test_that_validate_returns_expected_msg_if__validate_passes(filetype_format_
 
 
 def test_that_validate_throws_exception_if_file_read_error(filetype_format_class):
-    with patch.object(FileTypeFormat, "_validate",) as patch_validate, patch.object(
+    with patch.object(
+        FileTypeFormat,
+        "_validate",
+    ) as patch_validate, patch.object(
         FileTypeFormat,
         "read_file",
         side_effect=Exception("mocked error"),
     ) as patch_read_file, patch.object(
         FileTypeFormat, "_cross_validate"
     ) as patch_cross_validate:
-
         result_cls = filetype_format_class.validate(filePathList=["something.txt"])
         assert result_cls.warnings == ""
         assert result_cls.errors == (

--- a/tests/test_example_filetype_format.py
+++ b/tests/test_example_filetype_format.py
@@ -49,8 +49,8 @@ def test_that_validate_returns_expected_msg_if__validate_passes(filetype_format_
         result_cls = filetype_format_class.validate(filePathList=["something.txt"])
         patch_validate.assert_called_once()
         patch_cross_validate.assert_called_once()
-        assert result_cls.warnings == "some_warning\nsome_cross_warning"
-        assert result_cls.errors == "some_cross_error"
+        assert result_cls.warnings == "some_warning\nsome_cross_warning\n"
+        assert result_cls.errors == "some_cross_error\n"
 
 
 def test_that_validate_throws_exception_if_file_read_error(filetype_format_class):

--- a/tests/test_input_to_database.py
+++ b/tests/test_input_to_database.py
@@ -951,6 +951,7 @@ class TestValidation:
                 entities,
                 format_registry={"test": valiate_cls},
                 genie_config=genie_config,
+                ancillary_files=entities,
             )
             assert patch_query.call_count == 2
             patch_validatefile.assert_called_once_with(

--- a/tests/test_maf.py
+++ b/tests/test_maf.py
@@ -336,12 +336,12 @@ def test_that__cross_validate_returns_warning_if_id_cols_do_not_exist(maf_class)
             pd.DataFrame(
                 dict(
                     SAMPLE_ID=[
-                        "GENIE-SAGE-ID1-1",
+                        "GENIE-SAGE-ID1-0",
                         "GENIE-SAGE-ID1-2",
                     ],
                 )
             ),
-            "The values between TUMOR_SAMPLE_BARCODE in data_mutations_extended_SAGE.txt and SAMPLE_ID in data_clinical_supp.txt are not exactly the same.",
+            "Not all values for TUMOR_SAMPLE_BARCODE in data_mutations_extended_SAGE.txt can be found in SAMPLE_ID in data_clinical_supp.txt.",
             "",
         ),
         (

--- a/tests/test_maf.py
+++ b/tests/test_maf.py
@@ -312,7 +312,9 @@ def test_that__cross_validate_does_not_call_check_col_exist_if_clinical_df_read_
         patch_check_col_exist.assert_not_called()
 
 
-def test_that__cross_validate_does_not_call_check_values_if_id_cols_do_not_exist(maf_class):
+def test_that__cross_validate_does_not_call_check_values_if_id_cols_do_not_exist(
+    maf_class,
+):
     with patch.object(
         validate,
         "parse_file_info_in_nested_list",
@@ -344,7 +346,8 @@ def test_that__cross_validate_does_not_call_check_values_if_id_cols_do_not_exist
                     ],
                 )
             ),
-            "Not all values for TUMOR_SAMPLE_BARCODE in data_mutations_extended_SAGE.txt can be found in SAMPLE_ID in data_clinical_supp.txt.",
+            "At least one TUMOR_SAMPLE_BARCODE in your MAF file does not exist as a SAMPLE_ID in your sample clinical file. "
+            "Please update your file(s) to be consistent.\n",
             "",
         ),
         (

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -511,7 +511,7 @@ def test_that_parse_file_info_in_nested_list_returns_expected(
     "test_df1,test_df2,expected_errors,expected_warnings",
     [
         (
-            pd.DataFrame({"ID": [1, 2, 3, 3]}),
+            pd.DataFrame({"ID": [1, 2]}),
             pd.DataFrame({"ID2": [1, 2, 3]}),
             "",
             "",
@@ -519,13 +519,13 @@ def test_that_parse_file_info_in_nested_list_returns_expected(
         (
             pd.DataFrame({"ID": [1, 2, 3, 4]}),
             pd.DataFrame({"ID2": [1, 2, 3]}),
-            "The values between ID in test1 and ID2 in test2 are not exactly the same.",
+            "Not all values for ID in test1 can be found in ID2 in test2.",
             "",
         ),
         (
             pd.DataFrame({"ID": [3, 4, 5]}),
             pd.DataFrame({"ID2": [1, 2, 3]}),
-            "The values between ID in test1 and ID2 in test2 are not exactly the same.",
+            "Not all values for ID in test1 can be found in ID2 in test2.",
             "",
         ),
     ],

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -519,13 +519,15 @@ def test_that_parse_file_info_in_nested_list_returns_expected(
         (
             pd.DataFrame({"ID": [1, 2, 3, 4]}),
             pd.DataFrame({"ID2": [1, 2, 3]}),
-            "Not all values for ID in test1 can be found in ID2 in test2.",
+            "At least one ID in your test1 file does not exist as a ID2 in your test2 file. "
+            "Please update your file(s) to be consistent.\n",
             "",
         ),
         (
             pd.DataFrame({"ID": [3, 4, 5]}),
             pd.DataFrame({"ID2": [1, 2, 3]}),
-            "Not all values for ID in test1 can be found in ID2 in test2.",
+            "At least one ID in your test1 file does not exist as a ID2 in your test2 file. "
+            "Please update your file(s) to be consistent.\n",
             "",
         ),
     ],

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -463,3 +463,84 @@ def test_perform_validate(syn, genie_config):
         patch_syn_upload.assert_called_once_with(
             syn=syn, filepaths=arg.filepath, parentid=arg.parentid
         )
+
+
+@pytest.mark.parametrize(
+    "test_nested_list,expected",
+    [
+        ([[]], {"files": {}, "file_info": {"name": "", "path": []}}),
+        (
+            [
+                [{"name": "test_txt1", "path": "/some_path1.txt"}],
+                [{"name": "test_txt2", "path": "/some_path2.txt"}],
+            ],
+            {"files": {}, "file_info": {"name": "", "path": []}},
+        ),
+        (
+            [
+                [
+                    {"name": "test_file1_1", "path": "/some_path1_1.txt"},
+                    {"name": "test_file1_2", "path": "/some_path1_2.txt"},
+                ],
+                [{"name": "test_file2", "path": "/some_path2.txt"}],
+            ],
+            {
+                "files": {
+                    "test_file1_1": "/some_path1_1.txt",
+                    "test_file1_2": "/some_path1_2.txt",
+                },
+                "file_info": {
+                    "name": "test_file1_1,test_file1_2",
+                    "path": ["/some_path1_1.txt", "/some_path1_2.txt"],
+                },
+            },
+        ),
+    ],
+    ids=["empty_nested_list", "no_files_with_substr", "valid_files"],
+)
+def test_that_parse_file_info_in_nested_list_returns_expected(
+    test_nested_list, expected
+):
+    result = validate.parse_file_info_in_nested_list(
+        nested_list=test_nested_list, search_str="test_file1"
+    )
+    assert result == expected
+
+
+@pytest.mark.parametrize(
+    "test_df1,test_df2,expected_errors,expected_warnings",
+    [
+        (
+            pd.DataFrame({"ID": [1, 2, 3, 3]}),
+            pd.DataFrame({"ID2": [1, 2, 3]}),
+            "",
+            "",
+        ),
+        (
+            pd.DataFrame({"ID": [1, 2, 3, 4]}),
+            pd.DataFrame({"ID2": [1, 2, 3]}),
+            "The values between ID in test1 and ID2 in test2 are not exactly the same.",
+            "",
+        ),
+        (
+            pd.DataFrame({"ID": [3, 4, 5]}),
+            pd.DataFrame({"ID2": [1, 2, 3]}),
+            "The values between ID in test1 and ID2 in test2 are not exactly the same.",
+            "",
+        ),
+    ],
+    ids=["all_match", "some_match", "no_match"],
+)
+def test_that_check_values_between_two_df_returns_expected(
+    test_df1, test_df2, expected_errors, expected_warnings
+):
+    errors, warnings = validate.check_values_between_two_df(
+        df1=test_df1,
+        df1_filename="test1",
+        df1_id_to_check="ID",
+        df2=test_df2,
+        df2_filename="test2",
+        df2_id_to_check="ID2",
+    )
+    assert errors == expected_errors
+    assert warnings == expected_warnings


### PR DESCRIPTION
**Purpose:** This PR adds further cross-validation functionality by adding the ability to cross-validate ids in the maf files with the clinical sample files. 

This uses the newly introduced `ancillary_files` attribute in the specific filetypeformat classes to cross validate.