### PR TITLE
[GEN-833] Remove support for python 3.7, pin synapseclient

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
@@ -64,7 +64,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v4
       with:
         python-version: '3.x'
     - name: Install dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.8, 3.9]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This repository documents code used to gather, QC, standardize, and analyze data
 ## Dependencies
 
 This package contains both R, Python and cli tools.  These are tools or packages you will need, to be able to reproduce these results:
-- Python >3.7 or <3.10
+- Python >=3.8 or <3.10
     - `pip install -r requirements.txt`
 - [bedtools](https://bedtools.readthedocs.io/en/latest/content/installation.html)
 - R 4.2.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,4 @@ pandas>=1.0,<1.5.0
 pyranges==0.0.115
 # known working version 6.0
 PyYAML>=5.1
-synapseclient>=2.7.0
+synapseclient>=2.7.0,<3.0.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,7 +19,6 @@ classifiers =
     Programming Language :: Python
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3 :: Only
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Topic :: Scientific/Engineering
@@ -30,14 +29,14 @@ project_urls =
 [options]
 packages = find:
 install_requires =
-    synapseclient>=2.7.0
+    synapseclient>=2.7.0, <3.0.0
     pandas>=1.0,<1.5.0
     httplib2>=0.11.3
     PyYAML>=5.1
     chardet>=3.0.4
     pyranges==0.0.115
     numpy<=1.22.2
-python_requires = >=3.7, <3.10
+python_requires = >=3.8, <3.10
 include_package_data = True
 zip_safe = False
 scripts =


### PR DESCRIPTION
**Purpose:** This PR removes all support for `python 3.7` and pins `synapseclient` to be <3.0.0 and >= 2.7.0