### PR TITLE
[GEN-905] - Change error of start position > end position to a warning

### DIFF
--- a/genie/validate.py
+++ b/genie/validate.py
@@ -383,11 +383,11 @@ def check_variant_start_and_end_positions(
     warnings = ""
 
     if any(input_df[start_pos_col] > input_df[end_pos_col]):
-        errors = (
+        warnings = (
             f"{filename}: Your variants file has record(s) that have an end position "
             "value less than the start position value. Please update your file to be consistent. "
             "When we annotate using the genome-nexus-annotation-pipeline, the records with this "
-            "position discrepancy will show a blank reference and variant allele.\n"
+            "position discrepancy will be re-annotated with different end position values.\n"
         )
     return errors, warnings
 

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -701,25 +701,25 @@ def test_that_check_values_between_two_df_returns_expected(
             pd.DataFrame(
                 {"start_pos": [1, 2], "end_pos": [0, 4], "some_col": ["a", "b"]}
             ),
+            "",
             (
                 "test_file: Your variants file has record(s) that have an end position "
                 "value less than the start position value. Please update your file to be consistent. "
                 "When we annotate using the genome-nexus-annotation-pipeline, the records with this "
-                "position discrepancy will show a blank reference and variant allele.\n"
+                "position discrepancy will be re-annotated with different end position values.\n"
             ),
-            "",
         ),
         (
             pd.DataFrame(
                 {"start_pos": [1, 2], "end_pos": [0, 1], "some_col": ["a", "b"]}
             ),
+            "",
             (
                 "test_file: Your variants file has record(s) that have an end position "
                 "value less than the start position value. Please update your file to be consistent. "
                 "When we annotate using the genome-nexus-annotation-pipeline, the records with this "
-                "position discrepancy will show a blank reference and variant allele.\n"
+                "position discrepancy will be re-annotated with different end position values.\n"
             ),
-            "",
         ),
         (
             pd.DataFrame(


### PR DESCRIPTION
Genome Nexus now handles this issue, so instead of an error, we just throw a warning