### PR TITLE
[GEN-868] add year death validation

### DIFF
--- a/genie/process_functions.py
+++ b/genie/process_functions.py
@@ -6,16 +6,15 @@ import logging
 import os
 import time
 from typing import Optional, Union
-import yaml
 
 import pandas as pd
 import requests
 import synapseclient
+import yaml
+from genie import extract
 from requests.adapters import HTTPAdapter
 from synapseclient import Synapse
 from urllib3.util import Retry
-
-from genie import extract
 
 pd.options.mode.chained_assignment = None
 
@@ -166,16 +165,16 @@ def checkUrl(url):
 
 
 # TODO Add to validate.py
-def checkColExist(DF: pd.DataFrame, key: Union[str, int]):
+def checkColExist(DF: pd.DataFrame, key: Union[str, int, list]) -> bool:
     """
-    This function checks if the column exists in a dataframe
+    This function checks if the column(s) exist(s) in a dataframe
 
     Args:
         DF: pandas dataframe
-        key: Expected column header name
+        key: Expected column header name(s)
 
     Returns:
-        bool:  True if column exists
+        bool:  True if column(s) exist(s)
     """
     result = False if DF.get(key) is None else True
     return result

--- a/genie_registry/clinical.py
+++ b/genie_registry/clinical.py
@@ -186,7 +186,7 @@ def _check_year_death_validity(clinicaldf: pd.DataFrame) -> str:
         Error message if YEAR_DEATH if invalid
     """
     error = ""
-    # generate temp dataframe to handle datatype mismatch in a column
+    # Generate temp dataframe to handle datatype mismatch in a column
     temp = clinicaldf.copy()
     # Convert YEAR_DEATH and YEAR_CONTACT to numeric, coercing errors to NaN
     temp["YEAR_DEATH"] = pd.to_numeric(temp["YEAR_DEATH"], errors="coerce")

--- a/genie_registry/clinical.py
+++ b/genie_registry/clinical.py
@@ -196,6 +196,7 @@ def _check_year_death_validity(clinicaldf: pd.DataFrame) -> str:
         "N/A",
         temp["YEAR_DEATH"] >= temp["YEAR_CONTACT"],
     )
+    index = [",".join(str(idx)) for idx, i in enumerate(check_result) if i == "False"]
     if "False" in check_result:
         error = "Patient Clinical File: Please double check your YEAR_DEATH and YEAR_CONTACT columns. YEAR_DEATH must be >= YEAR_CONTACT.\n"
     return error

--- a/genie_registry/clinical.py
+++ b/genie_registry/clinical.py
@@ -177,7 +177,11 @@ def _check_int_year_consistency(
 
 def _check_year_death_validity(clinicaldf: pd.DataFrame) -> str:
     """
-    Check if YEAR_DEATH >= YEAR_CONTACT
+    Check if YEAR_DEATH >= YEAR_CONTACT.
+    YEAR_DEATH should alway be equal or large than YEAR_CONTACT if they are both available.
+    This function compares rows with numeric values in both columns and returns comparion results("True"/"False")
+    If either of the column contains NA or nominal data (e.g. "Unknown", "Not Collected", "Unknown", "Not Applicable"),
+    then "N/A" will be outputed.
 
     Args:
         clinicaldf: Clinical Data Frame
@@ -196,8 +200,8 @@ def _check_year_death_validity(clinicaldf: pd.DataFrame) -> str:
         "N/A",
         temp["YEAR_DEATH"] >= temp["YEAR_CONTACT"],
     )
-    index = [",".join(str(idx)) for idx, i in enumerate(check_result) if i == "False"]
-    if "False" in check_result:
+    idx = [",".join(str(idx)) for idx, i in enumerate(check_result) if i == "False"]
+    if idx:
         error = "Patient Clinical File: Please double check your YEAR_DEATH and YEAR_CONTACT columns. YEAR_DEATH must be >= YEAR_CONTACT.\n"
     return error
 
@@ -851,10 +855,10 @@ class Clinical(FileTypeFormat):
         total_error.write(error)
 
         # CHECK: YEAR DEATH against YEAR CONTACT
