### PR TITLE
[GEN-738] Add variant position validation for maf file

### DIFF
--- a/genie/validate.py
+++ b/genie/validate.py
@@ -318,3 +318,34 @@ def check_values_between_two_df(
         )
 
     return errors, warnings
+
+
+def check_variant_start_and_end_positions(
+    input_df: pd.DataFrame, start_pos_col: str, end_pos_col: str, filename: str
+) -> tuple:
+    """Checks that a variant's start position is less than its
+        end position
+
+    Args:
+        input_df (pd.DataFrame): Input data to check positions
+        start_pos_col (str): Name of the start position column
+        end_pos_col (str): Name of the end position column
+        filename (str): Name of the file
+
+    Returns:
+        tuple: The errors and warnings from the position validation
+               Defaults to blank strings
+
+    """
+    errors = ""
+    warnings = ""
+
+    if any(input_df[start_pos_col] > input_df[end_pos_col]):
+        errors = (
+            f"{filename}: Your variants file has record(s) that have an end position value "
+            "less than the start position value. When we annotate through the "
+            "genome-nexus-annotation-pipeline, the records with this position "
+            "discrepancy will show a blank reference and variant allele. "
+            "Please update your file to be consistent.\n"
+        )
+    return errors, warnings

--- a/genie/validate.py
+++ b/genie/validate.py
@@ -342,10 +342,9 @@ def check_variant_start_and_end_positions(
 
     if any(input_df[start_pos_col] > input_df[end_pos_col]):
         errors = (
-            f"{filename}: Your variants file has record(s) that have an end position value "
-            "less than the start position value. When we annotate through the "
-            "genome-nexus-annotation-pipeline, the records with this position "
-            "discrepancy will show a blank reference and variant allele. "
-            "Please update your file to be consistent.\n"
+            f"{filename}: Your variants file has record(s) that have an end position "
+            "value less than the start position value. Please update your file to be consistent. "
+            "When we annotate using the genome-nexus-annotation-pipeline, the records with this "
+            "position discrepancy will show a blank reference and variant allele.\n"
         )
     return errors, warnings

--- a/genie_registry/maf.py
+++ b/genie_registry/maf.py
@@ -283,7 +283,7 @@ class maf(FileTypeFormat):
                 input_df=mutationDF,
                 start_pos_col="START_POSITION",
                 end_pos_col="END_POSITION",
-                filename = "maf"
+                filename="maf",
             )
             total_error.write(errors)
             warning.write(warnings)

--- a/genie_registry/maf.py
+++ b/genie_registry/maf.py
@@ -275,6 +275,18 @@ class maf(FileTypeFormat):
             )
             total_error.write(error)
 
+        # only check end position as start position is required col
+        if process_functions.checkColExist(
+            mutationDF, "START_POSITION"
+        ) and process_functions.checkColExist(mutationDF, "END_POSITION"):
+            errors, warnings = validate.check_variant_start_and_end_positions(
+                input_df=mutationDF,
+                start_pos_col="START_POSITION",
+                end_pos_col="END_POSITION",
+                filename = "maf"
+            )
+            total_error.write(errors)
+            warning.write(warnings)
         return total_error.getvalue(), warning.getvalue()
 
     def _cross_validate(self, mutationDF: pd.DataFrame) -> tuple:

--- a/genie_registry/maf.py
+++ b/genie_registry/maf.py
@@ -196,7 +196,10 @@ class maf(FileTypeFormat):
             "N_DEPTH",
             "N_REF_COUNT",
             "N_ALT_COUNT",
+            "START_POSITION",
+            "END_POSITION",
         ]
+        actual_numerical_cols = []
         for col in numerical_cols:
             col_exists = process_functions.checkColExist(mutationDF, col)
             if col_exists:
@@ -211,6 +214,8 @@ class maf(FileTypeFormat):
                     pass
                 if mutationDF[col].dtype not in [int, float]:
                     total_error.write(f"maf: {col} must be a numerical column.\n")
