### PR TITLE
[GEN-974] Allow NaN, nan and NA strings for mutation data

### DIFF
--- a/genie/config.py
+++ b/genie/config.py
@@ -1,4 +1,5 @@
 """Configuration to obtain registry classes"""
+
 import importlib
 import logging
 

--- a/genie/create_case_lists.py
+++ b/genie/create_case_lists.py
@@ -1,6 +1,7 @@
 """
 Creates case lists per cancer type
 """
+
 from collections import defaultdict
 import csv
 import os

--- a/genie/dashboard_table_updater.py
+++ b/genie/dashboard_table_updater.py
@@ -1,4 +1,5 @@
 """Updates dashboard tables"""
+
 import argparse
 import datetime
 import logging
@@ -347,9 +348,11 @@ def update_oncotree_code_tables(syn, database_mappingdf):
     oncotree_mapping = process_functions.get_oncotree_code_mappings(oncotree_link)
 
     clinicaldf["PRIMARY_CODES"] = [
-        oncotree_mapping[i.upper()]["ONCOTREE_PRIMARY_NODE"]
-        if i.upper() in oncotree_mapping.keys()
-        else "DEPRECATED_CODE"
+        (
+            oncotree_mapping[i.upper()]["ONCOTREE_PRIMARY_NODE"]
+            if i.upper() in oncotree_mapping.keys()
+            else "DEPRECATED_CODE"
+        )
         for i in clinicaldf.ONCOTREE_CODE
     ]
 
@@ -457,9 +460,9 @@ def update_sample_difference_table(syn, database_mappingdf):
         .applymap(int)
     )
 
