### PR TITLE
[GEN-1028] Generate failed annotations report dashboard

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -100,6 +100,8 @@ Make sure to run each of the [pipeline steps here](README.md#developing-locally)
 
 #### Running tests
 
+##### Tests in Python
+
 This package uses [`pytest`](https://pytest.org/en/latest/) to run tests. The test code is located in the [tests](./tests) subdirectory.
 
 Here's how to run the test suite:
@@ -108,7 +110,17 @@ Here's how to run the test suite:
 pytest -vs tests/
 ```
 
-Tests are also run automatically by Github Actions on any pull request and are required to pass before merging.
+Tests in Python are also run automatically by Github Actions on any pull request and are required to pass before merging.
+
+##### Tests in R
+
+This package uses [`testthat`](https://testthat.r-lib.org/) to run tests in R. The test code is located in the [testthat](./R/tests/testthat) subdirectory.
+
+Here's how to run the test suite:
+
+```shell
+Rscript -e "testthat::test_dir('R/tests/testthat/')"
+```
 
 #### Test Development
 

--- a/R/dashboard_template_functions.R
+++ b/R/dashboard_template_functions.R
@@ -1,0 +1,41 @@
+# ---------------------------------------------------------------------------
+# Title: dashboard_template_functions.R
+# Description: This script contains helper functions used in 
+# templates/dashboardTemplate.Rmd
+# ---------------------------------------------------------------------------
+
+#' This function gets the database to synapse id mapping table,
+#' maps the provided database_name to its synapse id and returns it
+#'
+#' @param database_name (str) database name in database 
+#' to synapse id mapping table
+#' @param database_synid_mappingid (str) synapse id of the database 
+#' to synapse id mapping table
+#'
+#' @return (str) synapse id of the mapped database name
+get_syn_id_from_mapped_database <- function(database_name, database_synid_mappingid){
+    database_synid_mapping = synTableQuery(sprintf('select * from %s',
+                                               database_synid_mappingid))
+    database_synid_mappingdf = as.data.frame(database_synid_mapping)
+    table_synid = database_synid_mappingdf$Id[database_synid_mappingdf$Database == database_name]
+    return(table_synid)
+}
+
+#' This function creates a table of failed annotation counts by grouped columns
+#' @param maf_data (data.frame) input maf data frame
+#' @param group_by_cols (str vector) list of columns to create counts by
+#' @param counts_col_name (str) name to give to the counts column
+#'
+#' @return (data.frame) counts table
+get_failed_annotation_table_counts <- function(maf_data, group_by_cols, counts_col_name){
+    table_counts <- table(maf_data[maf_data$Annotation_Status == "FAILED", group_by_cols])
+
+    if (nrow(table_counts) == 0){
+        counts_table <- data.frame(matrix(ncol = length(group_by_cols) + 1, nrow = 0))
+    } else{
+        counts_table <- as.data.frame(table_counts)
+    }
+    colnames(counts_table) <- c(group_by_cols, counts_col_name)
+    counts_table <- counts_table[do.call(order, counts_table[group_by_cols]), ]
+    return(counts_table)
+}

--- a/R/tests/testthat/test_dashboard_template_functions.R
+++ b/R/tests/testthat/test_dashboard_template_functions.R
@@ -1,0 +1,69 @@
+# tests for dashboard_template_functions.R
+
+source("../../dashboard_template_functions.R")
+
+library(synapser)
+library(testthat)
+
+sample_counts_table <- function() {
+  data <- data.frame(
+    Center = factor(c("GOLD","SAGE", "TEST"), 
+                      levels = c("GOLD", "SAGE", "TEST")),
+    Counts = c(1, 2, 1)
+  )
+  return(data)
+}
+
+empty_counts_table <- function() {
+  data <- data.frame(
+    Center = logical(),
+    Counts = logical()
+  )
+  return(data)
+}
+
+sample_maf_table <- function() {
+  data <- data.frame(
+    Center = c("TEST", "TEST", "SAGE", "SAGE", "GOLD", "BRONZE"),
+    Tumor_Sample_Barcode = c("SAGE1", "SAGE2", "SAGE3", "SAGE4", "SAGE5", "SAGE6"),
+    Annotation_Status = c("SUCCESS", "FAILED", "FAILED", "FAILED", "FAILED", "SUCCESS")
+  )
+  return(data)
+}
+
+sample_maf_table_no_failed_annotations <- function() {
+  data <- data.frame(
+    Center = c("TEST", "SAGE", "GOLD"),
+    Tumor_Sample_Barcode = c("SAGE1", "SAGE2", "SAGE3"),
+    Annotation_Status = c("SUCCESS", "SUCCESS", "SUCCESS")
+  )
+  return(data)
+}
+
+
+test_that("get_syn_id_from_mapped_database_gets_correct_value", {
+  synLogin()
+  result <- get_syn_id_from_mapped_database(
+    database_name = "vcf2maf", 
+    database_synid_mappingid = "syn11600968"
+  )
+  expect_equal(result, "syn53270419")
+})
+
+
+test_that("get_failed_annotation_table_counts_returns_expected_output", {
+  result <- get_failed_annotation_table_counts(
+    maf_data=sample_maf_table(), 
+    group_by_cols="Center", 
+    counts_col_name="Counts")
+  expect_equal(result, sample_counts_table())
+})
+
+test_that("get_failed_annotation_table_counts_returns_empty_table_with_no_failed_annotations", {
+  result <- get_failed_annotation_table_counts(
+    maf_data=sample_maf_table_no_failed_annotations(), 
+    group_by_cols="Center", 
+    counts_col_name="Counts")
+  expect_equal(result, empty_counts_table())
+})
+

--- a/R/tests/testthat/test_dashboard_template_functions.R
+++ b/R/tests/testthat/test_dashboard_template_functions.R
@@ -44,10 +44,10 @@ sample_maf_table_no_failed_annotations <- function() {
 test_that("get_syn_id_from_mapped_database_gets_correct_value", {
   synLogin()
   result <- get_syn_id_from_mapped_database(
-    database_name = "vcf2maf", 
+    database_name = "main",
     database_synid_mappingid = "syn11600968"
   )
-  expect_equal(result, "syn53270419")
+  expect_equal(result, "syn7208886")
 })
 
 

--- a/templates/dashboardTemplate.Rmd
+++ b/templates/dashboardTemplate.Rmd
@@ -30,7 +30,7 @@ suppressMessages(library(RColorBrewer))
 suppressMessages(library(jsonlite))
 suppressMessages(library(knitr))
 
-source("../R/dashboard_template_functions.R")
+source("R/dashboard_template_functions.R")
 
 createCenterColumn <- function(clinicalDf) {
   if (is.null(clinicalDf$CENTER)) {

--- a/templates/dashboardTemplate.Rmd
+++ b/templates/dashboardTemplate.Rmd
@@ -30,6 +30,8 @@ suppressMessages(library(RColorBrewer))
 suppressMessages(library(jsonlite))
 suppressMessages(library(knitr))
 
+source("../R/dashboard_template_functions.R")
+
 createCenterColumn <- function(clinicalDf) {
   if (is.null(clinicalDf$CENTER)) {
     centers = unlist(
@@ -401,6 +403,40 @@ For patient retractions submitted between these months, the records will be remo
 * April-June
 * October-December
 
+---
+
+### Genome nexus failed annotations summary
+
+The table below displays the number of failed annotations per center. If a center has no failed annotations, no record will appear in the table for that center.
+
+```{r}
+maf_table_synid = get_syn_id_from_mapped_database(
+  database_name="vcf2maf", 
+  database_synid_mappingid = database_synid_mappingid
+)
+
+# get narrow maf table
+maf_table <- as.data.frame(synTableQuery(sprintf('select * from %s', maf_table_synid)))
+
+counts_table <- get_failed_annotation_table_counts(
+  maf_table, 
+  group_by_cols = "Center", 
+  counts_col_name = "Number of failed annotations"
+  )
+knitr::kable(counts_table, col.names = c("Center", "Number of failed annotations"))
+
+#get project page on synapse
+main_syn_id <- get_syn_id_from_mapped_database(
+    database_name="main", 
+    database_synid_mappingid = database_synid_mappingid
+)
+```
+
+Follow this navigation guide from the `r paste0("[Synapse project files page](https://www.synapse.org/#!Synapse:", main_syn_id, "/files/){target='_blank'}")` to find your center's detailed failed annotations error report.
+
+Files &rarr; Centers &rarr; [Center name] &rarr; Errors &rarr; failed_annotations_error_report.txt
+
+View the version comment column in Synapse for your report to find the version associated with this release.
 
 ---
 


### PR DESCRIPTION
**Purpose:** This is a draft PR. This PR will add a section to our dashboard that showcases the number of failed annotations per center and also let sites know where to find their failed annotations report

**Testing:**
- Created R unit tests for some of the dashboard functions
- Generated the relevant section of the dashboard R markdown file. See current look:
<img width="967" alt="image" src="https://github.com/Sage-Bionetworks/Genie/assets/26471741/a781cb70-8bad-4ba5-a12a-8fdb841fe3fa">
- Ran the `R/dashboard_markdown_generator.R` using the relevant dashboard code above in docker image


Depends on #545 
