### PR TITLE
[GEN-1545] Remove GERMLINE from valid values of the SV_STATUS

### DIFF
--- a/genie_registry/structural_variant.py
+++ b/genie_registry/structural_variant.py
@@ -1,11 +1,10 @@
-from io import StringIO
 import logging
 import os
+from io import StringIO
 
-from pandas import DataFrame
-
-from genie.example_filetype_format import FileTypeFormat
 from genie import load, process_functions, validate
+from genie.example_filetype_format import FileTypeFormat
+from pandas import DataFrame
 
 logger = logging.getLogger(__name__)
 
@@ -91,7 +90,7 @@ class StructuralVariant(FileTypeFormat):
         warn, error = process_functions.check_col_and_values(
             df=sv_df,
             col="SV_STATUS",
-            possible_values=["SOMATIC", "GERMLINE"],
+            possible_values=["SOMATIC"],
             filename="Structural Variant",
             required=True,
         )

--- a/tests/test_sv.py
+++ b/tests/test_sv.py
@@ -1,9 +1,8 @@
 from unittest.mock import patch
 
 import pandas as pd
-
-from genie_registry.structural_variant import StructuralVariant
 from genie import validate
+from genie_registry.structural_variant import StructuralVariant
 
 
 class TestSv:
@@ -52,7 +51,7 @@ class TestSv:
         sv_df = pd.DataFrame(
             {
                 "sample_id": ["GENIE-SAGE-ID1-1", "GENIE-SAGE-ID1-1", "ID3-1"],
-                "SV_STATUS": ["SOMATIC", "SOMATIC", "GERMLINE"],
+                "SV_STATUS": ["SOMATIC", "SOMATIC", "SOMATIC"],
             }
         )
         error, warning = self.sv_cls._validate(sv_df)
@@ -80,7 +79,7 @@ class TestSv:
         sv_df = pd.DataFrame(
             {
                 "sample_id": ["GENIE-SAGE-ID1-1", "GENIE-SAGE-ID2-1"],
-                "SV_STATUS": ["SOMATIC", "GERMLINE"],
+                "SV_STATUS": ["SOMATIC", "SOMATIC"],
                 "SITE1_ENTREZ_GENE_ID": [1, "foo"],
                 "SITE2_ENTREZ_GENE_ID": [1, "foo"],
                 "SITE1_REGION_NUMBER": [1, "foo"],
@@ -118,7 +117,7 @@ class TestSv:
                     "GENIE-SAGE-ID2-1",
                     "GENIE-SAGE-ID3-1",
                 ],
-                "SV_STATUS": ["SOMATIC", "GERMLINE", "GERMLINE"],
+                "SV_STATUS": ["SOMATIC", "SOMATIC", "SOMATIC"],
                 "SITE1_ENTREZ_GENE_ID": [1, 2, 2],
                 "SITE2_ENTREZ_GENE_ID": [1, 3, 3],
                 "SITE1_REGION_NUMBER": [1, 2, 2],
@@ -154,3 +153,20 @@ class TestSv:
                 "_validate_chromosome should be called twice for sv file"
                 "since it has two potential chromosome columns to check"
             )
+
+    def test_validation_flag_GERMLINE_in_SV_STATUS(self):
+        sv_df = pd.DataFrame(
+            {
+                "sample_id": [
+                    "GENIE-SAGE-ID1-1",
+                    "GENIE-SAGE-ID2-1",
+                    "GENIE-SAGE-ID3-1",
+                ],
+                "SV_STATUS": ["SOMATIC", "SOMATIC", "GERMLINE"],
+            }
+        )
+        error, warning = self.sv_cls._validate(sv_df)
+        assert error == (
+            "Structural Variant: Please double check your SV_STATUS column.  This column must only be these values: SOMATIC\n"
+        )
+        assert warning == ""


### PR DESCRIPTION
Problem:

We have no need to collect germline structural variants and we didn't inform the data uploader about this when validating the data.

Solution:

Update the validation check for SV_STATUS and remove GERMLINE from valid values so when sites submit a germline variant, we flag that variant to be removed.

Testing:

Unit test has been added and integrated test has been done on EC2 and Tower.

<img width="812" alt="Screenshot 2024-10-29 at 10 39 32 AM" src="https://github.com/user-attachments/assets/0d8a0ae3-52f2-46f8-9a1b-8007c551a0c5">
