### PR TITLE
[GEN-809] Validate allele columns

### DIFF
--- a/genie/validate.py
+++ b/genie/validate.py
@@ -424,7 +424,7 @@ def get_invalid_allele_rows(
     allowed_comb_alleles: list,
     allowed_ind_alleles: list,
     ignore_case: bool = False,
-    allow_na: bool = False
+    allow_na: bool = False,
 ) -> pd.Index:
     """
     Find invalid indices in a DataFrame column based on allowed allele values.

--- a/genie_registry/maf.py
+++ b/genie_registry/maf.py
@@ -47,14 +47,6 @@ def _check_allele_col(df, col):
     error = ""
     warning = ""
     if col_exist:
-        # CHECK: The value "NA" can't be used as a placeholder
-        if sum(df[col].fillna("") == "NA") > 0:
-            warning = (
-                "maf: "
-                f"{col} column contains 'NA' values, "
-                "which cannot be placeholders for blank values.  "
-                "Please put in empty strings for blank values.\n"
-            )
         # CHECK: There can't be any null values
         if sum(df[col].isnull()) > 0:
             error = f"maf: {col} can't have any blank or null values.\n"

--- a/genie_registry/maf.py
+++ b/genie_registry/maf.py
@@ -71,7 +71,8 @@ class maf(FileTypeFormat):
 
     _process_kwargs = []
     _allele_cols = ["REFERENCE_ALLELE", "TUMOR_SEQ_ALLELE1", "TUMOR_SEQ_ALLELE2"]
-    _allowed_alleles = ["A", "T", "C", "G", "N", " ", "-"]
+    _allowed_comb_alleles = ["A", "T", "C", "G", "N"]
+    _allowed_ind_alleles = ['-']
 
     def _validateFilename(self, filePath):
         """
@@ -302,13 +303,16 @@ class maf(FileTypeFormat):
                 invalid_indices = validate.get_invalid_allele_rows(
                     mutationDF,
                     allele_col,
-                    allowed_alleles=self._allowed_alleles,
+                    allowed_comb_alleles=self._allowed_comb_alleles,
+                    allowed_ind_alleles=self._allowed_ind_alleles,
                     ignore_case=True,
+                    allow_na=False
                 )
                 errors, warnings = validate.get_allele_validation_message(
                     invalid_indices,
                     invalid_col=allele_col,
-                    allowed_alleles=self._allowed_alleles,
+                    allowed_comb_alleles=self._allowed_comb_alleles,
+                    allowed_ind_alleles=self._allowed_ind_alleles,
                     fileformat=self._fileType,
                 )
                 total_error.write(errors)

--- a/genie_registry/maf.py
+++ b/genie_registry/maf.py
@@ -70,6 +70,8 @@ class maf(FileTypeFormat):
     _fileType = "maf"
 
     _process_kwargs = []
