### PR TITLE
[GEN-1078] HOTFIX: Add in new known string columns as MSK added new columns into maf file

### DIFF
--- a/genie/process_mutation.py
+++ b/genie/process_mutation.py
@@ -105,11 +105,14 @@ KNOWN_STRING_COLS = [
     "CDNA_CHANGE",
     "AMINO_ACID_CHANGE",
     "TRANSCRIPT",
+    "transcript",
     "STRAND_VEP",
     "HGNC_ID",
     "PUBMED",
     "PICK",
     "Exon_Number",
+    "genomic_location_explanation",
+    "Annotation_Status"
 ]
 
 

--- a/genie/process_mutation.py
+++ b/genie/process_mutation.py
@@ -112,7 +112,7 @@ KNOWN_STRING_COLS = [
     "PICK",
     "Exon_Number",
     "genomic_location_explanation",
-    "Annotation_Status"
+    "Annotation_Status",
 ]
 
 


### PR DESCRIPTION
Note: This PR is being merged into main to enable processing.

**Problem**

The first 5000 rows of file do not always contain the correct dtype

**Solution**
Set the known string columns to be string type so that the code doesn't try to convert string to integer