+                else:
+                    actual_numerical_cols.append(col)
 
         # CHECK: Must have TUMOR_SEQ_ALLELE2
         error, warn = _check_allele_col(mutationDF, "TUMOR_SEQ_ALLELE2")
@@ -276,9 +281,11 @@ class maf(FileTypeFormat):
             total_error.write(error)
 
         # only check end position as start position is required col
-        if process_functions.checkColExist(
-            mutationDF, "START_POSITION"
-        ) and process_functions.checkColExist(mutationDF, "END_POSITION"):
+        if (
+            process_functions.checkColExist(mutationDF, "START_POSITION")
+            and process_functions.checkColExist(mutationDF, "END_POSITION")
+            and set(["START_POSITION", "END_POSITION"]) <= set(actual_numerical_cols)
+        ):
             errors, warnings = validate.check_variant_start_and_end_positions(
                 input_df=mutationDF,
                 start_pos_col="START_POSITION",

--- a/tests/test_maf.py
+++ b/tests/test_maf.py
@@ -439,3 +439,30 @@ def test_that__get_dataframe_throws_value_error(maf_class):
             match="Number of fields in a line do not match the expected number of columns",
         ):
             maf_class._get_dataframe(["some_path"])
+
+
+def test_that__validate_does_not_call_check_variant_start_and_end_positions(
+    maf_class, valid_maf_df
+):
+    with patch.object(
+        validate, "check_variant_start_and_end_positions"
+    ) as patch_check_variant:
+        maf_class._validate(valid_maf_df)
+        patch_check_variant.assert_not_called()
+
+
+def test_that__validate_calls_check_variant_start_and_end_positions(
+    maf_class, valid_maf_df
+):
+    test_input = valid_maf_df.copy()
+    test_input["END_POSITION"] = test_input["START_POSITION"] + 1
+    with patch.object(
+        validate, "check_variant_start_and_end_positions"
+    , return_value = ("","")) as patch_check_variant:
+        maf_class._validate(test_input)
+        patch_check_variant.assert_called_once_with(
+            input_df=test_input,
+            start_pos_col="START_POSITION",
+            end_pos_col="END_POSITION",
+            filename="maf",
+        )