-    diff_between_releasesdf[
-        ["Clinical", "Mutation", "CNV", "SEG", "Fusions"]
-    ] = new_values
+    diff_between_releasesdf[["Clinical", "Mutation", "CNV", "SEG", "Fusions"]] = (
+        new_values
+    )
 
     load._update_table(
         syn,

--- a/genie/database_to_staging.py
+++ b/genie/database_to_staging.py
@@ -223,7 +223,9 @@ def remove_maf_samples(mafdf: pd.DataFrame, keep_samples: list) -> pd.DataFrame:
 
     """
     keep_maf = mafdf["Tumor_Sample_Barcode"].isin(keep_samples)
-    mafdf = mafdf.loc[keep_maf,]
+    mafdf = mafdf.loc[
+        keep_maf,
+    ]
     return mafdf
 
 

--- a/genie/database_to_staging.py
+++ b/genie/database_to_staging.py
@@ -223,9 +223,7 @@ def remove_maf_samples(mafdf: pd.DataFrame, keep_samples: list) -> pd.DataFrame:
 
     """
     keep_maf = mafdf["Tumor_Sample_Barcode"].isin(keep_samples)
-    mafdf = mafdf.loc[
-        keep_maf,
-    ]
+    mafdf = mafdf.loc[keep_maf,]
     return mafdf
 
 
@@ -1054,30 +1052,38 @@ def store_clinical_files(
     }
 
     clinicaldf["CANCER_TYPE"] = [
-        oncotree_dict[code.upper()]["CANCER_TYPE"]
-        if code.upper() in oncotree_dict.keys()
-        else float("nan")
+        (
+            oncotree_dict[code.upper()]["CANCER_TYPE"]
+            if code.upper() in oncotree_dict.keys()
+            else float("nan")
+        )
         for code in clinicaldf["ONCOTREE_CODE"]
     ]
 
     clinicaldf["CANCER_TYPE_DETAILED"] = [
-        oncotree_dict[code.upper()]["CANCER_TYPE_DETAILED"]
-        if code.upper() in oncotree_dict.keys()
-        else float("nan")
+        (
+            oncotree_dict[code.upper()]["CANCER_TYPE_DETAILED"]
+            if code.upper() in oncotree_dict.keys()
+            else float("nan")
+        )
         for code in clinicaldf["ONCOTREE_CODE"]
     ]
 
     clinicaldf["ONCOTREE_PRIMARY_NODE"] = [
-        oncotree_dict[code.upper()]["ONCOTREE_PRIMARY_NODE"]
-        if code.upper() in oncotree_dict.keys()
-        else float("nan")
+        (
+            oncotree_dict[code.upper()]["ONCOTREE_PRIMARY_NODE"]
+            if code.upper() in oncotree_dict.keys()
+            else float("nan")
+        )
         for code in clinicaldf["ONCOTREE_CODE"]
     ]
 
     clinicaldf["ONCOTREE_SECONDARY_NODE"] = [
-        oncotree_dict[code.upper()]["ONCOTREE_SECONDARY_NODE"]
-        if code.upper() in oncotree_dict.keys()
-        else float("nan")
+        (
+            oncotree_dict[code.upper()]["ONCOTREE_SECONDARY_NODE"]
+            if code.upper() in oncotree_dict.keys()
+            else float("nan")
+        )
         for code in clinicaldf["ONCOTREE_CODE"]
     ]
 
@@ -1088,9 +1094,11 @@ def store_clinical_files(
     # descriptions can match
     clinicaldf["AGE_AT_SEQ_REPORT_DAYS"] = clinicaldf["AGE_AT_SEQ_REPORT"]
     clinicaldf["AGE_AT_SEQ_REPORT"] = [
-        int(math.floor(int(float(age)) / 365.25))
-        if process_functions.checkInt(age)
-        else age
+        (
+            int(math.floor(int(float(age)) / 365.25))
+            if process_functions.checkInt(age)
+            else age
+        )
         for age in clinicaldf["AGE_AT_SEQ_REPORT"]
     ]
     clinicaldf["AGE_AT_SEQ_REPORT"][clinicaldf["AGE_AT_SEQ_REPORT"] == ">32485"] = ">89"

--- a/genie/example_filetype_format.py
+++ b/genie/example_filetype_format.py
@@ -1,6 +1,7 @@
 """TODO: Rename this to model.py
 This contains the GENIE model objects
 """
+
 from abc import ABCMeta
 from dataclasses import dataclass
 import logging

--- a/genie/load.py
+++ b/genie/load.py
@@ -2,6 +2,7 @@
 This module contains all the functions that stores data
 to Synapse
 """
+
 import logging
 import os
 import time

--- a/genie/process_functions.py
+++ b/genie/process_functions.py
@@ -1,4 +1,5 @@
 """Processing functions that are used in the GENIE pipeline"""
+
 import datetime
 import json
 import logging

--- a/genie/process_mutation.py
+++ b/genie/process_mutation.py
@@ -1,5 +1,6 @@
 """Process mutation files
 TODO deprecate this module and spread functions around"""
+
 from collections import namedtuple
 import logging
 import os

--- a/genie/transform.py
+++ b/genie/transform.py
@@ -1,6 +1,7 @@
 """This module contains all the transformation functions used throughout the GENIE
 package"""
 
+from typing import List
 import warnings
 
 import pandas as pd
@@ -68,14 +69,14 @@ def _convert_df_with_mixed_dtypes(read_csv_params: dict) -> pd.DataFrame:
 
 
 def _convert_values_to_na(
-    input_df: pd.DataFrame, values_to_replace: list, columns_to_convert: list
+    input_df: pd.DataFrame, values_to_replace: List[str], columns_to_convert: List[str]
 ) -> pd.DataFrame:
     """Converts given values to NA in an input dataset
 
     Args:
         input_df (pd.DataFrame): input dataset
-        values_to_replace (list): string values to replace with na
-        columns_to_convert (list): subset of columns to convert with na in
+        values_to_replace (List[str]): string values to replace with na
+        columns_to_convert (List[str]): subset of columns to convert with na in
 
     Returns:
         pd.DataFrame: dataset with specified values replaced with NAs

--- a/genie/transform.py
+++ b/genie/transform.py
@@ -64,3 +64,24 @@ def _convert_df_with_mixed_dtypes(read_csv_params: dict) -> pd.DataFrame:
         df = pd.read_csv(**read_csv_params, low_memory=False, engine="c")
     warnings.resetwarnings()
     return df
+
+
+def _convert_values_to_na(
+    input_df: pd.DataFrame, values_to_replace: list, columns_to_convert: list
+) -> pd.DataFrame:
+    """Converts given values to NA in an input dataset
+
+    Args:
+        input_df (pd.DataFrame): input dataset
+        values_to_replace (list): string values to replace with na
+        columns_to_convert (list): subset of columns to convert with na in
+
+    Returns:
+        pd.DataFrame: dataset with specified values replaced with NAs
+    """
+    if not input_df.empty:
+        replace_mapping = {value: None for value in values_to_replace}
+        input_df[columns_to_convert] = input_df[columns_to_convert].replace(
+            replace_mapping
+        )
+    return input_df

--- a/genie/transform.py
+++ b/genie/transform.py
@@ -1,5 +1,6 @@
 """This module contains all the transformation functions used throughout the GENIE
 package"""
+
 import warnings
 
 import pandas as pd

--- a/genie/write_invalid_reasons.py
+++ b/genie/write_invalid_reasons.py
@@ -1,4 +1,5 @@
 """Write invalid reasons"""
+
 import logging
 import os
 

--- a/genie_registry/__init__.py
+++ b/genie_registry/__init__.py
@@ -1,4 +1,5 @@
 """Initialize GENIE registry"""
+
 # Import logging last to not take in synapseclient logging
 import logging
 

--- a/genie_registry/assay.py
+++ b/genie_registry/assay.py
@@ -1,4 +1,5 @@
 """Assay information class"""
+
 import os
 import yaml
 

--- a/genie_registry/bed.py
+++ b/genie_registry/bed.py
@@ -1,4 +1,5 @@
 """GENIE bed class and functions"""
+
 import os
 import logging
 import subprocess

--- a/genie_registry/clinical.py
+++ b/genie_registry/clinical.py
@@ -1,4 +1,5 @@
 """Clinical file format validation and processing"""
+
 # from __future__ import annotations
 import datetime
 from io import StringIO

--- a/genie_registry/maf.py
+++ b/genie_registry/maf.py
@@ -199,10 +199,6 @@ class maf(FileTypeFormat):
         for col in numerical_cols:
             col_exists = process_functions.checkColExist(mutationDF, col)
             if col_exists:
-                # Since NA is an allowed value, when reading in the dataframe
-                # the 'NA' string is not converted.  This will convert all
-                # 'NA' values in the numerical columns into actual float('nan')
-                mutationDF.loc[mutationDF[col] == "NA", col] = float("nan")
                 # Attempt to convert column to float
                 try:
                     mutationDF[col] = mutationDF[col].astype(float)

--- a/genie_registry/maf.py
+++ b/genie_registry/maf.py
@@ -1,6 +1,7 @@
 from io import StringIO
-import os
 import logging
+import os
+from typing import List
 
 import pandas as pd
 
@@ -352,7 +353,7 @@ class maf(FileTypeFormat):
                     )
         return errors, warnings
 
-    def _get_dataframe(self, filePathList: list) -> pd.DataFrame:
+    def _get_dataframe(self, filePathList: List[str]) -> pd.DataFrame:
         """Get mutation dataframe
 
         1) Starts reading the first line in the file
@@ -376,7 +377,7 @@ class maf(FileTypeFormat):
         without errors
 
         Args:
-            filePathList (list): list of filepaths
+            filePathList (List[str]): list of filepath(s)
 
         Raises:
             ValueError: First line fields doesn't match second line fields in file

--- a/genie_registry/maf.py
+++ b/genie_registry/maf.py
@@ -370,28 +370,28 @@ class maf(FileTypeFormat):
                 "Number of fields in a line do not match the "
                 "expected number of columns"
             )
+
         read_csv_params = {
             "filepath_or_buffer": filePathList[0],
             "sep": "\t",
             "comment": "#",
-            # Keep the value 'NA'
+            "keep_default_na": False,
+            # Keep the value 'NA', 'nan', and 'NaN', as
+            # those are valid allele values
             "na_values": [
                 "-1.#IND",
                 "1.#QNAN",
                 "1.#IND",
                 "-1.#QNAN",
                 "#N/A N/A",
-                "NaN",
                 "#N/A",
                 "N/A",
                 "#NA",
                 "NULL",
                 "-NaN",
-                "nan",
                 "-nan",
                 "",
             ],
-            "keep_default_na": False,
             # This is to check if people write files
             # with R, quote=T
             "quoting": 3,
@@ -399,5 +399,17 @@ class maf(FileTypeFormat):
             # validator will cause the file to fail
             "skip_blank_lines": False,
         }
+
         mutationdf = transform._convert_df_with_mixed_dtypes(read_csv_params)
+
+        # convert back to NAs
+        mutationdf = transform._convert_values_to_na(
+            input_df=mutationdf,
+            values_to_replace=["NA", "nan", "NaN"],
+            columns_to_convert=[
+                col
+                for col in mutationdf.columns
+                if col.upper() not in self._allele_cols
+            ],
+        )
         return mutationdf

--- a/genie_registry/vcf.py
+++ b/genie_registry/vcf.py
@@ -1,5 +1,6 @@
 import logging
 import os
+from typing import List
 
 import pandas as pd
 
@@ -28,7 +29,7 @@ class vcf(FileTypeFormat):
         endswith_vcf = basename.endswith(".vcf")
         assert startswith_genie and endswith_vcf
 
-    def _get_dataframe(self, filePathList: list) -> pd.DataFrame:
+    def _get_dataframe(self, filePathList: List[str]) -> pd.DataFrame:
         """Get mutation dataframe
 
         1) Looks for the line in the file starting with #CHROM, that will be
