### PR TITLE
Do not cross-file validate if ancillary files not present

### DIFF
--- a/genie/example_filetype_format.py
+++ b/genie/example_filetype_format.py
@@ -2,9 +2,10 @@
 This contains the GENIE model objects
 """
 from abc import ABCMeta
+from dataclasses import dataclass
 import logging
 import os
-from typing import List
+from typing import List, Optional
 
 import pandas as pd
 
@@ -12,20 +13,13 @@ import pandas as pd
 logger = logging.getLogger(__name__)
 
 
+@dataclass
 class ValidationResults:
     """Validation results"""
 
-    def __init__(self, errors: str, warnings: str, detailed: str = None) -> None:
-        """
-        Args:
-            errors (str): errors for the file
-            warnings (str): warning for the file
-            detailed_errors (pd.DataFrame, optional): Dataframe of detailed row based
-                                                      error messages. Defaults to None.
-        """
-        self.errors = errors
-        self.warnings = warnings
-        self.detailed = detailed
+    errors: str
+    warnings: str
+    detailed: Optional[str] = None
 
     def is_valid(self) -> bool:
         """True if file is valid"""

--- a/genie/example_filetype_format.py
+++ b/genie/example_filetype_format.py
@@ -258,7 +258,7 @@ class FileTypeFormat(metaclass=ABCMeta):
             logger.info("VALIDATING %s" % os.path.basename(",".join(filePathList)))
             errors, warnings = self._validate(df, **mykwargs)
             # only cross-validate if validation passes
-            if not errors:
+            if not errors and self.ancillary_files is not None:
                 logger.info(
                     "CROSS-VALIDATING %s" % os.path.basename(",".join(filePathList))
                 )

--- a/genie/example_filetype_format.py
+++ b/genie/example_filetype_format.py
@@ -251,8 +251,12 @@ class FileTypeFormat(metaclass=ABCMeta):
         if not errors:
             logger.info("VALIDATING %s" % os.path.basename(",".join(filePathList)))
             errors, warnings = self._validate(df, **mykwargs)
-            # only cross-validate if validation passes
-            if not errors and self.ancillary_files is not None:
+            # only cross-validate if validation passes or ancillary files exist
+            # Assumes that self.ancillary_files won't be [[]] due to whats returned from
+            # extract.get_center_input_files
+            if not errors and (
+                isinstance(self.ancillary_files, list) and self.ancillary_files
+            ):
                 logger.info(
                     "CROSS-VALIDATING %s" % os.path.basename(",".join(filePathList))
                 )

--- a/tests/test_example_filetype_format.py
+++ b/tests/test_example_filetype_format.py
@@ -11,14 +11,9 @@ def filetype_format_class(syn):
     yield FileTypeFormat(syn, "SAGE", ancillary_files=[["mocked"]])
 
 
-@pytest.fixture
-def filetype_format_class_no_ancillary(syn):
-    yield FileTypeFormat(syn, "SAGE")
-
-
-def test_that_validate_no_cross_file_without_ancillary(
-    filetype_format_class_no_ancillary,
-):
+@pytest.mark.parametrize("invalid_ancillary", [[], None])
+def test_that_validate_no_cross_file_without_invalid_ancillary(invalid_ancillary, syn):
+    filetype_cls = FileTypeFormat(syn, "SAGE", ancillary_files=invalid_ancillary)
     with patch.object(
         FileTypeFormat,
         "_validate",
@@ -31,9 +26,7 @@ def test_that_validate_no_cross_file_without_ancillary(
         FileTypeFormat,
         "_cross_validate",
     ) as patch_cross_validate:
-        result_cls = filetype_format_class_no_ancillary.validate(
-            filePathList=["something.txt"]
-        )
+        result_cls = filetype_cls.validate(filePathList=["something.txt"])
         patch_validate.assert_called_once()
         patch_cross_validate.assert_not_called()
         assert result_cls.warnings == "some_warning\n"


### PR DESCRIPTION
Currently there is a bug introduced when users validate via the cli because ancillary files will be None by default. 

This will ensure that cross validation doesn't happen if there are no ancillary files.  Support for ancillary files via the cli can come later.