### PR TITLE
[GEN-756] Fix maf validation

### DIFF
--- a/genie/transform.py
+++ b/genie/transform.py
@@ -53,6 +53,6 @@ def _convert_df_with_mixed_dtypes(read_csv_params: dict) -> pd.DataFrame:
     try:
         df = pd.read_csv(**read_csv_params, low_memory=True)
     except pd.errors.DtypeWarning:
+        warnings.resetwarnings()
         df = pd.read_csv(**read_csv_params, low_memory=False, engine="c")
-    warnings.resetwarnings()
     return df

--- a/genie/transform.py
+++ b/genie/transform.py
@@ -1,5 +1,6 @@
 """This module contains all the transformation functions used throughout the GENIE
 package"""
+import warnings
 
 import pandas as pd
 from pandas.api.types import is_integer_dtype, is_float_dtype
@@ -41,3 +42,17 @@ def _convert_float_col_with_nas_to_int(df: pd.DataFrame, col: str) -> list:
         return new_vals
     else:
         return df[col].tolist()
+
+
+def _convert_df_with_mixed_dtypes(read_csv_params: dict) -> pd.DataFrame:
+    """This checks if a dataframe read in normally has mixed data types and converts a dataframe with
+    mixed datatypes to one datatype.
+        read_csv_params (dict): of input params and values to pandas's read_csv function.
+            needs to include filepath to dataset to be read in"""
+    warnings.simplefilter("error", pd.errors.DtypeWarning)
+    try:
+        df = pd.read_csv(**read_csv_params, low_memory=True)
+    except pd.errors.DtypeWarning:
+        df = pd.read_csv(**read_csv_params, low_memory=False, engine="c")
+    warnings.resetwarnings()
+    return df

--- a/genie/transform.py
+++ b/genie/transform.py
@@ -45,14 +45,23 @@ def _convert_float_col_with_nas_to_int(df: pd.DataFrame, col: str) -> list:
 
 
 def _convert_df_with_mixed_dtypes(read_csv_params: dict) -> pd.DataFrame:
-    """This checks if a dataframe read in normally has mixed data types and converts a dataframe with
-    mixed datatypes to one datatype.
+    
+    """This checks if a dataframe read in normally comes out with mixed data types (which happens 
+    when low_memory = True because read_csv parses in chunks and guesses dtypes by chunk) and 
+    converts a dataframe with mixed datatypes to one datatype. 
+    
+    Args:
         read_csv_params (dict): of input params and values to pandas's read_csv function.
-            needs to include filepath to dataset to be read in"""
+            needs to include filepath to dataset to be read in
+            
+    Returns:
+        pd.DataFrame : The dataset read in
+    """
     warnings.simplefilter("error", pd.errors.DtypeWarning)
     try:
         df = pd.read_csv(**read_csv_params, low_memory=True)
     except pd.errors.DtypeWarning:
         warnings.resetwarnings()
+        # setting engine to c as that is the only engine that works with low_memory=False
         df = pd.read_csv(**read_csv_params, low_memory=False, engine="c")
     return df

--- a/genie/transform.py
+++ b/genie/transform.py
@@ -60,7 +60,7 @@ def _convert_df_with_mixed_dtypes(read_csv_params: dict) -> pd.DataFrame:
     try:
         df = pd.read_csv(**read_csv_params, low_memory=True)
     except pd.errors.DtypeWarning:
-        warnings.resetwarnings()
         # setting engine to c as that is the only engine that works with low_memory=False
         df = pd.read_csv(**read_csv_params, low_memory=False, engine="c")
+    warnings.resetwarnings()
     return df

--- a/genie/transform.py
+++ b/genie/transform.py
@@ -45,15 +45,14 @@ def _convert_float_col_with_nas_to_int(df: pd.DataFrame, col: str) -> list:
 
 
 def _convert_df_with_mixed_dtypes(read_csv_params: dict) -> pd.DataFrame:
-    
-    """This checks if a dataframe read in normally comes out with mixed data types (which happens 
-    when low_memory = True because read_csv parses in chunks and guesses dtypes by chunk) and 
-    converts a dataframe with mixed datatypes to one datatype. 
-    
+    """This checks if a dataframe read in normally comes out with mixed data types (which happens
+    when low_memory = True because read_csv parses in chunks and guesses dtypes by chunk) and
+    converts a dataframe with mixed datatypes to one datatype.
+
     Args:
         read_csv_params (dict): of input params and values to pandas's read_csv function.
             needs to include filepath to dataset to be read in