+    _allele_cols = ["REFERENCE_ALLELE", "TUMOR_SEQ_ALLELE1", "TUMOR_SEQ_ALLELE2"]
+    _allowed_alleles = ["A", "T", "C", "G", "N", " ", "-"]
 
     def _validateFilename(self, filePath):
         """
@@ -294,21 +296,24 @@ class maf(FileTypeFormat):
             )
             total_error.write(errors)
             warning.write(warnings)
-            
-        # TODO: add these lists as class attribute or global
-        allele_cols = ["REFERENCE_ALLELE", "TUMOR_SEQ_ALLELE1", "TUMOR_SEQ_ALLELE2"]
-        allowed_alleles = ['A','T','C','G','N', ' ', '-']
-        for allele_col in allele_cols:
+
+        for allele_col in self._allele_cols:
             if process_functions.checkColExist(mutationDF, allele_col):
                 invalid_indices = validate.get_invalid_allele_rows(
-                    mutationDF, allele_col, allowed_alleles = allowed_alleles, ignore_case = True
+                    mutationDF,
+                    allele_col,
+                    allowed_alleles=self._allowed_alleles,
+                    ignore_case=True,
                 )
                 errors, warnings = validate.get_allele_validation_message(
-                    invalid_indices, invalid_col = allele_col, allowed_alleles = allowed_alleles, fileformat="maf"
+                    invalid_indices,
+                    invalid_col=allele_col,
+                    allowed_alleles=self._allowed_alleles,
+                    fileformat=self._fileType,
                 )
                 total_error.write(errors)
                 warning.write(warnings)
-                
+
         return total_error.getvalue(), warning.getvalue()
 
     def _cross_validate(self, mutationDF: pd.DataFrame) -> tuple:

--- a/genie_registry/maf.py
+++ b/genie_registry/maf.py
@@ -64,7 +64,7 @@ class maf(FileTypeFormat):
     _process_kwargs = []
     _allele_cols = ["REFERENCE_ALLELE", "TUMOR_SEQ_ALLELE1", "TUMOR_SEQ_ALLELE2"]
     _allowed_comb_alleles = ["A", "T", "C", "G", "N"]
-    _allowed_ind_alleles = ['-']
+    _allowed_ind_alleles = ["-"]
 
     def _validateFilename(self, filePath):
         """
@@ -298,7 +298,7 @@ class maf(FileTypeFormat):
                     allowed_comb_alleles=self._allowed_comb_alleles,
                     allowed_ind_alleles=self._allowed_ind_alleles,
                     ignore_case=True,
-                    allow_na=False
+                    allow_na=False,
                 )
                 errors, warnings = validate.get_allele_validation_message(
                     invalid_indices,

--- a/genie_registry/maf.py
+++ b/genie_registry/maf.py
@@ -294,6 +294,21 @@ class maf(FileTypeFormat):
             )
             total_error.write(errors)
             warning.write(warnings)
+            
+        # TODO: add these lists as class attribute or global
+        allele_cols = ["REFERENCE_ALLELE", "TUMOR_SEQ_ALLELE1", "TUMOR_SEQ_ALLELE2"]
+        allowed_alleles = ['A','T','C','G','N', ' ', '-']
+        for allele_col in allele_cols:
+            if process_functions.checkColExist(mutationDF, allele_col):
+                invalid_indices = validate.get_invalid_allele_rows(
+                    mutationDF, allele_col, allowed_alleles = allowed_alleles, ignore_case = True
+                )
+                errors, warnings = validate.get_allele_validation_message(
+                    invalid_indices, invalid_col = allele_col, allowed_alleles = allowed_alleles, fileformat="maf"
+                )
+                total_error.write(errors)
+                warning.write(warnings)
+                
         return total_error.getvalue(), warning.getvalue()
 
     def _cross_validate(self, mutationDF: pd.DataFrame) -> tuple:

--- a/genie_registry/vcf.py
+++ b/genie_registry/vcf.py
@@ -141,7 +141,10 @@ class vcf(FileTypeFormat):
 
         if process_functions.checkColExist(vcfdf, self._allele_col):
             invalid_indices = validate.get_invalid_allele_rows(
-                vcfdf, self._allele_col, allowed_alleles=self._allowed_alleles, ignore_case=True
+                vcfdf,
+                self._allele_col,
+                allowed_alleles=self._allowed_alleles,
+                ignore_case=True,
             )
             errors, warnings = validate.get_allele_validation_message(
                 invalid_indices,

--- a/genie_registry/vcf.py
+++ b/genie_registry/vcf.py
@@ -18,7 +18,7 @@ class vcf(FileTypeFormat):
     _fileType = "vcf"
 
     _process_kwargs = []
-    _allele_col = "REF"
+    _allele_cols = ["REF"]
     _allowed_comb_alleles = ["A", "T", "C", "G", "N"]
     _allowed_ind_alleles = []
 
@@ -140,24 +140,25 @@ class vcf(FileTypeFormat):
         total_error += error
         warning += warn
 
-        if process_functions.checkColExist(vcfdf, self._allele_col):
-            invalid_indices = validate.get_invalid_allele_rows(
-                vcfdf,
-                input_col=self._allele_col,
-                allowed_comb_alleles=self._allowed_comb_alleles,
-                allowed_ind_alleles=self._allowed_ind_alleles,
-                ignore_case=True,
-                allow_na=False
+        for allele_col in self._allele_cols:
+            if process_functions.checkColExist(vcfdf, allele_col):
+                invalid_indices = validate.get_invalid_allele_rows(
+                    vcfdf,
+                    input_col=allele_col,
+                    allowed_comb_alleles=self._allowed_comb_alleles,
+                    allowed_ind_alleles=self._allowed_ind_alleles,
+                    ignore_case=True,
+                    allow_na=False,
                 )
-            errors, warnings = validate.get_allele_validation_message(
-                invalid_indices,
-                invalid_col=self._allele_col,
-                allowed_comb_alleles=self._allowed_comb_alleles,
-                allowed_ind_alleles=self._allowed_ind_alleles,
-                fileformat=self._fileType,
-            )
-            total_error += errors
-            warning += warnings
+                errors, warnings = validate.get_allele_validation_message(
+                    invalid_indices,
+                    invalid_col=allele_col,
+                    allowed_comb_alleles=self._allowed_comb_alleles,
+                    allowed_ind_alleles=self._allowed_ind_alleles,
+                    fileformat=self._fileType,
+                )
+                total_error += errors
+                warning += warnings
 
         # No white spaces
         white_space = vcfdf.apply(lambda x: contains_whitespace(x), axis=1)

--- a/genie_registry/vcf.py
+++ b/genie_registry/vcf.py
@@ -137,6 +137,22 @@ class vcf(FileTypeFormat):
         total_error += error
         warning += warn
 
+        # TODO: add this as class attribute or global
+        allele_col = "REF"
+        allowed_alleles = ["A", "T", "C", "G", "N"]
+        if process_functions.checkColExist(vcfdf, allele_col):
+            invalid_indices = validate.get_invalid_allele_rows(
+                vcfdf, allele_col, allowed_alleles=allowed_alleles, ignore_case=True
+            )
+            errors, warnings = validate.get_allele_validation_message(
+                invalid_indices,
+                invalid_col=allele_col,
+                allowed_alleles=allowed_alleles,
+                fileformat="vcf",
+            )
+            total_error += errors
+            warning += warnings
+
         # No white spaces
         white_space = vcfdf.apply(lambda x: contains_whitespace(x), axis=1)
         if sum(white_space) > 0:

--- a/genie_registry/vcf.py
+++ b/genie_registry/vcf.py
@@ -19,7 +19,8 @@ class vcf(FileTypeFormat):
 
     _process_kwargs = []
     _allele_col = "REF"
-    _allowed_alleles = ["A", "T", "C", "G", "N"]
+    _allowed_comb_alleles = ["A", "T", "C", "G", "N"]
+    _allowed_ind_alleles = []
 
     def _validateFilename(self, filePath):
         basename = os.path.basename(filePath[0])
@@ -142,14 +143,17 @@ class vcf(FileTypeFormat):
         if process_functions.checkColExist(vcfdf, self._allele_col):
             invalid_indices = validate.get_invalid_allele_rows(
                 vcfdf,
-                self._allele_col,
-                allowed_alleles=self._allowed_alleles,
+                input_col=self._allele_col,
+                allowed_comb_alleles=self._allowed_comb_alleles,
+                allowed_ind_alleles=self._allowed_ind_alleles,
                 ignore_case=True,
-            )
+                allow_na=False
+                )
             errors, warnings = validate.get_allele_validation_message(
                 invalid_indices,
                 invalid_col=self._allele_col,
-                allowed_alleles=self._allowed_alleles,
+                allowed_comb_alleles=self._allowed_comb_alleles,
+                allowed_ind_alleles=self._allowed_ind_alleles,
                 fileformat=self._fileType,
             )
             total_error += errors

--- a/genie_registry/vcf.py
+++ b/genie_registry/vcf.py
@@ -18,6 +18,8 @@ class vcf(FileTypeFormat):
     _fileType = "vcf"
 
     _process_kwargs = []
+    _allele_col = "REF"
+    _allowed_alleles = ["A", "T", "C", "G", "N"]
 
     def _validateFilename(self, filePath):
         basename = os.path.basename(filePath[0])
@@ -137,18 +139,15 @@ class vcf(FileTypeFormat):
         total_error += error
         warning += warn
 
-        # TODO: add this as class attribute or global
-        allele_col = "REF"
-        allowed_alleles = ["A", "T", "C", "G", "N"]
-        if process_functions.checkColExist(vcfdf, allele_col):
+        if process_functions.checkColExist(vcfdf, self._allele_col):
             invalid_indices = validate.get_invalid_allele_rows(
-                vcfdf, allele_col, allowed_alleles=allowed_alleles, ignore_case=True
+                vcfdf, self._allele_col, allowed_alleles=self._allowed_alleles, ignore_case=True
             )
             errors, warnings = validate.get_allele_validation_message(
                 invalid_indices,
-                invalid_col=allele_col,
-                allowed_alleles=allowed_alleles,
-                fileformat="vcf",
+                invalid_col=self._allele_col,
+                allowed_alleles=self._allowed_alleles,
+                fileformat=self._fileType,
             )
             total_error += errors
             warning += warnings

--- a/tests/test_maf.py
+++ b/tests/test_maf.py
@@ -19,7 +19,13 @@ def valid_maf_df():
         dict(
             CHROMOSOME=[1, 2, 3, 4, 5],
             START_POSITION=[1, 2, 3, 4, 2],
-            REFERENCE_ALLELE=["A", "A", "A", "A", "A"],
+            REFERENCE_ALLELE=[
+                "C",
+                "G",
+                "NA",
+                "-",
+                "TAAAGATCGTACAGAA",
+            ],
             TUMOR_SAMPLE_BARCODE=[
                 "GENIE-SAGE-ID1-1",
                 "GENIE-SAGE-ID1-1",

--- a/tests/test_maf.py
+++ b/tests/test_maf.py
@@ -165,10 +165,6 @@ def test_errors_validation(maf_class):
         "Does not have the column headers that can give "
         "extra information to the processed maf: "
         "T_REF_COUNT, N_DEPTH.\n"
-        "maf: "
-        "REFERENCE_ALLELE column contains 'NA' values, "
-        "which cannot be placeholders for blank values.  "
-        "Please put in empty strings for blank values.\n"
     )
 
     assert error == expectedErrors
@@ -213,9 +209,6 @@ def test_invalid_validation(maf_class):
         "This is the list of accepted allele values that can only appear individually: -\n"
     )
     expectedWarnings = (
-        "maf: TUMOR_SEQ_ALLELE2 column contains 'NA' values, "
-        "which cannot be placeholders for blank values.  "
-        "Please put in empty strings for blank values.\n"
         "maf: Does not have the column headers that can give "
         "extra information to the processed maf: T_REF_COUNT.\n"
     )
@@ -226,23 +219,10 @@ def test_invalid_validation(maf_class):
 @pytest.mark.parametrize("col", ["temp", "REFERENCE_ALLELE"])
 def test_noerror__check_allele_col(col):
     """Test error and warning is an empty string if REF col isn't passed in"""
-    df = pd.DataFrame(dict(REFERENCE_ALLELE=["A", "A"]))
+    df = pd.DataFrame(dict(REFERENCE_ALLELE=["NA", "A"]))
     error, warning = genie_registry.maf._check_allele_col(df, col)
     assert error == ""
     assert warning == ""
-
-
-def test_warning__check_allele_col():
-    """Test warning occurs when 'NA' string is passed in"""
-    df = pd.DataFrame(dict(TEMP=["NA", "A"]))
-    error, warning = genie_registry.maf._check_allele_col(df, "TEMP")
-    assert error == ""
-    assert warning == (
-        "maf: "
-        "TEMP column contains 'NA' values, "
-        "which cannot be placeholders for blank values.  "
-        "Please put in empty strings for blank values.\n"
-    )
 
 
 def test_error__check_allele_col():

--- a/tests/test_maf.py
+++ b/tests/test_maf.py
@@ -94,6 +94,8 @@ def test_firstcolumn_validation(maf_class):
         "maf: First column header must be "
         "one of these: CHROMOSOME, HUGO_SYMBOL, "
         "TUMOR_SAMPLE_BARCODE.\n"
+        "maf: Your REFERENCE_ALLELE column has invalid allele values. "
+        "These are the accepted allele values: ['A', 'T', 'C', 'G', 'N', ' ', '-'].\n"
     )
     assert error == expectedErrors
     assert warning == ""
