### PR TITLE
[GEN-1067] add functionality to warn for identical ref and tsa2

### DIFF
--- a/genie_registry/maf.py
+++ b/genie_registry/maf.py
@@ -29,9 +29,18 @@ def _check_tsa1_tsa2(df):
                 "All values in TUMOR_SEQ_ALLELE1 must match all values in "
                 "REFERENCE_ALLELE or all values in TUMOR_SEQ_ALLELE2.\n"
             )
-    if tsa2_col_exist and ref_col_exist and not df.query('REFERENCE_ALLELE == TUMOR_SEQ_ALLELE2').empty:
-        error =(f"{error}REFERENCE_ALLELE should not equal to TUMOR_SEQ_ALLELE2. Please check row: {', '.join(str(e+1) for e in df.query('REFERENCE_ALLELE == TUMOR_SEQ_ALLELE2').index.values)}.\n")
+    if (
+        tsa2_col_exist
+        and ref_col_exist
+        and not df.query("REFERENCE_ALLELE == TUMOR_SEQ_ALLELE2").empty
+    ):
+        error = (
+            "maf: Contains instances where values in REFERENCE_ALLELE match values in TUMOR_SEQ_ALLELE2. "
+            "This is invalid. Please correct."
+        )
+        row_index = df.query("REFERENCE_ALLELE == TUMOR_SEQ_ALLELE2").index.values
     return error
+
 
 def _check_allele_col(df, col):
     """

--- a/genie_registry/maf.py
+++ b/genie_registry/maf.py
@@ -11,7 +11,7 @@ from genie import process_functions, transform, validate
 logger = logging.getLogger(__name__)
 
 
-def _check_tsa1_tsa2(df):
+def _check_allele_col_validity(df):
     """If maf file has both TSA1 and TSA2,
     TSA1 must equal REF, or TSA1 must equal TSA2, and REF must not equal TSA2
     """
@@ -270,7 +270,7 @@ class maf(FileTypeFormat):
         #             "start with 'chr' or any 'WT' values.\n"
         #         )
 
-        error = _check_tsa1_tsa2(mutationDF)
+        error = _check_allele_col_validity(mutationDF)
         total_error.write(error)
 
         if process_functions.checkColExist(mutationDF, "TUMOR_SAMPLE_BARCODE"):

--- a/genie_registry/maf.py
+++ b/genie_registry/maf.py
@@ -35,7 +35,7 @@ def _check_tsa1_tsa2(df):
         and not df.query("REFERENCE_ALLELE == TUMOR_SEQ_ALLELE2").empty
     ):
         error = (
-            "maf: Contains instances where values in REFERENCE_ALLELE match values in TUMOR_SEQ_ALLELE2. "
+            f"{error}maf: Contains instances where values in REFERENCE_ALLELE match values in TUMOR_SEQ_ALLELE2. "
             "This is invalid. Please correct.\n"
         )
         row_index = df.query("REFERENCE_ALLELE == TUMOR_SEQ_ALLELE2").index.values

--- a/genie_registry/maf.py
+++ b/genie_registry/maf.py
@@ -30,10 +30,8 @@ def _check_tsa1_tsa2(df):
                 "REFERENCE_ALLELE or all values in TUMOR_SEQ_ALLELE2.\n"
             )
     if tsa2_col_exist and ref_col_exist and not df.query('REFERENCE_ALLELE == TUMOR_SEQ_ALLELE2').empty:
-        error =(f"{error}REFERENCE_ALLELE should not equal to TUMOR_SEQ_ALLELE2. " 
-                f"Please check row: {', '.join(str(e+1) for e in df.query('REFERENCE_ALLELE == TUMOR_SEQ_ALLELE2').index.values)}.\n")
+        error =(f"{error}REFERENCE_ALLELE should not equal to TUMOR_SEQ_ALLELE2. Please check row: {', '.join(str(e+1) for e in df.query('REFERENCE_ALLELE == TUMOR_SEQ_ALLELE2').index.values)}.\n")
     return error
-
 
 def _check_allele_col(df, col):
     """

