### PR TITLE
[GEN-1026] Output annotation error report

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,7 @@ RUN apt-get update && apt-get install -y --allow-unauthenticated --no-install-re
 		# texlive-generic-recommended \
 		texlive-latex-extra \
 		# genome nexus
-		openjdk-8-jre \
+		openjdk-11-jre \
 		# This is for reticulate
 		python3.8-venv && \
 	apt-get clean && \
@@ -83,6 +83,6 @@ WORKDIR /root/
 # Must move this git clone to after the install of Genie,
 # because must update cbioportal
 RUN git clone https://github.com/cBioPortal/cbioportal.git -b v5.3.19
-RUN git clone https://github.com/Sage-Bionetworks/annotation-tools.git -b 0.0.3
+RUN git clone https://github.com/Sage-Bionetworks/annotation-tools.git -b 0.0.4
 
 WORKDIR /root/Genie

--- a/genie/process_mutation.py
+++ b/genie/process_mutation.py
@@ -202,12 +202,14 @@ def process_mutation_workflow(
         "syn22053204",
         ifcollision="overwrite.local",
         downloadLocation=genie_config["genie_annotation_pkg"],
+        version=1, #TODO: This should pull from a config file in the future
     )
     # Genome Nexus Jar file
     syn.get(
         "syn22084320",
         ifcollision="overwrite.local",
         downloadLocation=genie_config["genie_annotation_pkg"],
+        version=13, #TODO: This should pull from a config file in the future
     )
 
     annotated_maf_path = annotate_mutation(

--- a/genie/process_mutation.py
+++ b/genie/process_mutation.py
@@ -250,6 +250,7 @@ def annotate_mutation(
     """
     input_files_dir = tempfile.mkdtemp(dir=workdir)
     output_files_dir = tempfile.mkdtemp(dir=workdir)
+    error_dir = os.path.join(output_files_dir, f"{center}_error_reports")
 
     for mutation_file in mutation_files:
         move_mutation(mutation_file, input_files_dir)
@@ -262,6 +263,7 @@ def annotate_mutation(
         os.path.join(genie_annotation_pkg, "annotation_suite_wrapper.sh"),
         f"-i={input_files_dir}",
         f"-o={output_files_dir}",
+        f"-e={error_dir}",
         f"-m={merged_maf_path}",
         f"-c={center}",
         "-s=WXS",

--- a/genie/process_mutation.py
+++ b/genie/process_mutation.py
@@ -202,14 +202,14 @@ def process_mutation_workflow(
         "syn22053204",
         ifcollision="overwrite.local",
         downloadLocation=genie_config["genie_annotation_pkg"],
-        version=1,  # TODO: This should pull from a config file in the future
+        # version=1,  # TODO: This should pull from a config file in the future
     )
     # Genome Nexus Jar file
     syn.get(
         "syn22084320",
         ifcollision="overwrite.local",
         downloadLocation=genie_config["genie_annotation_pkg"],
-        version=13,  # TODO: This should pull from a config file in the future
+        # version=13,  # TODO: This should pull from a config file in the future
     )
 
     annotated_maf_path = annotate_mutation(

--- a/genie/process_mutation.py
+++ b/genie/process_mutation.py
@@ -202,14 +202,14 @@ def process_mutation_workflow(
         "syn22053204",
         ifcollision="overwrite.local",
         downloadLocation=genie_config["genie_annotation_pkg"],
-        version=1, #TODO: This should pull from a config file in the future
+        version=1,  # TODO: This should pull from a config file in the future
     )
     # Genome Nexus Jar file
     syn.get(
         "syn22084320",
         ifcollision="overwrite.local",
         downloadLocation=genie_config["genie_annotation_pkg"],
-        version=13, #TODO: This should pull from a config file in the future
+        version=13,  # TODO: This should pull from a config file in the future
     )
 
     annotated_maf_path = annotate_mutation(

--- a/tests/test_process_mutation.py
+++ b/tests/test_process_mutation.py
@@ -104,13 +104,13 @@ def test_process_mutation_workflow(syn, genie_config):
             "syn22053204",
             ifcollision="overwrite.local",
             downloadLocation=genie_annotation_pkg,
-            version=1,  # TODO: This should pull from a config file in the future
+            # version=1,  # TODO: This should pull from a config file in the future
         ),
         call(
             "syn22084320",
             ifcollision="overwrite.local",
             downloadLocation=genie_annotation_pkg,
-            version=13,  # TODO: This should pull from a config file in the future
+            # version=13,  # TODO: This should pull from a config file in the future
         ),
     ]
     center = "SAGE"

--- a/tests/test_process_mutation.py
+++ b/tests/test_process_mutation.py
@@ -104,11 +104,13 @@ def test_process_mutation_workflow(syn, genie_config):
             "syn22053204",
             ifcollision="overwrite.local",
             downloadLocation=genie_annotation_pkg,
+            version=1, #TODO: This should pull from a config file in the future
         ),
         call(
             "syn22084320",
             ifcollision="overwrite.local",
             downloadLocation=genie_annotation_pkg,
+            version=13, #TODO: This should pull from a config file in the future
         ),
     ]
     center = "SAGE"
@@ -148,6 +150,7 @@ def test_annotate_mutation():
     workdir = "working/dir/path"
     mktemp_calls = [call(dir=workdir)] * 2
     input_dir = "input/dir"
+    error_dir = "input/dir/SAGE_error_reports"
     with patch.object(
         tempfile, "mkdtemp", return_value=input_dir
     ) as patch_mktemp, patch.object(
@@ -169,6 +172,7 @@ def test_annotate_mutation():
                 "annotation/pkg/path/annotation_suite_wrapper.sh",
                 f"-i={input_dir}",
                 f"-o={input_dir}",
+                f"-e={error_dir}",
                 f"-m=input/dir/data_mutations_extended_{center}.txt",
                 f"-c={center}",
                 "-s=WXS",

--- a/tests/test_process_mutation.py
+++ b/tests/test_process_mutation.py
@@ -104,13 +104,13 @@ def test_process_mutation_workflow(syn, genie_config):
             "syn22053204",
             ifcollision="overwrite.local",
             downloadLocation=genie_annotation_pkg,
-            version=1, #TODO: This should pull from a config file in the future
+            version=1,  # TODO: This should pull from a config file in the future
         ),
         call(
             "syn22084320",
             ifcollision="overwrite.local",
             downloadLocation=genie_annotation_pkg,
-            version=13, #TODO: This should pull from a config file in the future
+            version=13,  # TODO: This should pull from a config file in the future
         ),
     ]
     center = "SAGE"


### PR DESCRIPTION
**Purpose:** Part of the ticket to allow for the output of the annotation error report. 
This will add the new annotation-tools tag (once the annotation-tools PR gets merged and a new tag gets created) and the required java 11 update to the docker image in order to support the new `annotator.jar` file used as part of the GEN-1026 update.

**Testing:**
Rebuilt docker container in ec2 instance and ran the process mutation files. Files ran successfully.

Depends on [annotation-tools PR #8](https://github.com/Sage-Bionetworks/annotation-tools/pull/8)