@@ -147,6 +149,10 @@ def test_errors_validation(maf_class):
         "This column must only be these values: 1, 2, 3, 4, 5, 6, 7, 8, 9, "
         "10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, X, Y, MT\n"
         "maf: TUMOR_SAMPLE_BARCODE must start with GENIE-SAGE\n"
+        "maf: Your REFERENCE_ALLELE column has invalid allele values. "
+        "These are the accepted allele values: ['A', 'T', 'C', 'G', 'N', ' ', '-'].\n"
+        "maf: Your TUMOR_SEQ_ALLELE2 column has invalid allele values. "
+        "These are the accepted allele values: ['A', 'T', 'C', 'G', 'N', ' ', '-'].\n"
     )
     expectedWarnings = (
         "maf: "
@@ -195,6 +201,8 @@ def test_invalid_validation(maf_class):
         "maf: "
         "TUMOR_SEQ_ALLELE2 can't have any blank or null values.\n"
         "maf: TUMOR_SAMPLE_BARCODE must start with GENIE-SAGE\n"
+        "maf: Your TUMOR_SEQ_ALLELE2 column has invalid allele values. "
+        "These are the accepted allele values: ['A', 'T', 'C', 'G', 'N', ' ', '-'].\n"
     )
     expectedWarnings = (
         "maf: TUMOR_SEQ_ALLELE2 column contains 'NA' values, "

--- a/tests/test_maf.py
+++ b/tests/test_maf.py
@@ -95,7 +95,9 @@ def test_firstcolumn_validation(maf_class):
         "one of these: CHROMOSOME, HUGO_SYMBOL, "
         "TUMOR_SAMPLE_BARCODE.\n"
         "maf: Your REFERENCE_ALLELE column has invalid allele values. "
-        "These are the accepted allele values: ['A', 'T', 'C', 'G', 'N', ' ', '-'].\n"
+        "This is the list of accepted allele values that can appear individually "
+        f"or in combination with each other: A,T,C,G,N.\n"
+        "This is the list of accepted allele values that can only appear individually: -\n"
     )
     assert error == expectedErrors
     assert warning == ""