--- a/tests/test_maf.py
+++ b/tests/test_maf.py
@@ -168,7 +168,8 @@ def test_invalid_validation(maf_class):
         dict(
             CHROMOSOME=[1, 2, 3, 4, 2, 4],
             T_ALT_COUNT=[1, 2, 3, 4, 3, 4],
-            START_POSITION=[1, 2, 3, 4, 2, 4],
+            START_POSITION=[1, 2, "string", 4, 2, 4],
+            END_POSITION=["1", "2", 3, "string", 4, 5],
             REFERENCE_ALLELE=["A ", "A ", "A", "A ", "A ", " A"],
             TUMOR_SAMPLE_BARCODE=["ID1-1", "ID1-1", "ID1-1", "ID1-1", "ID1-1", "ID1-1"],
             N_DEPTH=[1, 2, 3, 4, 3, 4],
@@ -189,6 +190,8 @@ def test_invalid_validation(maf_class):
         "maf: "
         "If missing T_DEPTH, must have T_REF_COUNT!\n"
         "maf: N_REF_COUNT must be a numerical column.\n"
+        "maf: START_POSITION must be a numerical column.\n"
+        "maf: END_POSITION must be a numerical column.\n"
         "maf: "
         "TUMOR_SEQ_ALLELE2 can't have any blank or null values.\n"
         "maf: TUMOR_SAMPLE_BARCODE must start with GENIE-SAGE\n"
@@ -441,21 +444,54 @@ def test_that__get_dataframe_throws_value_error(maf_class):
             maf_class._get_dataframe(["some_path"])
 
 
+@pytest.mark.parametrize(
+    "test_input",
+    [
+        pd.DataFrame(
+            dict(
+                START_POSITION=[23, 24, 25],
+            )
+        ),
+        pd.DataFrame(
+            dict(
+                START_POSITION=[23, 24, 25],
+                END_POSITION=["val1", "23", "val3"],
+            )
+        ),
+    ],
+    ids=["no_end_pos_col", "pos_cols_str"]
+)
 def test_that__validate_does_not_call_check_variant_start_and_end_positions(
-    maf_class, valid_maf_df
+    maf_class, test_input
 ):
     with patch.object(
-        validate, "check_variant_start_and_end_positions"
+        validate, "check_variant_start_and_end_positions", return_value=("", "")
     ) as patch_check_variant:
-        maf_class._validate(valid_maf_df)
+        maf_class._validate(test_input)
         patch_check_variant.assert_not_called()
 
 
+@pytest.mark.parametrize(
+    "test_input",
+    [
+        pd.DataFrame(
+            dict(
+                START_POSITION=[23, 24, 25],
+                END_POSITION=[25, 26, 27],
+            )
+        ),
+        pd.DataFrame(
+            dict(
+                START_POSITION=[23, 24, 25],
+                END_POSITION=["23", "24", "25"],
+            )
+        ),
+    ],
+    ids=["all_numeric_pos", "str_numeric_pos"]
+)
 def test_that__validate_calls_check_variant_start_and_end_positions(
-    maf_class, valid_maf_df
+    maf_class, test_input
 ):
-    test_input = valid_maf_df.copy()
-    test_input["END_POSITION"] = test_input["START_POSITION"] + 1
     with patch.object(
         validate, "check_variant_start_and_end_positions", return_value=("", "")
     ) as patch_check_variant:

--- a/tests/test_maf.py
+++ b/tests/test_maf.py
@@ -457,8 +457,8 @@ def test_that__validate_calls_check_variant_start_and_end_positions(
     test_input = valid_maf_df.copy()
     test_input["END_POSITION"] = test_input["START_POSITION"] + 1
     with patch.object(
-        validate, "check_variant_start_and_end_positions"
-    , return_value = ("","")) as patch_check_variant:
+        validate, "check_variant_start_and_end_positions", return_value=("", "")
+    ) as patch_check_variant:
         maf_class._validate(test_input)
         patch_check_variant.assert_called_once_with(
             input_df=test_input,

--- a/tests/test_maf.py
+++ b/tests/test_maf.py
@@ -459,7 +459,7 @@ def test_that__get_dataframe_throws_value_error(maf_class):
             )
         ),
     ],
-    ids=["no_end_pos_col", "pos_cols_str"]
+    ids=["no_end_pos_col", "pos_cols_str"],
 )
 def test_that__validate_does_not_call_check_variant_start_and_end_positions(
     maf_class, test_input
@@ -487,7 +487,7 @@ def test_that__validate_does_not_call_check_variant_start_and_end_positions(
             )
         ),
     ],
-    ids=["all_numeric_pos", "str_numeric_pos"]
+    ids=["all_numeric_pos", "str_numeric_pos"],
 )
 def test_that__validate_calls_check_variant_start_and_end_positions(
     maf_class, test_input

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -564,9 +564,9 @@ def test_that_check_values_between_two_df_returns_expected(
             ),
             (
                 "test_file: Your variants file has record(s) that have an end position "
-            "value less than the start position value. Please update your file to be consistent. "
-            "When we annotate using the genome-nexus-annotation-pipeline, the records with this "
-            "position discrepancy will show a blank reference and variant allele.\n"
+                "value less than the start position value. Please update your file to be consistent. "
+                "When we annotate using the genome-nexus-annotation-pipeline, the records with this "
+                "position discrepancy will show a blank reference and variant allele.\n"
             ),
             "",
         ),
