### PR TITLE
[GEN-1294] pin r-base version and upgrade to Node 20

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,9 +25,9 @@ jobs:
       matrix:
         python-version: [3.8, 3.9]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
@@ -47,7 +47,7 @@ jobs:
       run: |
         pytest tests/ --cov=genie --cov=genie_registry --cov-report=html
     - name: Upload pytest test results
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: pytest-results-${{ matrix.python-version }}
         path: htmlcov
@@ -57,7 +57,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: psf/black@stable
 
   deploy:
@@ -67,9 +67,9 @@ jobs:
     permissions:
       id-token: write
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: '3.x'
     - name: Install dependencies

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,8 +23,8 @@ RUN apt-get update && apt-get install -y --allow-unauthenticated --no-install-re
 		python3-pip \
 		python3-dev \
 		git \
-		r-base \
-		r-base-dev \
+		r-base-core=4.3.3-1.2004.0 \
+		r-base-dev=4.3.3-1.2004.0 \
 		cmake \
 		curl \
 		# synapser client dependencies

--- a/tests/test_clinical.py
+++ b/tests/test_clinical.py
@@ -1142,7 +1142,7 @@ def test__check_year_death_validity(df, expected_indices):
         (
             pd.Index([2, 3]),
             "Patient Clinical File: Please double check your YEAR_DEATH and YEAR_CONTACT columns. "
-            "YEAR_DEATH must be >= YEAR_CONTACT. "
+            "YEAR_DEATH must be >= YEAR_CONTACT. ",
         ),
     ],
     ids=[
@@ -1219,7 +1219,7 @@ def test__check_int_dod_validity(df, expected_indices):
         (
             pd.Index([2, 3]),
             "Patient Clinical File: Please double check your INT_DOD and INT_CONTACT columns. "
-            "INT_DOD must be >= INT_CONTACT. "
+            "INT_DOD must be >= INT_CONTACT. ",
         ),
     ],
     ids=[


### PR DESCRIPTION
Problem:

The Build_Docker step in the ci pipeline failed recently and ran into the Error: install of package 'rlang' failed [error code 1]. I figured the root cause for the pipeline breaks because that the [newest r-base (4.4.0) ](https://www.r-bloggers.com/2024/04/whats-new-in-r-4-4-0/) was released 4/25/2024. The apt-install pulled this version of r-base which is incompatible with the gcc-9.

Solution:

Pin r-base version to 4.3 and update actions of Node 16 with Node 20.

Testing:

Tested the workflow locally and it run through successfully. 