--- a/genie_registry/maf.py
+++ b/genie_registry/maf.py
@@ -13,7 +13,7 @@ logger = logging.getLogger(__name__)
 
 def _check_tsa1_tsa2(df):
     """If maf file has both TSA1 and TSA2,
-    TSA1 must equal REF, or TSA1 must equal TSA2.
+    TSA1 must equal REF, or TSA1 must equal TSA2, and REF must not equal TSA2
     """
     tsa2_col_exist = process_functions.checkColExist(df, "TUMOR_SEQ_ALLELE2")
     tsa1_col_exist = process_functions.checkColExist(df, "TUMOR_SEQ_ALLELE1")
@@ -29,6 +29,9 @@ def _check_tsa1_tsa2(df):
                 "All values in TUMOR_SEQ_ALLELE1 must match all values in "
                 "REFERENCE_ALLELE or all values in TUMOR_SEQ_ALLELE2.\n"
             )
+    if tsa2_col_exist and ref_col_exist and not df.query('REFERENCE_ALLELE == TUMOR_SEQ_ALLELE2').empty:
+        error =(f"{error}REFERENCE_ALLELE should not equal to TUMOR_SEQ_ALLELE2. " 
+                f"Please check row: {', '.join(str(e+1) for e in df.query('REFERENCE_ALLELE == TUMOR_SEQ_ALLELE2').index.values)}.\n")
     return error
 
 

--- a/genie_registry/maf.py
+++ b/genie_registry/maf.py
@@ -36,7 +36,7 @@ def _check_tsa1_tsa2(df):
     ):
         error = (
             "maf: Contains instances where values in REFERENCE_ALLELE match values in TUMOR_SEQ_ALLELE2. "
-            "This is invalid. Please correct."
+            "This is invalid. Please correct.\n"
         )
         row_index = df.query("REFERENCE_ALLELE == TUMOR_SEQ_ALLELE2").index.values
     return error

--- a/tests/test_maf.py
+++ b/tests/test_maf.py
@@ -81,7 +81,7 @@ def test_firstcolumn_validation(maf_class):
             "N_DEPTH": [1, 2, 3, 4, 3],
             "N_REF_COUNT": [1, 2, 3, 4, 3],
             "N_ALT_COUNT": [1, 2, 3, 4, 3],
-            "TUMOR_SEQ_ALLELE2": ["A", "A", "A", "A", "A"],
+            "TUMOR_SEQ_ALLELE2": ["T", "A", "A", "A", "A"],
         }
     )
     order = [
@@ -258,6 +258,39 @@ def test_invalid__check_tsa1_tsa2():
         "REFERENCE_ALLELE or all values in TUMOR_SEQ_ALLELE2.\n"
     )
 