@@ -39,7 +40,7 @@ class vcf(FileTypeFormat):
         then convert the ones in the non-allele columns back to actual NAs
 
         Args:
-            filePathList (list): _description_
+            filePathList (List[str]): list of filepath(s)
 
         Raises:
             ValueError: when line with #CHROM doesn't exist in file

--- a/genie_registry/vcf.py
+++ b/genie_registry/vcf.py
@@ -28,7 +28,25 @@ class vcf(FileTypeFormat):
         endswith_vcf = basename.endswith(".vcf")
         assert startswith_genie and endswith_vcf
 
-    def _get_dataframe(self, filePathList):
+    def _get_dataframe(self, filePathList: list) -> pd.DataFrame:
+        """Get mutation dataframe
+
+        1) Looks for the line in the file starting with #CHROM, that will be
+        the header line (columns).
+
+        2) When reading in the data, we keep the 'NA', 'nan', and 'NaN'
+        as strings in the data because these are valid allele values
+        then convert the ones in the non-allele columns back to actual NAs
+
+        Args:
+            filePathList (list): _description_
+
+        Raises:
+            ValueError: when line with #CHROM doesn't exist in file
+
+        Returns:
+            pd.DataFrame: mutation data
+        """
         headers = None
         filepath = filePathList[0]
         with open(filepath, "r") as vcffile:
