### PR TITLE
[GEN-1348] Allow in mapping tables

### DIFF
--- a/genie/extract.py
+++ b/genie/extract.py
@@ -279,12 +279,6 @@ def get_genie_config(
     center_mapping_df.index = center_mapping_df.center
     # Add center configurations including input/staging synapse ids
     genie_config["center_config"] = center_mapping_df.to_dict("index")
-
-    genie_config["ethnicity_mapping"] = "syn7434242"
-    genie_config["race_mapping"] = "syn7434236"
-    genie_config["sex_mapping"] = "syn7434222"
-    genie_config["sampletype_mapping"] = "syn7434273"
-
     return genie_config
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -46,6 +46,7 @@ def genie_config():
         "releaseFolder": "syn17079016",
         "assayinfo": "syn18404286",
         "logs": "syn10155804",
+        "sv": "syn51663925",
         "center_config": {
             "SAGE": {
                 "center": "SAGE",
@@ -73,11 +74,12 @@ def genie_config():
             },
         },
         "genie_annotation_pkg": "/path/to/nexus",
-        "ethnicity_mapping": "syn7434242",
-        "race_mapping": "syn7434236",
-        "sex_mapping": "syn7434222",
-        "sampletype_mapping": "syn7434273",
+        "ethnicity_mapping": "syn60548943",
+        "race_mapping": "syn60548944",
+        "sex_mapping": "syn60548946",
+        "sampletype_mapping": "syn60548941",
         "clinical_tier_release_scope": "syn8545211",
+        "clinical_code_to_desc_map": "syn59486337",
     }
     return config
 

--- a/tests/test_clinical.py
+++ b/tests/test_clinical.py
@@ -54,10 +54,10 @@ sampledf = pd.DataFrame(
 )
 
 table_query_results_map = {
-    ("select * from syn7434222",): createMockTable(sexdf),
-    ("select * from syn7434236",): createMockTable(no_nan),
-    ("select * from syn7434242",): createMockTable(no_nan),
-    ("select * from syn7434273",): createMockTable(no_nan),
+    ("select * from syn60548946",): createMockTable(sexdf),
+    ("select * from syn60548944",): createMockTable(no_nan),
+    ("select * from syn60548943",): createMockTable(no_nan),
+    ("select * from syn60548941",): createMockTable(no_nan),
     (
         "select fieldName from syn8545211 where patient is True and inClinicalDb is True",
     ): createMockTable(patientdf),


### PR DESCRIPTION
**Purpose:** We want to add test versions of the ETHNICITY, SAMPLE_TYPE, RACE and SEX mapping tables so that whenever we add updates to these tables, we're testing the updates out first before modifying the production versions.

**Testing:**
- Run test pipeline with docker image with changes, and check that the new updates made it into the descriptions
- Run the pipeline comparison script between the pipeline run on this PR's docker image and the `develop` docker image
We see expected differences in the clinical patient files at the `staging` and `consortium_release` steps. We only see the changes in the `data_clinical.txt` file at the `public_release` step but not the `data_clinical_patient.txt`. This is expected