+def test_invalid__check_ref_tsa2():
+    """Test the scenario in which maf file has identical REF and tsa2 and fails"""
+    df = pd.DataFrame(
+        dict(
+            REFERENCE_ALLELE=["A", "A", "A"],
+            TUMOR_SEQ_ALLELE1=["A", "A", "A"],
+            TUMOR_SEQ_ALLELE2=["A", "C", "C"],
+        )
+    )
+    error = genie_registry.maf._check_tsa1_tsa2(df)
+    assert error == (
+        "REFERENCE_ALLELE should not equal to TUMOR_SEQ_ALLELE2. "
+        "Please check row: 1.\n"
+    )
+
+def test_invalid__check_ref_tsa1_tsa2():
+    """Test the scenario in which maf file has TSA1 and TSA2 and fails"""
+    df = pd.DataFrame(
+        dict(
+            REFERENCE_ALLELE=["A", "A", "A"],
+            TUMOR_SEQ_ALLELE1=["B", "B", "B"],
+            TUMOR_SEQ_ALLELE2=["A", "C", "C"],
+        )
+    )
+    error = genie_registry.maf._check_tsa1_tsa2(df)
+    assert error == (
+        "maf: Contains both "
+        "TUMOR_SEQ_ALLELE1 and TUMOR_SEQ_ALLELE2 columns. "
+        "All values in TUMOR_SEQ_ALLELE1 must match all values in "
+        "REFERENCE_ALLELE or all values in TUMOR_SEQ_ALLELE2.\n"
+        "REFERENCE_ALLELE should not equal to TUMOR_SEQ_ALLELE2. "
+        "Please check row: 1.\n"
+    )
 
 @pytest.mark.parametrize(
     "df",

--- a/tests/test_maf.py
+++ b/tests/test_maf.py
@@ -241,26 +241,6 @@ def test_error__check_allele_col():
     assert warning == ""
 
 
-def test_invalid__check_ref_tsa1_tsa2():
-    """Test the scenario in which maf file has TSA1 and TSA2 and fails"""
-    df = pd.DataFrame(
-        dict(
-            REFERENCE_ALLELE=["A", "A", "A"],
-            TUMOR_SEQ_ALLELE1=["B", "B", "B"],
-            TUMOR_SEQ_ALLELE2=["A", "C", "C"],
-        )
-    )
-    error = genie_registry.maf._check_tsa1_tsa2(df)
-    assert error == (
-        "maf: Contains both "
-        "TUMOR_SEQ_ALLELE1 and TUMOR_SEQ_ALLELE2 columns. "
-        "All values in TUMOR_SEQ_ALLELE1 must match all values in "
-        "REFERENCE_ALLELE or all values in TUMOR_SEQ_ALLELE2.\n"
-        "REFERENCE_ALLELE should not equal to TUMOR_SEQ_ALLELE2. "
-        "Please check row: 1.\n"
-    )
-
-
 @pytest.mark.parametrize(
     "test_df,expected_error",
     [
@@ -335,6 +315,21 @@ def test_invalid__check_ref_tsa1_tsa2():
             ),
             "",
         ),
+        (
+            pd.DataFrame(
+                dict(
+                    REFERENCE_ALLELE=["A", "A", "A"],
+                    TUMOR_SEQ_ALLELE1=["B", "B", "B"],
+                    TUMOR_SEQ_ALLELE2=["A", "C", "C"],
+                )
+            ),
+            "maf: Contains both "
+            "TUMOR_SEQ_ALLELE1 and TUMOR_SEQ_ALLELE2 columns. "
+            "All values in TUMOR_SEQ_ALLELE1 must match all values in "
+            "REFERENCE_ALLELE or all values in TUMOR_SEQ_ALLELE2.\n"
+            "maf: Contains instances where values in REFERENCE_ALLELE match values in TUMOR_SEQ_ALLELE2. "
+            "This is invalid. Please correct.\n",
+        ),
     ],
     ids=[
         "matching_tsa1_tsa2",
@@ -344,6 +339,7 @@ def test_invalid__check_ref_tsa1_tsa2():
         "identical_ref_tsa2_missing_tsa1",
         "valid_ref_tsa2_missing_tsa1",
         "missing_tsa2_ref",
+        "invalid_tsa1_identical_ref_tsa2",
     ],
 )
 def test__check_tsa1_tsa2(test_df, expected_error):

--- a/tests/test_maf.py
+++ b/tests/test_maf.py
@@ -258,6 +258,7 @@ def test_invalid__check_tsa1_tsa2():
         "REFERENCE_ALLELE or all values in TUMOR_SEQ_ALLELE2.\n"
     )
 
+
 def test_invalid__check_ref_tsa2():
     """Test the scenario in which maf file has identical REF and tsa2 and fails"""
     df = pd.DataFrame(
@@ -269,9 +270,10 @@ def test_invalid__check_ref_tsa2():
     )
     error = genie_registry.maf._check_tsa1_tsa2(df)
     assert error == (
-        "REFERENCE_ALLELE should not equal to TUMOR_SEQ_ALLELE2. "
-        "Please check row: 1.\n"
+        "maf: Contains instances where values in REFERENCE_ALLELE match values in TUMOR_SEQ_ALLELE2. "
+        "This is invalid. Please correct.\n"
     )
+
 
 def test_invalid__check_ref_tsa1_tsa2():
     """Test the scenario in which maf file has TSA1 and TSA2 and fails"""
@@ -291,6 +293,7 @@ def test_invalid__check_ref_tsa1_tsa2():
         "REFERENCE_ALLELE should not equal to TUMOR_SEQ_ALLELE2. "
         "Please check row: 1.\n"
     )
+
 
 @pytest.mark.parametrize(
     "df",


### PR DESCRIPTION
Purpose: 
This PR includes changes in `_check_tsa1_tsa2` function of `maf.py` to throw errors (column level and row level) when REFERENCE_ALLELE is equal to TUMOR_SEQ_ALLELE2. 

Test:
1. Unit tests are included. 
2. Updated  [GOLD center file](https://www.synapse.org/#!Synapse:syn52955202) and [Test center file](https://www.synapse.org/#!Synapse:syn51611938) and ran validation locally and on ec2 instance. 