@@ -150,9 +152,13 @@ def test_errors_validation(maf_class):
         "10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, X, Y, MT\n"
         "maf: TUMOR_SAMPLE_BARCODE must start with GENIE-SAGE\n"
         "maf: Your REFERENCE_ALLELE column has invalid allele values. "
-        "These are the accepted allele values: ['A', 'T', 'C', 'G', 'N', ' ', '-'].\n"
+        "This is the list of accepted allele values that can appear individually "
+        "or in combination with each other: A,T,C,G,N.\n"
+        "This is the list of accepted allele values that can only appear individually: -\n"
         "maf: Your TUMOR_SEQ_ALLELE2 column has invalid allele values. "
-        "These are the accepted allele values: ['A', 'T', 'C', 'G', 'N', ' ', '-'].\n"
+        "This is the list of accepted allele values that can appear individually "
+        "or in combination with each other: A,T,C,G,N.\n"
+        "This is the list of accepted allele values that can only appear individually: -\n"
     )
     expectedWarnings = (
         "maf: "
@@ -202,7 +208,9 @@ def test_invalid_validation(maf_class):
         "TUMOR_SEQ_ALLELE2 can't have any blank or null values.\n"
         "maf: TUMOR_SAMPLE_BARCODE must start with GENIE-SAGE\n"
         "maf: Your TUMOR_SEQ_ALLELE2 column has invalid allele values. "
-        "These are the accepted allele values: ['A', 'T', 'C', 'G', 'N', ' ', '-'].\n"
+        "This is the list of accepted allele values that can appear individually "
+        "or in combination with each other: A,T,C,G,N.\n"
+        "This is the list of accepted allele values that can only appear individually: -\n"
     )
     expectedWarnings = (
         "maf: TUMOR_SEQ_ALLELE2 column contains 'NA' values, "

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -866,6 +866,50 @@ def get_invalid_allele_rows_test_cases():
             "ignore_case": True,
             "allow_na": True,
         },