@@ -44,8 +62,6 @@ class vcf(FileTypeFormat):
                 header=None,
                 names=headers,
                 keep_default_na=False,
-                # Keep the value 'NA', 'nan', and 'NaN', as
-                # those are valid allele values
                 na_values=[
                     "-1.#IND",
                     "1.#QNAN",
@@ -64,7 +80,6 @@ class vcf(FileTypeFormat):
         else:
             raise ValueError("Your vcf must start with the header #CHROM")
 
-        # convert back to NAs
         vcfdf = transform._convert_values_to_na(
             input_df=vcfdf,
             values_to_replace=["NA", "nan", "NaN"],

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
 """genie package setup"""
+
 from setuptools import setup
 
 setup()

--- a/tests/test_assay.py
+++ b/tests/test_assay.py
@@ -1,4 +1,5 @@
 """Test assay information validation and processing"""
+
 import copy
 from unittest.mock import patch
 

--- a/tests/test_bed.py
+++ b/tests/test_bed.py
@@ -1,4 +1,5 @@
 """Test GENIE Bed class"""
+
 import tempfile
 import shutil
 from unittest import mock

--- a/tests/test_database_to_staging.py
+++ b/tests/test_database_to_staging.py
@@ -1,4 +1,5 @@
 """Tests database to staging functions"""
+
 import os
 from unittest import mock
 from unittest.mock import patch

--- a/tests/test_example_filetype_format.py
+++ b/tests/test_example_filetype_format.py
@@ -76,7 +76,10 @@ def test_that_validate_returns_expected_msg_if__validate_passes(filetype_format_
 
 
 def test_that_validate_throws_exception_if_file_read_error(filetype_format_class):
-    with patch.object(FileTypeFormat, "_validate",) as patch_validate, patch.object(
+    with patch.object(
+        FileTypeFormat,
+        "_validate",
+    ) as patch_validate, patch.object(
         FileTypeFormat,
         "read_file",
         side_effect=Exception("mocked error"),

--- a/tests/test_example_filetype_format.py
+++ b/tests/test_example_filetype_format.py
@@ -76,10 +76,7 @@ def test_that_validate_returns_expected_msg_if__validate_passes(filetype_format_
 
 
 def test_that_validate_throws_exception_if_file_read_error(filetype_format_class):
-    with patch.object(
-        FileTypeFormat,
-        "_validate",
-    ) as patch_validate, patch.object(
+    with patch.object(FileTypeFormat, "_validate",) as patch_validate, patch.object(
         FileTypeFormat,
         "read_file",
         side_effect=Exception("mocked error"),

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -1,4 +1,5 @@
 """Test genie.extract module"""
+
 from unittest.mock import patch
 
 import pandas as pd

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -1,6 +1,7 @@
 """
 Test GENIE filters
 """
+
 import datetime
 import os
 import sys

--- a/tests/test_input_to_database.py
+++ b/tests/test_input_to_database.py
@@ -668,7 +668,7 @@ class emptytable_mock:
 
 
 class TestValidation:
-    def setup(self):
+    def setup_method(self):
         valid = [
             [
                 sample_clinical_entity.id,

--- a/tests/test_maf.py
+++ b/tests/test_maf.py
@@ -7,6 +7,8 @@ from genie import process_functions, transform, validate
 import genie_registry.maf
 from genie_registry.maf import maf
 
+OPEN_BUILTIN = "builtins.open"
+
 
 @pytest.fixture
 def maf_class(syn):
@@ -428,7 +430,7 @@ def test_that__cross_validate_returns_expected_msg_if_valid(
     ids=["no_pound_sign", "pound_sign"],
 )
 def test_that__get_dataframe_returns_expected_result(maf_class, test_input, expected):
-    with patch("builtins.open", mock_open(read_data=test_input)):
+    with patch(OPEN_BUILTIN, mock_open(read_data=test_input)):
         test = maf_class._get_dataframe(["some_path"])
         pd.testing.assert_frame_equal(test, expected)
 
@@ -441,7 +443,7 @@ def test_that__get_dataframe_reads_in_correct_nas(maf_class):
         "TEST\t3846\tN/A\n"
         "NA\tnan\tNaN"
     )
-    with patch("builtins.open", mock_open(read_data=file)):
+    with patch(OPEN_BUILTIN, mock_open(read_data=file)):
         expected = pd.DataFrame(
             {
                 "Hugo_Symbol": ["TEST", "TEST", "TEST", None],
@@ -483,7 +485,7 @@ def test_that__get_dataframe_uses_correct_columns_to_replace(
     maf_class, input, expected_columns
 ):
     file = "Hugo_Symbol\tEntrez_Gene_Id\tReference_Allele\n" "TEST\t3845\tNA"
-    with patch("builtins.open", mock_open(read_data=file)), patch.object(
+    with patch(OPEN_BUILTIN, mock_open(read_data=file)), patch.object(
         pd, "read_csv", return_value=input
     ), patch.object(transform, "_convert_values_to_na") as patch_convert_to_na:
         maf_class._get_dataframe(["some_path"])

--- a/tests/test_maf.py
+++ b/tests/test_maf.py
@@ -40,7 +40,7 @@ def valid_maf_df():
             T_REF_COUNT=[1, 2, 3, 4, 3],
             N_DEPTH=[1, 2, 3, float("nan"), 3],
             N_REF_COUNT=[1, 2, 3, 4, 3],
-            N_ALT_COUNT=[1, 2, 3, 4, 3],
+            N_ALT_COUNT=[1, None, 3, 4, 3],
             TUMOR_SEQ_ALLELE2=["A", "A", "A", "A", "A"],
         )
     )

--- a/tests/test_process_mutation.py
+++ b/tests/test_process_mutation.py
@@ -40,7 +40,7 @@ def test_format_maf():
 
 
 class TestDtype:
-    def setup(self):
+    def setup_method(self):
         self.testdf = pd.DataFrame({"foo": [1], "bar": ["baz"]})
         self.column_types = {"foo": "int64", "bar": "object"}
         self.mutation_path = "/path/test.csv"

--- a/tests/test_process_mutation.py
+++ b/tests/test_process_mutation.py
@@ -1,4 +1,5 @@
 """Test process mutation functions"""
+
 import os
 from collections import namedtuple
 from pandas.testing import assert_frame_equal

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -186,3 +186,60 @@ class TestConvertMixedDtypes:
                 ],
                 any_order=False,
             )
+
+
+def get__convert_values_to_na_test_cases():
+    return [
+        {
+            "name": "single_col",
+            "input_df": pd.DataFrame({"col1": ["N/A", "SAGE-SAGE-1", "-nan"]}),
+            "values_to_replace": ["N/A", "-nan"],
+            "columns_to_convert": ["col1"],
+            "expected_df": pd.DataFrame({"col1": [None, "SAGE-SAGE-1", None]}),
+        },
+        {
+            "name": "multi_col",
+            "input_df": pd.DataFrame(
+                {"col1": ["N/A", "-nan", "1"], "col2": ["-nan", "N/A", "2"]}
+            ),
+            "values_to_replace": ["N/A", "-nan"],
+            "columns_to_convert": ["col1", "col2"],
+            "expected_df": pd.DataFrame(
+                {"col1": [None, None, "1"], "col2": [None, None, "2"]}
+            ),
+        },
+        {
+            "name": "empty_cols",
+            "input_df": pd.DataFrame(columns=["col1", "col2"]),
+            "values_to_replace": ["NaN", "NA", "nan"],
+            "columns_to_convert": ["col1", "col2"],
+            "expected_df": pd.DataFrame(columns=["col1", "col2"]),
+        },
+        {
+            "name": "empty df",
+            "input_df": pd.DataFrame(),
+            "values_to_replace": ["NaN"],
+            "columns_to_convert": ["col3"],
+            "expected_df": pd.DataFrame(),
+        },
+    ]
+
+
+@pytest.mark.parametrize(
+    "test_cases", get__convert_values_to_na_test_cases(), ids=lambda x: x["name"]
+)
+def test_that__convert_values_to_na_returns_expected(test_cases):
+    result = transform._convert_values_to_na(
+        test_cases["input_df"],
+        test_cases["values_to_replace"],
+        test_cases["columns_to_convert"],
+    )
+    pd.testing.assert_frame_equal(result, test_cases["expected_df"])
+
+
+def test_that__convert_values_to_na_throws_key_error_if_nonexistent_cols():
+    input_df = pd.DataFrame({"col1": ["N/A", "SAGE-SAGE-1", "-nan"]})
+    values_to_replace = "NaN"
+    columns_to_convert = "col3"
+    with pytest.raises(KeyError):
+        transform._convert_values_to_na(input_df, values_to_replace, columns_to_convert)

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -1,4 +1,5 @@
 """Test genie.transform module"""
+
 import os
 from io import BytesIO
 from unittest import mock

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -1,4 +1,5 @@
 """Tests validate.py"""
+
 from unittest.mock import Mock, patch
 
 import pandas as pd

--- a/tests/test_vcf.py
+++ b/tests/test_vcf.py
@@ -5,6 +5,8 @@ from unittest.mock import mock_open, patch
 from genie import transform
 from genie_registry.vcf import vcf
 
+OPEN_BUILTIN = "builtins.open"
+
 
 @pytest.fixture
 def vcf_class(syn):
@@ -257,7 +259,7 @@ def test_validation_more_than_11_cols(vcf_class):
 
 def test_that__get_dataframe_throws_value_error_if_no_headers(vcf_class):
     file = "CHROM\tALT\tREF\n" "TEST\t3845\tNA"
-    with patch("builtins.open", mock_open(read_data=file)):
+    with patch(OPEN_BUILTIN, mock_open(read_data=file)):
         with pytest.raises(
             ValueError, match="Your vcf must start with the header #CHROM"
         ):
@@ -272,7 +274,7 @@ def test_that__get_dataframe_reads_in_correct_nas(vcf_class):
         "TEST\t3846\tN/A\n"
         "NA\tnan\tNaN"
     )
-    with patch("builtins.open", mock_open(read_data=file)):
+    with patch(OPEN_BUILTIN, mock_open(read_data=file)):
         expected = pd.DataFrame(
             {
                 "#CHROM": ["TEST", "TEST", "TEST", None],
@@ -314,7 +316,7 @@ def test_that__get_dataframe_uses_correct_columns_to_replace(
     vcf_class, input, expected_columns
 ):
     file = "#CHROM\tALT\tref\n" "TEST\t3845\tNA"
-    with patch("builtins.open", mock_open(read_data=file)), patch.object(
+    with patch(OPEN_BUILTIN, mock_open(read_data=file)), patch.object(
         pd, "read_csv", return_value=input
     ), patch.object(transform, "_convert_values_to_na") as patch_convert_to_na:
         vcf_class._get_dataframe(["some_path"])

--- a/tests/test_write_invalid_reasons.py
+++ b/tests/test_write_invalid_reasons.py
@@ -1,4 +1,5 @@
 """Test write invalid reasons module"""
+
 from unittest import mock
 from unittest.mock import patch
 


### PR DESCRIPTION
**Purpose:** This is a draft PR. This PR allows in the "NaN", "nan" and "NA" strings for allele columns in the vcf and maf datasets because these are valid allele combinations.

**Changes:**
- [_convert_values_to_na in genie/transform.py](https://github.com/Sage-Bionetworks/Genie/pull/549/files#diff-f5e09cd8a62285bf7d3ff1917b948de18ec663c78a15a600176178682757fd8eR70)- new function to convert all occurrences of values in a dataframe to NA, this is a helper function that is used in the `_get_dataframe` methods of the `vcf.py` and `maf.py` files
- [_get_dataframe in maf.py](https://github.com/Sage-Bionetworks/Genie/pull/549/files#diff-323044b86c877fd4af48462d3e131927c1a76d6ecef14abf031d1847a7619718L373-L403)
- [_get_dataframe in vcf.py](https://github.com/Sage-Bionetworks/Genie/pull/549/files#diff-f5006d44639bc1a25df2986607f6edaf6f310b9139ef670420d09a38f5e04c98L40-L45)
-  I decided to add the allowing in of the "NaN", "nan" and "NA" strings in this method because we need this to occur for validation and processing, and this is the method that is used in both. I also had to do some special handling for maf files because they can allow in case insensitive column names. The in-depth reasoning behind allowing in  "NaN", "nan" and "NA" strings for ALL of the dataset, then converting them back to NA in **non-allele columns** can be found in the comments of the [JIRA ticket](https://sagebionetworks.jira.com/browse/GEN-974). Summary of reasoning is that it is difficult to use`read_csv` to only convert specific columns, especially since it already has a bunch of arguments for NA specific handling, and order of operations comes into play here. See the [docs for more details](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.read_csv.html#pandas-read-csv). 

**Testing:**
- [X] Updated and ran pytests locally
- [X] Updated maf and vcf test files in test synapse project to include NaN, nan and NA as valid allele values and ran genie pipeline all the way through locally (integration test)
- [X] Ran genie pipeline under docker image