### PR TITLE
fix: update maf read_csv

### DIFF
--- a/genie_registry/maf.py
+++ b/genie_registry/maf.py
@@ -364,5 +364,10 @@ class maf(FileTypeFormat):
             # Retain completely blank lines so that
             # validator will cause the file to fail
             skip_blank_lines=False,
+
+            # allows mixed datatypes when reading
+            # can occur when trying to read chunks
+            # chromosome triesto parse as str and int
+            low_memory=False,
         )
         return mutationdf

--- a/genie_registry/maf.py
+++ b/genie_registry/maf.py
@@ -364,7 +364,6 @@ class maf(FileTypeFormat):
             # Retain completely blank lines so that
             # validator will cause the file to fail
             skip_blank_lines=False,
-
             # allows mixed datatypes when reading
             # can occur when trying to read chunks
             # chromosome triesto parse as str and int


### PR DESCRIPTION
I was running into an issue validating my data_mutations_extended.txt file, this was the problem:

```
→genie validate data_mutations_extended_PROV.txt PROV
Welcome, Jake  VanCampen!

INFO:synapseclient_default:Welcome, Jake  VanCampen!

Downloading  [####################]100.00%   1.7kB/1.7kB (1.4MB/s) SYNAPSE_TABLE_QUERY_125739515.csv Done...
Downloading  [####################]100.00%   1.1kB/1.1kB (1.9MB/s) SYNAPSE_TABLE_QUERY_125734614.csv Done...
Downloading  [--------------------]   0.0bytes (0.0bytes/s) tree     [WARNING] /Users/jake.vancampenprovidence.org/Projects/Genie/genie_registry/maf.py:339: DtypeWarning: Columns (0) have mixed types. Specify dtype option on import or set low_memory=False.
  mutationdf = pd.read_csv(

WARNING:py.warnings:/Users/jake.vancampenprovidence.org/Projects/Genie/genie_registry/maf.py:339: DtypeWarning: Columns (0) have mixed types. Specify dtype option on import or set low_memory=False.
  mutationdf = pd.read_csv(

INFO:genie.example_filetype_format:VALIDATING data_mutations_extended_PROV.txt
ERROR:genie.example_filetype_format:maf: Please double check your CHROMOSOME column.  This column must only be these values: 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, X, Y, MT
```

After making the following change in the validator code the is the output now:

```
→genie validate data_mutations_extended_PROV.txt PROV
Welcome, Jake  VanCampen!

INFO:synapseclient_default:Welcome, Jake  VanCampen!

INFO:genie.example_filetype_format:VALIDATING data_mutations_extended_PROV.txt
INFO:genie.example_filetype_format:YOUR FILE IS VALIDATED!
```

Yay!
