### PR TITLE
[GEN-1065] Use OIDC with pypi in genie package publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,9 +57,11 @@ jobs:
       - uses: actions/checkout@v2
       - uses: psf/black@stable
 
-  build-dist:
+  build-and-publish:
     needs: [test, lint]
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python
@@ -74,12 +76,5 @@ jobs:
       run: python -m build
     - name: List contents of dist directory
       run: ls -l dist
-
-  publish:
-    needs: [test, lint, build-dist]
-    runs-on: ubuntu-latest
-    permissions:
-      id-token: write
-    steps:
     - name: Publish to pypi
       uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,9 +57,10 @@ jobs:
       - uses: actions/checkout@v2
       - uses: psf/black@stable
 
-  build-and-publish:
+  deploy:
     needs: [test, lint]
     runs-on: ubuntu-latest
+    if: github.event_name == 'release'
     permissions:
       id-token: write
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,8 @@ jobs:
         pip install setuptools wheel build
     - name: Build distributions
       run: python -m build
+    - name: List contents of dist directory
+      run: ls -l dist
 
   publish:
     needs: [test, lint, build-dist]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: psf/black@stable
 
-  build:
+  build-dist:
     needs: [test, lint]
     runs-on: ubuntu-latest
     steps:
@@ -69,13 +69,12 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install setuptools wheel twine
+        pip install setuptools wheel build
     - name: Build distributions
-      run: |
-        python setup.py sdist bdist_wheel
+      run: python -m build
 
   publish:
-    needs: [test, lint, build]
+    needs: [test, lint, build-dist]
     runs-on: ubuntu-latest
     permissions:
       id-token: write

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,10 +57,9 @@ jobs:
       - uses: actions/checkout@v2
       - uses: psf/black@stable
 
-  deploy:
+  build:
     needs: [test, lint]
     runs-on: ubuntu-latest
-    if: github.event_name == 'release'
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python
@@ -71,10 +70,15 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install setuptools wheel twine
-    - name: Build and publish
-      env:
-        TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
-        TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+    - name: Build distributions
       run: |
         python setup.py sdist bdist_wheel
-        twine upload dist/*
+
+  publish:
+    needs: [test, lint, build]
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    steps:
+    - name: Publish to pypi
+      uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,5 @@ jobs:
         pip install setuptools wheel build
     - name: Build distributions
       run: python -m build
-    - name: List contents of dist directory
-      run: ls -l dist
     - name: Publish to pypi
       uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
**Purpose:** Leverage existing OIDC integration with pypi to publish genie package distributions to pypi in CI/CD

**Testing:** Per JIRA ticket's testing requirement, tested this by building and pushing to version 16.1 (pre-existing in pypi) and got this [expected result](https://github.com/Sage-Bionetworks/Genie/actions/runs/7894657083/job/21545758587)