+        {
+            "name": "float_nas_not_allowed",
+            "input": pd.DataFrame(
+                {"REFERENCE_ALLELE": [1.5, 2.0, float("nan"), 3.5, 4.0]}
+            ),
+            "expected_index": pd.Index([0, 1, 2, 3, 4]),
+            "allowed_comb_alleles": ["A", "T", "C", "G", "-"],
+            "allowed_ind_alleles": [],
+            "ignore_case": True,
+            "allow_na": False,
+        },
+        {
+            "name": "float_nas_allowed",
+            "input": pd.DataFrame(
+                {"REFERENCE_ALLELE": [1.5, 2.0, float("nan"), 3.5, 4.0]}
+            ),
+            "expected_index": pd.Index([0, 1, 3, 4]),
+            "allowed_comb_alleles": ["A", "T", "C", "G", "-"],
+            "allowed_ind_alleles": [],
+            "ignore_case": True,
+            "allow_na": True,
+        },
+        {
+            "name": "all_missing_nas_allowed",
+            "input": pd.DataFrame(
+                {"REFERENCE_ALLELE": [float("nan"), float("nan"), float("nan")]}
+            ),
+            "expected_index": pd.Index([]),
+            "allowed_comb_alleles": ["A", "T", "C", "G", "-"],
+            "allowed_ind_alleles": [],
+            "ignore_case": True,
+            "allow_na": True,
+        },
+        {
+            "name": "all_missing_nas_not_allowed",
+            "input": pd.DataFrame(
+                {"REFERENCE_ALLELE": [float("nan"), float("nan"), float("nan")]}
+            ),
+            "expected_index": pd.Index([0, 1, 2]),
+            "allowed_comb_alleles": ["A", "T", "C", "G", "-"],
+            "allowed_ind_alleles": [],
+            "ignore_case": True,
+            "allow_na": False,
+        },
     ]
 
 

--- a/tests/test_vcf.py
+++ b/tests/test_vcf.py
@@ -232,7 +232,9 @@ def test_validation_invalid_content(vcf_class):
         "vcf: Please double check your #CHROM column.  This column must only be these values: "
         "1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, X, Y, MT\n"
         "vcf: Your REF column has invalid allele values. "
-        "These are the accepted allele values: ['A', 'T', 'C', 'G', 'N'].\n"
+        "This is the list of accepted allele values that can appear individually "
+        "or in combination with each other: A,T,C,G,N.\n"
+        "This is the list of accepted allele values that can only appear individually: \n"
     )
     expectedWarning = "vcf: Should not have the chr prefix in front of chromosomes.\n"
     assert error == expectedError

