### PR TITLE
[GEN-851] Hotfix pin cbioportal repo version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -82,7 +82,7 @@ RUN python3 setup.py develop
 WORKDIR /root/
 # Must move this git clone to after the install of Genie,
 # because must update cbioportal
-RUN git clone https://github.com/cBioPortal/cbioportal.git
+RUN git clone https://github.com/cBioPortal/cbioportal.git -b v5.3.19
 RUN git clone https://github.com/Sage-Bionetworks/annotation-tools.git -b 0.0.2
 
 WORKDIR /root/Genie


### PR DESCRIPTION
**Purpose:** Running into the issue of a missing package when pulling the latest repo version from cBioPortal whilest running the public release. We will pin the version of cbioportal repo to an earlier one of `v5.3.19` in our dockerfile.