### PR TITLE
[GEN-977] update annotation-tools version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -83,6 +83,6 @@ WORKDIR /root/
 # Must move this git clone to after the install of Genie,
 # because must update cbioportal
 RUN git clone https://github.com/cBioPortal/cbioportal.git -b v5.3.19
-RUN git clone https://github.com/Sage-Bionetworks/annotation-tools.git -b 0.0.2
+RUN git clone https://github.com/Sage-Bionetworks/annotation-tools.git -b 0.0.3
 
 WORKDIR /root/Genie


### PR DESCRIPTION
**Purpose:** In order to support 'N' alleles, we had to update the annotation-tools repo and create a new release as a result. We will have to pin the new version in main genie.

Links to https://github.com/Sage-Bionetworks/annotation-tools/pull/7