--- a/tests/test_vcf.py
+++ b/tests/test_vcf.py
@@ -29,7 +29,7 @@ def test_validation_valid_no_samples(vcf_class):
             "#CHROM": ["2", "9", "12"],
             "POS": [69688533, 99401860, 53701241],
             "ID": ["AAK1", "AAED1", "AAAS"],
-            "REF": ["AAK1", "AAED1", "AAAS"],
+            "REF": ["AANT", "AACG", "AAAN"],
             "ALT": ["AAK1", "AAED1", "AAAS"],
             "QUAL": ["AAK1", "AAED1", "AAAS"],
             "FILTER": ["AAK1", "AAED1", "AAAS"],
@@ -47,7 +47,7 @@ def test_validation_valid_one_sample_tumor(vcf_class):
             "#CHROM": ["2", "9", "12"],
             "POS": [69688533, 99401860, 53701241],
             "ID": ["AAK1", "AAED1", "AAAS"],
-            "REF": ["AAK1", "AAED1", "AAAS"],
+            "REF": ["AANT", "AACG", "AAAN"],
             "ALT": ["AAK1", "AAED1", "AAAS"],
             "QUAL": ["AAK1", "AAED1", "AAAS"],
             "FILTER": ["AAK1", "AAED1", "AAAS"],
@@ -67,7 +67,7 @@ def test_validation_valid_one_sample(vcf_class):
             "#CHROM": ["2", "9", "12"],
             "POS": [69688533, 99401860, 53701241],
             "ID": ["AAK1", "AAED1", "AAAS"],
-            "REF": ["AAK1", "AAED1", "AAAS"],
+            "REF": ["AANT", "AACG", "AAAN"],
             "ALT": ["AAK1", "AAED1", "AAAS"],
             "QUAL": ["AAK1", "AAED1", "AAAS"],
             "FILTER": ["AAK1", "AAED1", "AAAS"],
@@ -88,7 +88,7 @@ def test_validation_missing_format_col(vcf_class):
             "#CHROM": ["2", "9", "12"],
             "POS": [69688533, 99401860, 53701241],
             "ID": ["AAK1", "AAED1", "AAAS"],
-            "REF": ["AAK1", "AAED1", "AAAS"],
+            "REF": ["AANT", "AACG", "AAAN"],
             "ALT": ["AAK1", "AAED1", "AAAS"],
             "QUAL": ["AAK1", "AAED1", "AAAS"],
             "FILTER": ["AAK1", "AAED1", "AAAS"],
@@ -107,7 +107,7 @@ def test_validation_invalid_one_sample(vcf_class):
             "#CHROM": ["2", "9", "12"],
             "POS": [69688533, 99401860, 53701241],
             "ID": ["AAK1", "AAED1", "AAAS"],
-            "REF": ["AAK1", "AAED1", "AAAS"],
+            "REF": ["AANT", "AACG", "AAAN"],
             "ALT": ["AAK1", "AAED1", "AAAS"],
             "QUAL": ["AAK1", "AAED1", "AAAS"],
             "FILTER": ["AAK1", "AAED1", "AAAS"],
@@ -130,7 +130,7 @@ def test_validation_valid_two_samples(vcf_class):
             "#CHROM": ["2", "9", "12"],
             "POS": [69688533, 99401860, 53701241],
             "ID": ["AAK1", "AAED1", "AAAS"],
-            "REF": ["AAK1", "AAED1", "AAAS"],
+            "REF": ["AANT", "AACG", "AAAN"],
             "ALT": ["AAK1", "AAED1", "AAAS"],
             "QUAL": ["AAK1", "AAED1", "AAAS"],
             "FILTER": ["AAK1", "AAED1", "AAAS"],
@@ -151,7 +151,7 @@ def test_validation_invalid_two_samples_tumor(vcf_class):
             "#CHROM": ["2", "9", "12"],
             "POS": [69688533, 99401860, 53701241],
             "ID": ["AAK1", "AAED1", "AAAS"],
