### PR TITLE
[GEN-1163] Hotfix for annotation-tools

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -83,6 +83,7 @@ WORKDIR /root/
 # Must move this git clone to after the install of Genie,
 # because must update cbioportal
 RUN git clone https://github.com/cBioPortal/cbioportal.git -b v5.3.19
-RUN git clone https://github.com/Sage-Bionetworks/annotation-tools.git -b 0.0.4
+RUN git clone https://github.com/Sage-Bionetworks/annotation-tools.git -b 0.0.5
+
 
 WORKDIR /root/Genie


### PR DESCRIPTION
**Purpose:** This PR is the follow-up to [GEN-1163 in annotation-tools](https://github.com/Sage-Bionetworks/annotation-tools/pull/9), it updates the `annotation-tools` version in dockerfile so we can re-release this repo and use the update