### PR TITLE
[GEN-846] & [GEN-845] Ignore case and allow underscores in cross-validate

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -125,12 +125,14 @@ patch.object(MODULE_NAME, "FUNCTION_TO_MOCK_NAME".return_value=SOME_RETURN_VALUE
 Follow gitflow best practices as linked above.
 
 1. Always merge all new features into `develop` branch first (unless it is a documentation, readme, or github action patch into `main`)
-1. After initial features are ready in the `develop` branch, create a `release-X.X` branch to prepare for the release.
+1. After initial features are ready in the `develop` branch, create a `release-X.X` branch (do not need to push this branch to remote) to prepare for the release.
     1. update the `__version__` parameter in `genie/__init__.py`
 1. Merge `release-X.X` branch into `main` - Not by pull request!
-1. Create release tag (`v...`) and include release notes.  Also include any known bugs for each release here.
+1. Create release tag (`v...`) and a brief message
+1. Push tag and change(s) from `main`
+1. Create a new release on the repo. Include release notes.  Also include any known bugs for each release here. Wait for the CI/CD to finish.
 1. Merge `main` back into `develop`
-
+1. Push `develop`
 
 ### DockerHub
 

--- a/genie/validate.py
+++ b/genie/validate.py
@@ -260,7 +260,11 @@ def parse_file_info_in_nested_list(
     ignore_case: bool = False,
     allow_underscore: bool = False,
 ) -> dict:
-    """Parses for a name and filepath in a nested list of Synapse entity objects
+    """
+    TODO: To refactor/remove once clinical file structure gets updated to
+    be non-nested
+    
+    Parses for a name and filepath in a nested list of Synapse entity objects
 
     Args:
         nested_list (list[list]): _description_
@@ -293,7 +297,6 @@ def parse_file_info_in_nested_list(
     file_info["name"] = ",".join(all_files.keys())
     file_info["path"] = list(all_files.values())  # type: ignore[assignment]
     return {"files": all_files, "file_info": file_info}
-    return all_files
 
 
 def check_values_between_two_df(

--- a/genie/validate.py
+++ b/genie/validate.py
@@ -263,7 +263,7 @@ def parse_file_info_in_nested_list(
     """
     TODO: To refactor/remove once clinical file structure gets updated to
     be non-nested
-    
+
     Parses for a name and filepath in a nested list of Synapse entity objects
 
     Args:

--- a/genie/validate.py
+++ b/genie/validate.py
@@ -273,7 +273,7 @@ def parse_file_info_in_nested_list(
             name(s) and filepath(s) of the file(s) found
     """
     file_info = {}
-    files = {
+    all_files = {
         file["name"]: file["path"]
         for files in nested_list
         for file in files
@@ -289,9 +289,11 @@ def parse_file_info_in_nested_list(
             )
         )
     }
-    file_info["name"] = ",".join(files.keys())
-    file_info["path"] = list(files.values())  # type: ignore[assignment]
-    return {"files": files, "file_info": file_info}
+
+    file_info["name"] = ",".join(all_files.keys())
+    file_info["path"] = list(all_files.values())  # type: ignore[assignment]
+    return {"files": all_files, "file_info": file_info}
+    return all_files
 
 
 def check_values_between_two_df(
@@ -401,9 +403,12 @@ def standardize_string_for_validation(
     Returns:
         str: standardized string
     """
-    standardized_str = input_string
-    if ignore_case:
-        standardized_str = standardized_str.lower()
-    if allow_underscore:
-        standardized_str = standardized_str.replace("_", "-")
-    return standardized_str
+    if isinstance(input_string, str):
+        standardized_str = input_string
+        if ignore_case:
+            standardized_str = standardized_str.lower()
+        if allow_underscore:
+            standardized_str = standardized_str.replace("_", "-")
+        return standardized_str
+    else:
+        return input_string

--- a/genie_registry/clinical.py
+++ b/genie_registry/clinical.py
@@ -1021,7 +1021,10 @@ class Clinical(FileTypeFormat):
 
         for seq_assay_id in seq_assay_ids:
             bed_files = validate.parse_file_info_in_nested_list(
-                nested_list=self.ancillary_files, search_str=f"{seq_assay_id}.bed"  # type: ignore[arg-type]
+                nested_list=self.ancillary_files,
+                search_str=f"{seq_assay_id}.bed",  # type: ignore[arg-type]
+                ignore_case=True,
+                allow_underscore=True,
             )
             if not bed_files["files"]:
                 missing_files.append(f"{seq_assay_id}.bed")
@@ -1074,6 +1077,8 @@ class Clinical(FileTypeFormat):
                         df2=assay_df,
                         df2_filename="assay information",
                         df2_id_to_check=col_to_validate,
+                        ignore_case=True,
+                        allow_underscore=True,
                     )
         return errors, warnings
 

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -662,7 +662,7 @@ def test_that_parse_file_info_in_nested_list_returns_expected_with_ignore_case_a
         "allow_underscore",
         "ignore_case_and_allow_underscore",
         "str_some_match",
-        "str_no_match"
+        "str_no_match",
     ],
 )
 def test_that_check_values_between_two_df_returns_expected(

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -507,14 +507,91 @@ def test_that_parse_file_info_in_nested_list_returns_expected(
     assert result == expected
 
 
+def test_that_parse_file_info_in_nested_list_returns_expected_with_ignore_case():
+    test_nested_list = (
+        [
+            [{"name": "test_file1_1", "path": "/some_path1_1.txt"}],
+            [{"name": "test_file2", "path": "/some_path2.txt"}],
+        ],
+    )
+    expected = (
+        {
+            "files": {
+                "test_file1_1": "/some_path1_1.txt",
+            },
+            "file_info": {
+                "name": "test_file1_1",
+                "path": ["/some_path1_1.txt"],
+            },
+        },
+    )
+    result = validate.parse_file_info_in_nested_list(
+        nested_list=test_nested_list, search_str="TEST-file1", ignore_case=True
+    )
+    assert result == expected
+
+
+def test_that_parse_file_info_in_nested_list_returns_expected_with_allow_underscore():
+    test_nested_list = (
+        [
+            [{"name": "test-file1-1"}],
+            [{"name": "test-file2"}],
+        ],
+    )
+    expected = (
+        {
+            "files": {
+                "test_file1-1": "/some_path1-1.txt",
+            },
+            "file_info": {
+                "name": "test-file1-1",
+                "path": ["/some-path1-1.txt"],
+            },
+        },
+    )
+    result = validate.parse_file_info_in_nested_list(
+        nested_list=test_nested_list, search_str="test_file1", allow_underscore=True
+    )
+    assert result == expected
+
+
+def test_that_parse_file_info_in_nested_list_returns_expected_with_ignore_case_and_allow_underscore():
+    test_nested_list = (
+        [
+            [{"name": "test-file1-1"}],
+            [{"name": "test-file2"}],
+        ],
+    )
+    expected = (
+        {
+            "files": {
+                "test-file1-1": "/some-path1-1.txt",
+            },
+            "file_info": {
+                "name": "test-file1_1",
+                "path": ["/some-path1-1.txt"],
+            },
+        },
+    )
+    result = validate.parse_file_info_in_nested_list(
+        nested_list=test_nested_list,
+        search_str="TEST-file1",
+        ignore_case=True,
+        allow_underscore=True,
+    )
+    assert result == expected
+
+
 @pytest.mark.parametrize(
-    "test_df1,test_df2,expected_errors,expected_warnings",
+    "test_df1,test_df2,expected_errors,expected_warnings,ignore_case,allow_underscore",
     [
         (
             pd.DataFrame({"ID": [1, 2]}),
             pd.DataFrame({"ID2": [1, 2, 3]}),
             "",
             "",
+            False,
+            False,
         ),
         (
             pd.DataFrame({"ID": [1, 2, 3, 4]}),
@@ -522,6 +599,8 @@ def test_that_parse_file_info_in_nested_list_returns_expected(
             "At least one ID in your test1 file does not exist as a ID2 in your test2 file. "
             "Please update your file(s) to be consistent.\n",
             "",
+            False,
+            False,
         ),
         (
             pd.DataFrame({"ID": [3, 4, 5]}),
@@ -529,12 +608,50 @@ def test_that_parse_file_info_in_nested_list_returns_expected(
             "At least one ID in your test1 file does not exist as a ID2 in your test2 file. "
             "Please update your file(s) to be consistent.\n",
             "",
+            False,
+            False,
+        ),
+        (
+            pd.DataFrame({"ID": ["TEST1", "TEST2", "TeSt3"]}),
+            pd.DataFrame({"ID2": ["test1", "test2", "TEST3"]}),
+            "",
+            "",
+            True,
+            False,
+        ),
+        (
+            pd.DataFrame({"ID": ["TEST_1", "TEST_2", "TEST-3"]}),
+            pd.DataFrame({"ID2": ["TEST_1", "TEST-2", "TEST_3"]}),
+            "",
+            "",
+            False,
+            True,
+        ),
+        (
+            pd.DataFrame({"ID": ["TEST_1", "TEST_2", "TeSt-3"]}),
+            pd.DataFrame({"ID2": ["test_1", "test-2", "TEST_3"]}),
+            "",
+            "",
+            True,
+            True,
         ),
     ],
-    ids=["all_match", "some_match", "no_match"],
+    ids=[
+        "all_match",
+        "some_match",
+        "no_match",
+        "ignore_case",
+        "allow_underscore",
+        "ignore_case_and_allow_underscore",
+    ],
 )
 def test_that_check_values_between_two_df_returns_expected(
-    test_df1, test_df2, expected_errors, expected_warnings
+    test_df1,
+    test_df2,
+    expected_errors,
+    expected_warnings,
+    ignore_case,
+    allow_underscore,
 ):
     errors, warnings = validate.check_values_between_two_df(
         df1=test_df1,
@@ -543,6 +660,8 @@ def test_that_check_values_between_two_df_returns_expected(
         df2=test_df2,
         df2_filename="test2",
         df2_id_to_check="ID2",
+        ignore_case=ignore_case,
+        allow_underscore=allow_underscore,
     )
     assert errors == expected_errors
     assert warnings == expected_warnings
@@ -603,3 +722,24 @@ def test_that_check_variant_start_and_end_positions_returns_expected(
     )
     assert errors == expected_errors
     assert warnings == expected_warnings
+
+
+def test_that_standardize_string_for_validation_ignores_case():
+    test_str = validate.standardize_string_for_validation(
+        input_string="SAGe-1", ignore_case=True
+    )
+    assert test_str == "sage-1"
+
+
+def test_that_standardize_string_for_validation_allows_underscores():
+    test_str = validate.standardize_string_for_validation(
+        input_string="SAGe_1", allow_underscore=True
+    )
+    assert test_str == "SAGe-1"
+
+
+def test_that_standardize_string_for_validation_allows_underscores_and_ignores_case():
+    test_str = validate.standardize_string_for_validation(
+        input_string="SAGe_1", ignore_case=True, allow_underscore=True
+    )
+    assert test_str == "sage-1"

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -635,6 +635,24 @@ def test_that_parse_file_info_in_nested_list_returns_expected_with_ignore_case_a
             True,
             True,
         ),
+        (
+            pd.DataFrame({"ID": ["TEST__1", "TEST_2", "TeSt-3"]}),
+            pd.DataFrame({"ID2": ["test_1", "test-2", "TEST_3"]}),
+            "At least one ID in your test1 file does not exist as a ID2 in your test2 file. "
+            "Please update your file(s) to be consistent.\n",
+            "",
+            True,
+            True,
+        ),
+        (
+            pd.DataFrame({"ID": ["TEST1", "TEST2", "TeSt3"]}),
+            pd.DataFrame({"ID2": ["test1", "test2", "TEST3"]}),
+            "At least one ID in your test1 file does not exist as a ID2 in your test2 file. "
+            "Please update your file(s) to be consistent.\n",
+            "",
+            False,
+            False,
+        ),
     ],
     ids=[
         "all_match",
@@ -643,6 +661,8 @@ def test_that_parse_file_info_in_nested_list_returns_expected_with_ignore_case_a
         "ignore_case",
         "allow_underscore",
         "ignore_case_and_allow_underscore",
+        "str_some_match",
+        "str_no_match"
     ],
 )
 def test_that_check_values_between_two_df_returns_expected(
@@ -724,29 +744,27 @@ def test_that_check_variant_start_and_end_positions_returns_expected(
     assert warnings == expected_warnings
 
 
-def test_that_standardize_string_for_validation_ignores_case():
+@pytest.mark.parametrize(
+    "input_str,expected,ignore_case,allow_underscore",
+    [
+        ("SAGe-1", "sage-1", True, False),
+        ("SAGe_1", "SAGe-1", False, True),
+        ("SAGe_1", "sage-1", True, True),
+        (120, 120, True, True),
+    ],
+    ids=[
+        "ignore_case",
+        "allow_underscore",
+        "ignore_case_and_allow_underscore",
+        "non_str",
+    ],
+)
+def test_that_standardize_string_for_validation_returns_expected(
+    input_str, expected, ignore_case, allow_underscore
+):
     test_str = validate.standardize_string_for_validation(
-        input_string="SAGe-1", ignore_case=True
+        input_string=input_str,
+        ignore_case=ignore_case,
+        allow_underscore=allow_underscore,
     )
-    assert test_str == "sage-1"
-
-
-def test_that_standardize_string_for_validation_allows_underscores():
-    test_str = validate.standardize_string_for_validation(
-        input_string="SAGe_1", allow_underscore=True
-    )
-    assert test_str == "SAGe-1"
-
-
-def test_that_standardize_string_for_validation_allows_underscores_and_ignores_case():
-    test_str = validate.standardize_string_for_validation(
-        input_string="SAGe_1", ignore_case=True, allow_underscore=True
-    )
-    assert test_str == "sage-1"
-
-
-def test_that_standardize_string_for_validation_does_nothing_for_non_str():
-    test_str = validate.standardize_string_for_validation(
-        input_string=120, ignore_case=True, allow_underscore=True
-    )
-    assert test_str == 120
+    assert test_str == expected

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -508,47 +508,47 @@ def test_that_parse_file_info_in_nested_list_returns_expected(
 
 
 def test_that_parse_file_info_in_nested_list_returns_expected_with_ignore_case():
-    test_nested_list = (
+    test_nested_list = [
         [
-            [{"name": "test_file1_1", "path": "/some_path1_1.txt"}],
-            [{"name": "test_file2", "path": "/some_path2.txt"}],
+            {"name": "TEST-file1-1", "path": "/some_path1_1.txt"},
+            {"name": "test-file1-2", "path": "/some_path1_2.txt"},
         ],
-    )
-    expected = (
-        {
-            "files": {
-                "test_file1_1": "/some_path1_1.txt",
-            },
-            "file_info": {
-                "name": "test_file1_1",
-                "path": ["/some_path1_1.txt"],
-            },
+        [{"name": "test_file2", "path": "/some_path2.txt"}],
+    ]
+    expected = {
+        "files": {
+            "TEST-file1-1": "/some_path1_1.txt",
+            "test-file1-2": "/some_path1_2.txt",
         },
-    )
+        "file_info": {
+            "name": "TEST-file1-1,test-file1-2",
+            "path": ["/some_path1_1.txt", "/some_path1_2.txt"],
+        },
+    }
     result = validate.parse_file_info_in_nested_list(
-        nested_list=test_nested_list, search_str="TEST-file1", ignore_case=True
+        nested_list=test_nested_list, search_str="tEsT-file1", ignore_case=True
     )
     assert result == expected
 
 
 def test_that_parse_file_info_in_nested_list_returns_expected_with_allow_underscore():
-    test_nested_list = (
+    test_nested_list = [
         [
-            [{"name": "test-file1-1"}],
-            [{"name": "test-file2"}],
+            {"name": "test_file1_1", "path": "/some_path1_1.txt"},
+            {"name": "test-file1_2", "path": "/some_path1_2.txt"},
         ],
-    )
-    expected = (
-        {
-            "files": {
-                "test_file1-1": "/some_path1-1.txt",
-            },
-            "file_info": {
-                "name": "test-file1-1",
-                "path": ["/some-path1-1.txt"],
-            },
+        [{"name": "test_file2", "path": "/some_path2.txt"}],
+    ]
+    expected = {
+        "files": {
+            "test_file1_1": "/some_path1_1.txt",
+            "test-file1_2": "/some_path1_2.txt",
         },
-    )
+        "file_info": {
+            "name": "test_file1_1,test-file1_2",
+            "path": ["/some_path1_1.txt", "/some_path1_2.txt"],
+        },
+    }
     result = validate.parse_file_info_in_nested_list(
         nested_list=test_nested_list, search_str="test_file1", allow_underscore=True
     )
@@ -556,26 +556,26 @@ def test_that_parse_file_info_in_nested_list_returns_expected_with_allow_undersc
 
 
 def test_that_parse_file_info_in_nested_list_returns_expected_with_ignore_case_and_allow_underscore():
-    test_nested_list = (
+    test_nested_list = [
         [
-            [{"name": "test-file1-1"}],
-            [{"name": "test-file2"}],
+            {"name": "TEST-file1_1", "path": "/some_path1_1.txt"},
+            {"name": "test_fiLE1_2", "path": "/some_path1_2.txt"},
         ],
-    )
-    expected = (
-        {
-            "files": {
-                "test-file1-1": "/some-path1-1.txt",
-            },
-            "file_info": {
-                "name": "test-file1_1",
-                "path": ["/some-path1-1.txt"],
-            },
+        [{"name": "test_file2", "path": "/some_path2.txt"}],
+    ]
+    expected = {
+        "files": {
+            "TEST-file1_1": "/some_path1_1.txt",
+            "test_fiLE1_2": "/some_path1_2.txt",
         },
-    )
+        "file_info": {
+            "name": "TEST-file1_1,test_fiLE1_2",
+            "path": ["/some_path1_1.txt", "/some_path1_2.txt"],
+        },
+    }
     result = validate.parse_file_info_in_nested_list(
         nested_list=test_nested_list,
-        search_str="TEST-file1",
+        search_str="TEST_file1",
         ignore_case=True,
         allow_underscore=True,
     )
@@ -743,3 +743,10 @@ def test_that_standardize_string_for_validation_allows_underscores_and_ignores_c
         input_string="SAGe_1", ignore_case=True, allow_underscore=True
     )
     assert test_str == "sage-1"
+
+
+def test_that_standardize_string_for_validation_does_nothing_for_non_str():
+    test_str = validate.standardize_string_for_validation(
+        input_string=120, ignore_case=True, allow_underscore=True
+    )
+    assert test_str == 120


### PR DESCRIPTION
**Purpose:** We would like to ignore case and allow underscores when cross-validating `SEQ_ASSAY_ID`s in clinical files against assay_information files' `SEQ_ASSAY_ID` values and bed file names.

This involves an addition of a new function to `validate.py` called `standardize_string_for_validation`. This function is called in all the affected clinical-assay_information and clinical-bed cross-validation functions within the `clinical.py` script.

Example) Something like SAGE_tEst-1 should compare as **equal** to something like Sage-test-1

This also completes JIRA ticket: [GEN-845](https://sagebionetworks.jira.com/browse/GEN-845)

[GEN-845]: https://sagebionetworks.jira.com/browse/GEN-845?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