-            
+
     Returns:
         pd.DataFrame : The dataset read in
     """

--- a/genie_registry/maf.py
+++ b/genie_registry/maf.py
@@ -324,7 +324,6 @@ class maf(FileTypeFormat):
             # Retain completely blank lines so that
             # validator will cause the file to fail
             skip_blank_lines=False,
-
             # allows mixed datatypes when reading
             # can occur when trying to read chunks
             # chromosome triesto parse as str and int

--- a/genie_registry/maf.py
+++ b/genie_registry/maf.py
@@ -328,9 +328,6 @@ class maf(FileTypeFormat):
             # Retain completely blank lines so that
             # validator will cause the file to fail
             "skip_blank_lines": False,
-            # allows mixed datatypes when reading
-            # can occur when trying to read chunks
-            # chromosome triesto parse as str and int
         }
         mutationdf = transform._convert_df_with_mixed_dtypes(read_csv_params)
         return mutationdf

--- a/genie_registry/maf.py
+++ b/genie_registry/maf.py
@@ -170,10 +170,6 @@ class maf(FileTypeFormat):
             for col in primary_cols:
                 if mutationDF[col].dtype == object:
                     mutationDF[col] = mutationDF[col].str.strip()
-                    mutationDF[col].mask(
-                        pd.to_numeric(mutationDF[col], errors="coerce").isnull(),
-                        mutationDF[col].str.strip(),
-                    )
             duplicated_idx = mutationDF.duplicated(primary_cols)
             # Find samples with duplicated variants
             duplicated_variants = (

--- a/genie_registry/maf.py
+++ b/genie_registry/maf.py
@@ -1,11 +1,12 @@
 from io import StringIO
 import os
 import logging
+import warnings
 
 import pandas as pd
 
 from genie.example_filetype_format import FileTypeFormat
-from genie import process_functions, validate
+from genie import process_functions, transform, validate
 
 logger = logging.getLogger(__name__)
 
@@ -169,6 +170,10 @@ class maf(FileTypeFormat):
             for col in primary_cols:
                 if mutationDF[col].dtype == object:
                     mutationDF[col] = mutationDF[col].str.strip()
+                    mutationDF[col].mask(
+                        pd.to_numeric(mutationDF[col], errors="coerce").isnull(),
+                        mutationDF[col].str.strip(),
+                    )
             duplicated_idx = mutationDF.duplicated(primary_cols)
             # Find samples with duplicated variants
             duplicated_variants = (
@@ -295,13 +300,12 @@ class maf(FileTypeFormat):
                 "Number of fields in a line do not match the "
                 "expected number of columns"
             )
-
-        mutationdf = pd.read_csv(
-            filePathList[0],
-            sep="\t",
-            comment="#",
+        read_csv_params = {
+            "filepath_or_buffer": filePathList[0],
+            "sep": "\t",
+            "comment": "#",
             # Keep the value 'NA'
-            na_values=[
+            "na_values": [
                 "-1.#IND",
                 "1.#QNAN",
                 "1.#IND",
@@ -317,16 +321,16 @@ class maf(FileTypeFormat):
                 "-nan",
                 "",
             ],
-            keep_default_na=False,
+            "keep_default_na": False,
             # This is to check if people write files
             # with R, quote=T
-            quoting=3,
+            "quoting": 3,
             # Retain completely blank lines so that
             # validator will cause the file to fail
-            skip_blank_lines=False,
+            "skip_blank_lines": False,
             # allows mixed datatypes when reading
             # can occur when trying to read chunks
             # chromosome triesto parse as str and int
-            low_memory=False,
-        )
+        }
+        mutationdf = transform._convert_df_with_mixed_dtypes(read_csv_params)
         return mutationdf

--- a/genie_registry/maf.py
+++ b/genie_registry/maf.py
@@ -324,5 +324,10 @@ class maf(FileTypeFormat):
             # Retain completely blank lines so that
             # validator will cause the file to fail
             skip_blank_lines=False,
+
+            # allows mixed datatypes when reading
+            # can occur when trying to read chunks
+            # chromosome triesto parse as str and int
+            low_memory=False,
         )
         return mutationdf

--- a/tests/test_maf.py
+++ b/tests/test_maf.py
@@ -1,4 +1,5 @@
-from unittest.mock import patch
+from io import BytesIO, StringIO
+from unittest.mock import mock_open, patch
 
 import pandas as pd
 import pytest
@@ -271,3 +272,26 @@ def test_valid__check_tsa1_tsa2(df):
     """Test valid TSA1 and TSA2"""
     error = genie_registry.maf._check_tsa1_tsa2(df)
     assert error == ""
+
+
+def test_that__get_dataframe_returns_expected_result(
+    maf_class,
+):
+    file = (
+        "Hugo_Symbol	Entrez_Gene_Id	Center	NCBI_Build	Chromosome\n"
+        "TEST	3845	TEST	GRCh37	12"
+    )
+    with patch("builtins.open", mock_open(read_data=file)) as mock_file:
+        test = maf_class._get_dataframe(["some_path"])
+        pd.testing.assert_frame_equal(
+            test,
+            pd.DataFrame(
+                {
+                    "Hugo_Symbol": ["TEST"],
+                    "Entrez_Gene_Id": [3845],
+                    "Center": ["TEST"],
+                    "NCBI_Build": ["GRCh37"],
+                    "Chromosome": [12],
+                }
+            ),
+        )

--- a/tests/test_maf.py
+++ b/tests/test_maf.py
@@ -274,17 +274,14 @@ def test_valid__check_tsa1_tsa2(df):
     assert error == ""
 
 
-def test_that__get_dataframe_returns_expected_result(
-    maf_class,
-):
-    file = (
-        "Hugo_Symbol	Entrez_Gene_Id	Center	NCBI_Build	Chromosome\n"
-        "TEST	3845	TEST	GRCh37	12"
-    )
-    with patch("builtins.open", mock_open(read_data=file)) as mock_file:
-        test = maf_class._get_dataframe(["some_path"])
-        pd.testing.assert_frame_equal(
-            test,
+@pytest.mark.parametrize(
+    "test_input,expected",
+    [
+        (
+            (
+                "Hugo_Symbol	Entrez_Gene_Id	Center	NCBI_Build	Chromosome\n"
+                "TEST	3845	TEST	GRCh37	12"
+            ),
             pd.DataFrame(
                 {
                     "Hugo_Symbol": ["TEST"],
@@ -294,4 +291,40 @@ def test_that__get_dataframe_returns_expected_result(
                     "Chromosome": [12],
                 }
             ),
-        )
+        ),
+        (
+            (
+                "#Something Something else\n"
+                "Hugo_Symbol	Entrez_Gene_Id	Center	NCBI_Build	Chromosome\n"
+                "TEST	3845	TEST	GRCh37	12"
+            ),
+            pd.DataFrame(
+                {
+                    "Hugo_Symbol": ["TEST"],
+                    "Entrez_Gene_Id": [3845],
+                    "Center": ["TEST"],
+                    "NCBI_Build": ["GRCh37"],
+                    "Chromosome": [12],
+                }
+            ),
+        ),
+    ],
+    ids=["no_pound_sign", "pound_sign"],
+)
+def test_that__get_dataframe_returns_expected_result(maf_class, test_input, expected):
+    with patch("builtins.open", mock_open(read_data=test_input)) as mock_file:
+        test = maf_class._get_dataframe(["some_path"])
+        pd.testing.assert_frame_equal(test, expected)
+
+
+def test_that__get_dataframe_throws_value_error(maf_class):
+    file = (
+        "#Hugo_Symbol	Entrez_Gene_Id	Center	NCBI_Build	Chromosome\n"
+        "TEST	3845	TEST	GRCh37	12"
+    )
+    with patch("builtins.open", mock_open(read_data=file)) as patch_open:
+        with pytest.raises(
+            ValueError,
+            match="Number of fields in a line do not match the expected number of columns",
+        ):
+            maf_class._get_dataframe(["some_path"])

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -1,10 +1,17 @@
 """Test genie.transform module"""
+from io import BytesIO
 from unittest.mock import patch
 
 import pandas as pd
+from pandas.api.types import (
+    is_float_dtype,
+    is_integer_dtype,
+    is_object_dtype,
+)
 import pytest
 
 from genie import transform
+from unittest import mock
 
 
 class TestConvertCols:
@@ -17,8 +24,12 @@ class TestConvertCols:
                 pd.DataFrame({"some_col": ["Val1", float("nan")]}),
                 ["Val1", float("nan")],
             ),
+            (
+                pd.DataFrame({"some_col": ["Val1", float("nan"), 1, "1"]}),
+                ["Val1", float("nan"), "1", "1"],
+            ),
         ],
-        ids=["float_w_na", "int_w_na", "string_w_na"],
+        ids=["float_w_na", "int_w_na", "string_w_na", "mixed_w_na"],
     )
     def test_that__convert_col_with_nas_to_str_keep_na_for_any_data_type(
         self, test_input, expected
@@ -35,8 +46,12 @@ class TestConvertCols:
                 pd.DataFrame({"some_col": ["Val1", "Val2"]}),
                 ["Val1", "Val2"],
             ),
+            (
+                pd.DataFrame({"some_col": ["Val1", 1, "2"]}),
+                ["Val1", "1", "2"],
+            ),
         ],
-        ids=["float_no_na", "string_no_na"],
+        ids=["float_no_na", "string_no_na", "mixed_no_na"],
     )
     def test_that__convert_col_with_nas_to_str_returns_correct_vals_with_no_na_data(
         self, test_input, expected
@@ -73,3 +88,94 @@ class TestConvertCols:
         result = transform._convert_float_col_with_nas_to_int(test_input, "some_col")
         assert result[0] == "Val1"
         assert pd.isna(result[1])
+
+
+@pytest.mark.parametrize(
+    "test_input,expected_output,expected_dtype", 
+    [
+        (
+            pd.DataFrame({"some_col": [1, "Val2", "1"]}),
+            pd.DataFrame({"some_col": ["1", "Val2", "1"]}),
+            is_object_dtype,
+        ),
+        (
+            pd.DataFrame({"some_col": ["Val1", "Val2", "Val3"]}),
+            pd.DataFrame({"some_col": ["Val1", "Val2", "Val3"]}),
+            is_object_dtype,
+        ),
+        (
+            pd.DataFrame({"some_col": [1.0, "Val2", 3]}),
+            pd.DataFrame({"some_col": ["1.0", "Val2", "3"]}),
+            is_object_dtype,
+        ),
+        (
+            pd.DataFrame({"some_col": ["2", "3", 1]}),
+            pd.DataFrame({"some_col": [2, 3, 1]}),
+            is_integer_dtype,
+        ),
+        (
+            pd.DataFrame({"some_col": [2, None, 1]}),
+            pd.DataFrame({"some_col": [2, None, 1]}),
+            is_float_dtype,
+        ),
+        (
+            pd.DataFrame({"some_col": [float("nan"), None, "1"]}),
+            pd.DataFrame({"some_col": [float("nan"), None, 1]}),
+            is_float_dtype,
+        ),
+        (
+            pd.DataFrame({"some_col": [float("nan"), "Val1", "1"]}),
+            pd.DataFrame({"some_col": [float("nan"), "Val1", "1"]}),
+            is_object_dtype,
+        ),
+        (
+            pd.DataFrame({"some_col": [1, 1.0, 3.0]}),
+            pd.DataFrame({"some_col": [1, 1.0, 3.0]}),
+            is_float_dtype,
+        ),
+    ],
+    ids=[
+        "mixed_dtype_str_int",
+        "all_str",
+        "mixed_dtype_float_int_str",
+        "mixed_dtype_all_int",
+        "int_none",
+        "int_nan",
+        "mixed_dtype_nan_str",
+        "int_float",
+    ],
+)
+class TestConvertMixedDtypes:
+    def test_that__convert_df_with_mixed_dtypes_gets_expected_output(
+        self, test_input, expected_output, expected_dtype
+    ):
+        # Create your in memory BytesIO file.
+        output = BytesIO()
+        test_input.to_csv(output, index=False)
+        output.seek(0)  # Contains the CSV in memory file.
+
+        df = transform._convert_df_with_mixed_dtypes(
+            {"filepath_or_buffer": output, "index_col": False}
+        )
+        pd.testing.assert_frame_equal(
+            df.reset_index(drop=True), expected_output.reset_index(drop=True)
+        )
+        assert expected_dtype(df["some_col"])
+
+    def test_that__convert_df_with_mixed_dtypes_catches_pandas_exception(
+        self, test_input, expected_output, expected_dtype
+    ):
+        # Create your in memory BytesIO file.
+        output = BytesIO()
+        test_input.to_csv(output, index=False)
+        output.seek(0)  # Contains the CSV in memory file.
+
+        with mock.patch.object(pd, "read_csv") as mock_read_csv:
+            transform._convert_df_with_mixed_dtypes(
+                {"filepath_or_buffer": output, "index_col": False}
+            )
+            mock_read_csv.assert_called_once_with(
+                filepath_or_buffer=output,
+                index_col=False,
+                low_memory=True,
+            )


### PR DESCRIPTION
**Purpose:** This adds a helper function to `maf.py`'s `_get_dataframe` function to allow for handing of files where it gets read in as mixed dtypes to avoid doing so.

Note that we still need to run a larger maf dataset that has mixed dtypes prior to validating through validation as part of an integration test.