### PR TITLE
[GEN-1263] Fix bed file duplicates

### DIFF
--- a/genie/load.py
+++ b/genie/load.py
@@ -162,7 +162,7 @@ def update_table(
         syn=syn,
         database=database,
         new_dataset=newData,
-        database_syn_id=databaseSynId,
+        database_synid=databaseSynId,
         primary_key_cols=databaseEnt.primaryKey,
         to_delete=toDelete,
     )

--- a/genie/load.py
+++ b/genie/load.py
@@ -159,7 +159,12 @@ def update_table(
     else:
         newData = newData[database.columns]
     _update_table(
-        syn, database, newData, databaseSynId, databaseEnt.primaryKey, toDelete
+        syn=syn,
+        database=database,
+        new_dataset=newData,
+        database_syn_id=databaseSynId,
+        primary_key_cols=databaseEnt.primaryKey,
+        to_delete=toDelete,
     )
 
 

--- a/genie_registry/bed.py
+++ b/genie_registry/bed.py
@@ -579,26 +579,34 @@ class bed(FileTypeFormat):
         seq_assay_id = seq_assay_id.upper().replace("_", "-")
         return {"seq_assay_id": seq_assay_id}
 
-    def process_steps(self, beddf, newPath, parentId, databaseSynId, seq_assay_id):
-        """
-        Process bed file, update bed database, write bed file to path
+    def process_steps(
+        self,
+        beddf: pd.DataFrame,
+        newPath: str,
+        parentId: str,
+        databaseSynId: str,
+        seq_assay_id: str,
+    ) -> str:
+        """Process bed file, update bed database, write bed file to path
 
         Args:
-            beddf: Bed dataframe
-            newPath: Path to new bed file
-            parentId: Synapse id to store gene panel file
-            databaseSynId: Synapse id of bed database
-            seq_assay_id: GENIE seq assay id
+            beddf (pd.DataFrame): input bed data
+            newPath (str): Path to new bed file
+            parentId (str): Synapse id to store gene panel file
+            databaseSynId (str): Synapse id of bed database
+            seq_assay_id (str): GENIE seq assay id
 
         Returns:
-            string: Path to new bed file
+            str: Path to new bed file
         """
-        final_beddf = self._process(beddf, seq_assay_id, newPath, parentId)
+        final_beddf = self._process(
+            beddf=beddf, seq_assay_id=seq_assay_id, newpath=newPath, parentid=parentId
+        )
         load.update_table(
             syn=self.syn,
             databaseSynId=databaseSynId,
             newData=final_beddf,
-            filterBy=self.center,
+            filterBy=seq_assay_id,
             filterByColumn="SEQ_ASSAY_ID",
             toDelete=True,
         )

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -123,6 +123,6 @@ def test_that_update_table_has_expected_calls(
         assert called_kwargs["syn"] == syn
         assert_frame_equal(called_kwargs["database"], subsetted_data)
         assert_frame_equal(called_kwargs["new_dataset"], test_new_data)
-        assert called_kwargs["database_syn_id"] == test_table_synid
+        assert called_kwargs["database_synid"] == test_table_synid
         assert called_kwargs["primary_key_cols"] == "PRIMARY_KEY"
         assert called_kwargs["to_delete"] == to_delete

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -96,10 +96,15 @@ def test_that_update_table_has_expected_calls(
 
     mock_database_ent = Mock()
     mock_database_ent.primaryKey = "PRIMARY_KEY"
-    syn.get.return_value = mock_database_ent
-    syn.tableQuery.return_value.asDataFrame.return_value = test_data
+    mock_database = Mock()
 
-    with patch.object(load, "_update_table") as patch__update_table:
+    with patch.object(syn, "get", return_value=mock_database_ent), patch.object(
+        syn, "tableQuery", return_value=mock_database
+    ) as patch_table_query, patch.object(
+        mock_database, "asDataFrame", return_value=test_data
+    ), patch.object(
+        load, "_update_table"
+    ) as patch__update_table:
         load.update_table(
             syn,
             databaseSynId=test_table_synid,
@@ -109,7 +114,7 @@ def test_that_update_table_has_expected_calls(
             col=cols_subset,
             toDelete=to_delete,
         )
-        syn.tableQuery.assert_called_with(
+        patch_table_query.assert_called_with(
             f"SELECT * FROM {test_table_synid} where CENTER ='test-center'"
         )
 

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -1,5 +1,8 @@
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
+import pandas as pd
+from pandas.testing import assert_frame_equal
+import pytest
 import synapseclient
 from synapseclient.core.exceptions import SynapseTimeoutError
 
@@ -67,3 +70,54 @@ def test_store_table_error(syn):
     with patch.object(syn, "store", side_effect=SynapseTimeoutError) as patch_store:
         load.store_table(syn, "full/path", "syn1234")
         patch_store.assert_called_once()
+
+
+@pytest.mark.parametrize(
+    "cols_subset, to_delete, subsetted_data",
+    [
+        (None, True, pd.DataFrame({"CENTER": ["test-center"], "data": [123]})),
+        (None, False, pd.DataFrame({"CENTER": ["test-center"], "data": [123]})),
+        (["CENTER"], True, pd.DataFrame({"CENTER": ["test-center"]})),
+        (["CENTER", "col_extra"], False, pd.DataFrame({"CENTER": ["test-center"]})),
+    ],
+    ids=[
+        "to_delete_is_true",
+        "to_delete_is_false",
+        "col_is_not_none",
+        "col_has_column_not_in_db",
+    ],
+)
+def test_that_update_table_has_expected_calls(
+    syn, cols_subset, to_delete, subsetted_data
+):
+    test_table_synid = "synZZZZ"
+    test_data = pd.DataFrame({"CENTER": ["test-center"], "data": [123]})
+    test_new_data = pd.DataFrame({"CENTER": ["test-center"], "data": [123]})
+
+    mock_database_ent = Mock()
+    mock_database_ent.primaryKey = "PRIMARY_KEY"
+    syn.get.return_value = mock_database_ent
+    syn.tableQuery.return_value.asDataFrame.return_value = test_data
+
+    with patch.object(load, "_update_table") as patch__update_table:
+        load.update_table(
+            syn,
+            databaseSynId=test_table_synid,
+            newData=test_new_data,
+            filterBy="test-center",
+            filterByColumn="CENTER",
+            col=cols_subset,
+            toDelete=to_delete,
+        )
+        syn.tableQuery.assert_called_with(
+            f"SELECT * FROM {test_table_synid} where CENTER ='test-center'"
+        )
+
+        # use this method to be able to compare dataframe arg values directly
+        called_kwargs = patch__update_table.call_args.kwargs
+        assert called_kwargs["syn"] == syn
+        assert_frame_equal(called_kwargs["database"], subsetted_data)
+        assert_frame_equal(called_kwargs["new_dataset"], test_new_data)
+        assert called_kwargs["database_syn_id"] == test_table_synid
+        assert called_kwargs["primary_key_cols"] == "PRIMARY_KEY"
+        assert called_kwargs["to_delete"] == to_delete


### PR DESCRIPTION
**Purpose:** This is a draft PR. This PR fixes the bug that always appends each bed file to the bed synapse database table during processing creating duplicates in the bed database table.

**Changes:**
- [Main fix is in bed.py in `process_steps`](https://github.com/Sage-Bionetworks/Genie/blob/gen-1263-fix-bed-file-dups/genie_registry/bed.py#L609-L610)


**Tests:**

- Added unit tests (also added tests to the `update_table` function as well since there wasn't any present
- Ran bed file through processing and no bed file rows were appended to the test bed database table here: https://www.synapse.org/#!Synapse:syn11600834/
- Ran bed file on NF tower using [updated docker image here](https://github.com/Sage-Bionetworks/Genie/pkgs/container/genie/213829252?tag=gen-1285-remove-row-based-validation) twice, and ran [pipeline comparison](https://github.com/Sage-Bionetworks/Genie_processing?tab=readme-ov-file#pipeline-version-comparisons) on it - no changes. [Bed database table here](https://www.synapse.org/#!Synapse:syn11600834/tables/)

Depends on #565 