-            "REF": ["AAK1", "AAED1", "AAAS"],
+            "REF": ["AANT", "AACG", "AAAN"],
             "ALT": ["AAK1", "AAED1", "AAAS"],
             "QUAL": ["AAK1", "AAED1", "AAAS"],
             "FILTER": ["AAK1", "AAED1", "AAAS"],
@@ -172,7 +172,7 @@ def test_validation_invalid_two_samples_normal(vcf_class):
             "#CHROM": ["2", "9", "12"],
             "POS": [69688533, 99401860, 53701241],
             "ID": ["AAK1", "AAED1", "AAAS"],
-            "REF": ["AAK1", "AAED1", "AAAS"],
+            "REF": ["AANT", "AACG", "AAAN"],
             "ALT": ["AAK1", "AAED1", "AAAS"],
             "QUAL": ["AAK1", "AAED1", "AAAS"],
             "FILTER": ["AAK1", "AAED1", "AAAS"],
@@ -193,7 +193,7 @@ def test_validation_invalid_white_space(vcf_class):
             "#CHROMM": ["2", "9", "12"],
             "POS": [69688533, 99401860, 53701241],
             "ID": ["AAK1", "AAED1", "AAAS"],
-            "REF": ["AAK1", "AAED1", "AAAS"],
+            "REF": ["AANT", "AACG", "AAAN"],
             "ALT": ["AAK1", "AAED1", "AAAS"],
             "QUAL": ["AAK1", "AAED1", "AAAS"],
             "FILTER": ["AAK1", "AA ED1", "AAAS"],
@@ -231,6 +231,8 @@ def test_validation_invalid_content(vcf_class):
         "space delimited instead of tab delimited.\n"
         "vcf: Please double check your #CHROM column.  This column must only be these values: "
         "1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, X, Y, MT\n"
+        "vcf: Your REF column has invalid allele values. "
+        "These are the accepted allele values: ['A', 'T', 'C', 'G', 'N'].\n"
     )
     expectedWarning = "vcf: Should not have the chr prefix in front of chromosomes.\n"
     assert error == expectedError


### PR DESCRIPTION
**Purpose:** There is no current allele validation so this PR adds it for the VCF and MAF file formats. Each format has its own list of accepted alleles. 

**Changes:** I added two general allele validation and allele validation message functions to `genie/validate.py`:
- [get_invalid_allele_rows](https://github.com/Sage-Bionetworks/Genie/blob/gen-809-validate-allele/genie/validate.py#L421)
- [get_allele_validation_message](https://github.com/Sage-Bionetworks/Genie/blob/gen-809-validate-allele/genie/validate.py#L466)

so that they can be more general and used by both vcf and maf file formats (and any relevant future file formats). I separated out the retrieval of the rows with the invalid allele values and the retrieval of the error message to make it easier for testing and also easier to implement row-based validation in the future if we would like (or keep our more high level validation).


**Special Considerations:** 
NA handling: Based on our discussion, we will wait to handle NAs (default solution right now is to flag NAs as invalid). Because I'm using regex to match on the allele values, I would run into an issue with any NAs/missingness in the columns. I think that it's currently enforced that we can't have emptiness for the allele columns in these file formats but I added [this parameter allow_na](https://github.com/Sage-Bionetworks/Genie/blob/gen-809-validate-allele/genie/validate.py#L460C35-L460C35) to flag any NAs as invalid otherwise the code will break when using `pandas.str.match`. We also have to have special handling to validate a column with all NA values in this function as well...

I talked more about the caveats of handling [NAs here](https://sagebionetworks.jira.com/browse/GEN-943)


**Testing:**
- Unit tests were written to test the general allele validation functions. 
- Maf and Vcf classes' tests were adjusted to account for the new allele validation. 
- Validation was run on the test genie project.