@@ -576,9 +576,9 @@ def test_that_check_values_between_two_df_returns_expected(
             ),
             (
                 "test_file: Your variants file has record(s) that have an end position "
-            "value less than the start position value. Please update your file to be consistent. "
-            "When we annotate using the genome-nexus-annotation-pipeline, the records with this "
-            "position discrepancy will show a blank reference and variant allele.\n"
+                "value less than the start position value. Please update your file to be consistent. "
+                "When we annotate using the genome-nexus-annotation-pipeline, the records with this "
+                "position discrepancy will show a blank reference and variant allele.\n"
             ),
             "",
         ),

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -563,11 +563,10 @@ def test_that_check_values_between_two_df_returns_expected(
                 {"start_pos": [1, 2], "end_pos": [0, 4], "some_col": ["a", "b"]}
             ),
             (
-                "test_file: Your variants file has record(s) that have an end position value "
-                "less than the start position value. When we annotate through the "
-                "genome-nexus-annotation-pipeline, the records with this position "
-                "discrepancy will show a blank reference and variant allele. "
-                "Please update your file to be consistent.\n"
+                "test_file: Your variants file has record(s) that have an end position "
+            "value less than the start position value. Please update your file to be consistent. "
+            "When we annotate using the genome-nexus-annotation-pipeline, the records with this "
+            "position discrepancy will show a blank reference and variant allele.\n"
             ),
             "",
         ),
@@ -576,11 +575,10 @@ def test_that_check_values_between_two_df_returns_expected(
                 {"start_pos": [1, 2], "end_pos": [0, 1], "some_col": ["a", "b"]}
             ),
             (
-                "test_file: Your variants file has record(s) that have an end position value "
-                "less than the start position value. When we annotate through the "
-                "genome-nexus-annotation-pipeline, the records with this position "
-                "discrepancy will show a blank reference and variant allele. "
-                "Please update your file to be consistent.\n"
+                "test_file: Your variants file has record(s) that have an end position "
+            "value less than the start position value. Please update your file to be consistent. "
+            "When we annotate using the genome-nexus-annotation-pipeline, the records with this "
+            "position discrepancy will show a blank reference and variant allele.\n"
             ),
             "",
         ),

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -546,3 +546,62 @@ def test_that_check_values_between_two_df_returns_expected(
     )
     assert errors == expected_errors
     assert warnings == expected_warnings
+
+
+@pytest.mark.parametrize(
+    "test_input,expected_errors,expected_warnings",
+    [
+        (
+            pd.DataFrame(
+                {"start_pos": [1, 2], "end_pos": [3, 4], "some_col": ["a", "b"]}
+            ),
+            "",
+            "",
+        ),
+        (
+            pd.DataFrame(
+                {"start_pos": [1, 2], "end_pos": [0, 4], "some_col": ["a", "b"]}
+            ),
+            (
+                "test_file: Your variants file has record(s) that have an end position value "
+                "less than the start position value. When we annotate through the "
+                "genome-nexus-annotation-pipeline, the records with this position "
+                "discrepancy will show a blank reference and variant allele. "
+                "Please update your file to be consistent.\n"
+            ),
+            "",
+        ),
+        (
+            pd.DataFrame(
+                {"start_pos": [1, 2], "end_pos": [0, 1], "some_col": ["a", "b"]}
+            ),
+            (
+                "test_file: Your variants file has record(s) that have an end position value "
+                "less than the start position value. When we annotate through the "
+                "genome-nexus-annotation-pipeline, the records with this position "
+                "discrepancy will show a blank reference and variant allele. "
+                "Please update your file to be consistent.\n"
+            ),
+            "",
+        ),
+        (
+            pd.DataFrame(
+                {"start_pos": [1, 2], "end_pos": [1, 2], "some_col": ["a", "b"]}
+            ),
+            "",
+            "",
+        ),
+    ],
+    ids=["start_lt_end_pos", "end_lt_start_pos", "end_all_lt_start_pos", "equal_pos"],
+)
+def test_that_check_variant_start_and_end_positions_returns_expected(
+    test_input, expected_errors, expected_warnings
+):
+    errors, warnings = validate.check_variant_start_and_end_positions(
+        input_df=test_input,
+        start_pos_col="start_pos",
+        end_pos_col="end_pos",
+        filename="test_file",
+    )
+    assert errors == expected_errors
+    assert warnings == expected_warnings


### PR DESCRIPTION
**Purpose:** This adds to `validate.py` a check for start and end positions for variant, and that the start position must be < end position. This is implemented for `maf` files.