### PR TITLE
[GEN-1285] Remove row-based validation error message

### DIFF
--- a/genie_registry/clinical.py
+++ b/genie_registry/clinical.py
@@ -220,8 +220,6 @@ def _check_year_death_validity_message(
         error = (
             "Patient Clinical File: Please double check your YEAR_DEATH and YEAR_CONTACT columns. "
             "YEAR_DEATH must be >= YEAR_CONTACT. "
-            f"There are {len(invalid_year_death_indices)} row(s) with YEAR_DEATH < YEAR_CONTACT. "
-            f"The row number(s) this occurs in are: {invalid_year_death_indices.tolist()}. Please correct.\n"
         )
     return error, warning
 
@@ -271,8 +269,6 @@ def _check_int_dod_validity_message(
         error = (
             "Patient Clinical File: Please double check your INT_DOD and INT_CONTACT columns. "
             "INT_DOD must be >= INT_CONTACT. "
-            f"There are {len(invalid_int_dod_indices)} row(s) with INT_DOD < INT_CONTACT. "
-            f"The row number(s) this occurs in are: {invalid_int_dod_indices.tolist()}. Please correct.\n"
         )
     return error, warning
 

--- a/tests/test_clinical.py
+++ b/tests/test_clinical.py
@@ -715,8 +715,6 @@ def test_errors__validate(clin_class):
             "'Unknown', 'Not Collected', 'Not Released', '>89', '<18'.\n"
             "Patient Clinical File: Please double check your YEAR_DEATH "
             "and YEAR_CONTACT columns. YEAR_DEATH must be >= YEAR_CONTACT. "
-            "There are 1 row(s) with YEAR_DEATH < YEAR_CONTACT. "
-            "The row number(s) this occurs in are: [4]. Please correct.\n"
             "Patient Clinical File: Please double check your INT_CONTACT "
             "column, it must be an integer, '>32485', '<6570', 'Unknown', "
             "'Not Released' or 'Not Collected'.\n"
@@ -728,8 +726,6 @@ def test_errors__validate(clin_class):
             "'Not Released' or 'Not Collected'.\n"
             "Patient Clinical File: Please double check your INT_DOD "
             "and INT_CONTACT columns. INT_DOD must be >= INT_CONTACT. "
-            "There are 1 row(s) with INT_DOD < INT_CONTACT. "
-            "The row number(s) this occurs in are: [2]. Please correct.\n"
             "Patient: you have inconsistent redaction and text values in "
             "YEAR_CONTACT, INT_CONTACT.\n"
             "Patient: you have inconsistent redaction and text values in "
@@ -1147,8 +1143,6 @@ def test__check_year_death_validity(df, expected_indices):
             pd.Index([2, 3]),
             "Patient Clinical File: Please double check your YEAR_DEATH and YEAR_CONTACT columns. "
             "YEAR_DEATH must be >= YEAR_CONTACT. "
-            "There are 2 row(s) with YEAR_DEATH < YEAR_CONTACT. "
-            "The row number(s) this occurs in are: [2, 3]. Please correct.\n",
         ),
     ],
     ids=[
@@ -1226,8 +1220,6 @@ def test__check_int_dod_validity(df, expected_indices):
             pd.Index([2, 3]),
             "Patient Clinical File: Please double check your INT_DOD and INT_CONTACT columns. "
             "INT_DOD must be >= INT_CONTACT. "
-            "There are 2 row(s) with INT_DOD < INT_CONTACT. "
-            "The row number(s) this occurs in are: [2, 3]. Please correct.\n",
         ),
     ],
     ids=[


### PR DESCRIPTION
Problem:
The row-based error message is somewhat misleading since the row indices are from the merged data frame of patient and sample data instead of the patient clinical file or sample clinical file. 

Solution:
Remove row-based validation

Test:
Affected unit tests are updated. 