-        haveColumn = process_functions.checkColExist(
+        has_death_and_contact_years = process_functions.checkColExist(
             clinicaldf, ["YEAR_DEATH", "YEAR_CONTACT"]
         )
-        if haveColumn:
+        if has_death_and_contact_years:
             error = _check_year_death_validity(clinicaldf=clinicaldf)
             total_error.write(error)
 

--- a/tests/test_clinical.py
+++ b/tests/test_clinical.py
@@ -9,6 +9,7 @@ import pytest
 import synapseclient
 from genie import process_functions, validate
 from genie_registry.clinical import Clinical
+import pdb
 
 
 def createMockTable(dataframe):
@@ -699,7 +700,9 @@ def test_errors__validate(clin_class):
             "column, it must be an integer in YYYY format <= {year} or "
             "'Unknown', 'Not Collected', 'Not Released', '>89', '<18'.\n"
             "Patient Clinical File: Please double check your YEAR_DEATH "
-            "and YEAR_CONTACT columns. YEAR_DEATH must be >= YEAR_CONTACT.\n"
+            "and YEAR_CONTACT columns. YEAR_DEATH must be >= YEAR_CONTACT. "
+            "There are 1 row(s) with YEAR_DEATH < YEAR_CONTACT. "
+            "Row [4] contain invalid values in the YEAR_DEATH field. Please correct.\n"
             "Patient Clinical File: Please double check your INT_CONTACT "
             "column, it must be an integer, '>32485', '<6570', 'Unknown', "
             "'Not Released' or 'Not Collected'.\n"
@@ -1063,11 +1066,11 @@ def test__check_int_dead_consistency_inconsistent(inconsistent_df):
 
 
 @pytest.mark.parametrize(
-    "df,expected_error",
+    "df,expected_indices",
     [
         (
             pd.DataFrame({"YEAR_DEATH": [420, 555, 390], "YEAR_CONTACT": [50, 40, 22]}),
-            "",
+            [],
         ),
         (
             pd.DataFrame(
@@ -1076,7 +1079,7 @@ def test__check_int_dead_consistency_inconsistent(inconsistent_df):
                     "YEAR_CONTACT": [50, 40, float("nan")],
                 }
             ),
-            "",
+            [],
         ),
         (
             pd.DataFrame(
@@ -1085,19 +1088,19 @@ def test__check_int_dead_consistency_inconsistent(inconsistent_df):
                     "YEAR_CONTACT": [50, 40, float("nan")],
                 }
             ),
-            "",
+            [],
         ),
         (
             pd.DataFrame(
                 {"YEAR_DEATH": [420, 666, 390], "YEAR_CONTACT": [50, 40, 555]}
             ),
-            "Patient Clinical File: Please double check your YEAR_DEATH and YEAR_CONTACT columns. YEAR_DEATH must be >= YEAR_CONTACT.\n",
+            [2],
         ),
         (
             pd.DataFrame(
                 {"YEAR_DEATH": [420, float("nan"), 390], "YEAR_CONTACT": [50, 40, 555]}
             ),
-            "Patient Clinical File: Please double check your YEAR_DEATH and YEAR_CONTACT columns. YEAR_DEATH must be >= YEAR_CONTACT.\n",
+            [2],
         ),
     ],
     ids=[
@@ -1108,9 +1111,39 @@ def test__check_int_dead_consistency_inconsistent(inconsistent_df):
         "invalid_dataframe_w_NAs",
     ],
 )
-def test__check_year_death_validity(df, expected_error):
-    error = genie_registry.clinical._check_year_death_validity(clinicaldf=df)
+def test__check_year_death_validity(df, expected_indices):
+    invalid_year_death_indices = genie_registry.clinical._check_year_death_validity(
+        clinicaldf=df
+    )
+    assert expected_indices == invalid_year_death_indices.tolist()
+
+
+@pytest.mark.parametrize(
+    "invalid_year_death_indices,expected_error",
+    [
+        (
+            pd.Index([]),
+            "",
+        ),
+        (
+            pd.Index([2, 3]),
+            "Patient Clinical File: Please double check your YEAR_DEATH and YEAR_CONTACT columns. "
+            "YEAR_DEATH must be >= YEAR_CONTACT. "
+            "There are 2 row(s) with YEAR_DEATH < YEAR_CONTACT. "
+            "Row [2, 3] contain invalid values in the YEAR_DEATH field. Please correct.\n",
+        ),
+    ],
+    ids=[
+        "valid_dataframe",
+        "invalid_dataframe",
+    ],
+)
+def test__check_year_death_validity_message(invalid_year_death_indices, expected_error):
+    error, warning = genie_registry.clinical._check_year_death_validity_message(
+        invalid_year_death_indices
+    )
     assert error == expected_error
+    assert warning == ""
 
 
 def get_cross_validate_bed_files_test_cases():

--- a/tests/test_clinical.py
+++ b/tests/test_clinical.py
@@ -9,7 +9,6 @@ import pytest
 import synapseclient
 from genie import process_functions, validate
 from genie_registry.clinical import Clinical
-import pdb
 
 
 def createMockTable(dataframe):

--- a/tests/test_process_functions.py
+++ b/tests/test_process_functions.py
@@ -28,6 +28,37 @@ ONCOTREE_ENT = "syn222"
 
 
 @pytest.mark.parametrize(
+    "df,key,expected_error",
+    [
+        (
+            pd.DataFrame({"foo": [420, 666, 390], "baz": [50, 40, 555]}),
+            "foo",
+            True,
+        ),
+        (
+            pd.DataFrame({"foo": [420, 666, 390], "baz": [50, 40, 555]}),
+            ["foo", "baz"],
+            True,
+        ),
+        (
+            pd.DataFrame({"foo": [420, 666, 390], "baz": [50, 40, 555]}),
+            ["foo1"],
+            False,
+        ),
+        (
+            pd.DataFrame({"foo": [420, 666, 390], "baz": [50, 40, 555]}),
+            ["foo1", "baz"],
+            False,
+        ),
+    ],
+    ids=["one_key_pass", "key_list_pass", "one_key_fail", "key_list_fail"],
+)
+def test_checkColExist(df, key, expected_error):
+    error = process_functions.checkColExist(df, key)
+    assert error == expected_error
+
+
+@pytest.mark.parametrize(
     "input_str,output",
     [
         ("1.0\t", "1\t"),


### PR DESCRIPTION
Problem:

Lack of validation check on whether YEAR_DEATH >= YEAR_CONTACT

Solution:

Add the validation check to compare YEAR_DEATH and YEAR_CONTACT when both of them exist and not NAs. 

Testing:
Unit test has been added. 