### PR TITLE
[GEN-1622] remove sample class filter

### DIFF
--- a/genie/consortium_to_public.py
+++ b/genie/consortium_to_public.py
@@ -5,8 +5,13 @@ import os
 
 import pandas as pd
 import synapseutils
-from genie import (create_case_lists, database_to_staging, extract, load,
-                   process_functions)
+from genie import (
+    create_case_lists,
+    database_to_staging,
+    extract,
+    load,
+    process_functions,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -148,7 +153,9 @@ def consortiumToPublic(
     allClin = clinicalDf[clinicalDf["SAMPLE_ID"].isin(publicReleaseSamples)]
     # check if cfDNA samples are present
     if not process_functions.check_values_in_column(allClin, "SAMPLE_CLASS", "cfDNA"):
-        logger.error("cfDNA samples should not be filtered out in the clinical dataframe.")
+        logger.error(
+            "cfDNA samples should not be filtered out in the clinical dataframe."
+        )
 
     allClin.to_csv(clinical_path, sep="\t", index=False)
 

--- a/genie/consortium_to_public.py
+++ b/genie/consortium_to_public.py
@@ -2,6 +2,7 @@
 
 import logging
 import os
+import sys
 
 import pandas as pd
 import synapseutils
@@ -14,6 +15,9 @@ from genie import (
 )
 
 logger = logging.getLogger(__name__)
+stdout_handler = logging.StreamHandler(stream=sys.stdout)
+stdout_handler.setLevel(logging.INFO)
+logger.addHandler(stdout_handler)
 
 
 # TODO: Add to transform.py

--- a/genie/consortium_to_public.py
+++ b/genie/consortium_to_public.py
@@ -5,13 +5,8 @@ import os
 
 import pandas as pd
 import synapseutils
-from genie import (
-    create_case_lists,
-    database_to_staging,
-    extract,
-    load,
-    process_functions,
-)
+from genie import (create_case_lists, database_to_staging, extract, load,
+                   process_functions)
 
 logger = logging.getLogger(__name__)
 
@@ -145,13 +140,15 @@ def consortiumToPublic(
     )
 
     # check if SAMPLE_CLASS is present
-    if not process_functions.checkColExist(publicRelease, "SAMPLE_CLASS"):
+    if not process_functions.check_values_in_column(
+        publicRelease, "fieldName", "SAMPLE_CLASS"
+    ):
         logger.error("Must have SAMPLE_CLASS column in the public release scope.")
 
     allClin = clinicalDf[clinicalDf["SAMPLE_ID"].isin(publicReleaseSamples)]
     # check if cfDNA samples are present
-    if not process_functions.has_cfDNA_samples(allClin):
-        logger.error("cfDNA samples should not be filtered out.")
+    if not process_functions.check_values_in_column(allClin, "SAMPLE_CLASS", "cfDNA"):
+        logger.error("cfDNA samples should not be filtered out in the clinical dataframe.")
 
     allClin.to_csv(clinical_path, sep="\t", index=False)
 

--- a/genie/database_to_staging.py
+++ b/genie/database_to_staging.py
@@ -501,24 +501,6 @@ def seq_date_filter(clinicalDf, processingDate, consortiumReleaseCutOff):
     return removeSeqDateSamples
 
 
-def sample_class_filter(clinical_df: pd.DataFrame) -> list:
-    """Filter samples by SAMPLE_CLASS
-
-    Args:
-        clinical_df (pd.DataFrame): Clinical dataframe
-
-    Returns:
-        list: List of samples to filter out
-    """
-    if clinical_df.get("SAMPLE_CLASS") is not None:
-        remove_samples = clinical_df["SAMPLE_ID"][
-            clinical_df["SAMPLE_CLASS"] == "cfDNA"
-        ].tolist()
-    else:
-        remove_samples = []
-    return remove_samples
-
-
 # TODO: Add to transform.py
 def mutation_in_cis_filter(
     syn,

--- a/genie/process_functions.py
+++ b/genie/process_functions.py
@@ -980,3 +980,17 @@ def create_missing_columns(dataset: pd.DataFrame, schema: dict) -> pd.Series:
         elif data_type == "boolean":
             dataset[column] = dataset[column].astype(pd.BooleanDtype())
     return dataset[list(schema.keys())]
+
+
+def has_cfDNA_samples(df: pd.DataFrame) -> bool:
+    """Check if cfDNA exist in SAMPLE_CLASS column of the clinical dataframe.
+    Args:
+        df (pd.DataFrame): The clinical dataframe
+    Returns:
+        bool: True if cfDNA samples exist(s)
+    """
+    if not checkColExist(df, "SAMPLE_CLASS"):
+        logger.error("Must have SAMPLE_CLASS column in the dataframe.")
+    else:
+        result = df.SAMPLE_CLASS.isin(["cfDNA"]).any()
+        return result

--- a/genie/process_functions.py
+++ b/genie/process_functions.py
@@ -982,15 +982,22 @@ def create_missing_columns(dataset: pd.DataFrame, schema: dict) -> pd.Series:
     return dataset[list(schema.keys())]
 
 
-def has_cfDNA_samples(df: pd.DataFrame) -> bool:
-    """Check if cfDNA exist in SAMPLE_CLASS column of the clinical dataframe.
+def check_values_in_column(
+    df: pd.DataFrame, col: str, values: Union[str, list]
+) -> bool:
+    """Check if a column in a dataframe contains specific values
     Args:
         df (pd.DataFrame): The clinical dataframe
+        col (str): The column name
+        values (list): Expected values in the column
     Returns:
-        bool: True if cfDNA samples exist(s)
+        bool: True if the column contains the specified values
     """
-    if not checkColExist(df, "SAMPLE_CLASS"):
-        logger.error("Must have SAMPLE_CLASS column in the dataframe.")
+    if not checkColExist(df, col):
+        logger.error(f"Must have {col} column in the dataframe.")
     else:
-        result = df.SAMPLE_CLASS.isin(["cfDNA"]).any()
+        # Ensure values is always a list for next step
+        if isinstance(values, str):
+            values = [values]
+        result = df[col].isin(values).any()
         return result

--- a/tests/test_process_functions.py
+++ b/tests/test_process_functions.py
@@ -717,39 +717,71 @@ def test_that_create_missing_columns_returns_expected_output_with_multi_col_df()
 
 
 @pytest.mark.parametrize(
-    "input_df",
-    [
-        pd.DataFrame({"some_col": ["Val1", "Val1", "Val2"]}),
-    ],
-    ids=["missing_SAMPLE_CLASS_column"],
+    "input_df,col,values",
+    [(pd.DataFrame({"some_col": ["Val1", "Val1", "Val2"]}), "test_col", "test_value")],
+    ids=["missing_the_column"],
 )
-def test_has_cfDNA_samples_no_SAMPLE_CLASS_column(input_df):
+def test_check_values_in_column_no_column(input_df, col, values):
     with patch.object(process_functions, "logger") as mock_logger:
-        results = process_functions.has_cfDNA_samples(input_df)
+        results = process_functions.check_values_in_column(input_df, col, values)
     mock_logger.error.assert_called_once_with(
-        "Must have SAMPLE_CLASS column in the dataframe."
+        "Must have test_col column in the dataframe."
     )
 
 
 @pytest.mark.parametrize(
-    "input_df, expected_results",
+    "input_df,col,values,expected_results",
     [
         (
             pd.DataFrame(
                 {"SAMPLE_ID": [1, 2, 3], "SAMPLE_CLASS": ["Val1", "Val1", "Val2"]}
             ),
+            "SAMPLE_CLASS",
+            "cfDNA",
+            False,
+        ),
+        (
+            pd.DataFrame(
+                {"SAMPLE_ID": [1, 2, 3], "SAMPLE_CLASS": ["Val1", "Val1", "Val2"]}
+            ),
+            "SAMPLE_CLASS",
+            ["test_value", "cfDNA"],
             False,
         ),
         (
             pd.DataFrame(
                 {"SAMPLE_ID": [1, 2, 3], "SAMPLE_CLASS": ["cfDNA", "Val1", "Val2"]}
             ),
+            "SAMPLE_CLASS",
+            "cfDNA",
+            True,
+        ),
+        (
+            pd.DataFrame(
+                {"SAMPLE_ID": [1, 2, 3], "SAMPLE_CLASS": ["cfDNA", "Tumor", "Val2"]}
+            ),
+            "SAMPLE_CLASS",
+            ["cfDNA", "Tumor"],
+            True,
+        ),
+        (
+            pd.DataFrame(
+                {"SAMPLE_ID": [1, 2, 3], "SAMPLE_CLASS": ["cfDNA", "Tumor", "Val2"]}
+            ),
+            "SAMPLE_CLASS",
+            ["cfDNA", "Tumor", "test_value"],
             True,
         ),
     ],
-    ids=["no_cfDNA_sampless", "have_cfDNA_samples"],
+    ids=[
+        "no_expected_single_value",
+        "no_expected_value_list",
+        "have_expected_single_value",
+        "have_expected_value_list",
+        "have_partial_expected_value_list",
+    ],
 )
-def test_has_cfDNA_samples_has_SAMPLE_CLASS_column(input_df, expected_results):
-    results = process_functions.has_cfDNA_samples(input_df)
+def test_check_values_in_column_has_column(input_df, col, values, expected_results):
+    results = process_functions.check_values_in_column(input_df, col, values)
 
     assert results == expected_results

--- a/tests/test_process_functions.py
+++ b/tests/test_process_functions.py
@@ -772,6 +772,12 @@ def test_check_values_in_column_no_column(input_df, col, values):
             ["cfDNA", "Tumor", "test_value"],
             True,
         ),
+        (
+            pd.DataFrame({"SAMPLE_ID": [], "SAMPLE_CLASS": []}),
+            "SAMPLE_CLASS",
+            ["cfDNA", "Tumor", "test_value"],
+            False,
+        ),
     ],
     ids=[
         "no_expected_single_value",
@@ -779,6 +785,7 @@ def test_check_values_in_column_no_column(input_df, col, values):
         "have_expected_single_value",
         "have_expected_value_list",
         "have_partial_expected_value_list",
+        "empty_dataframe_with_required_column",
     ],
 )
 def test_check_values_in_column_has_column(input_df, col, values, expected_results):

--- a/tests/test_process_functions.py
+++ b/tests/test_process_functions.py
@@ -751,7 +751,5 @@ def test_has_cfDNA_samples_no_SAMPLE_CLASS_column(input_df):
 )
 def test_has_cfDNA_samples_has_SAMPLE_CLASS_column(input_df, expected_results):
     results = process_functions.has_cfDNA_samples(input_df)
-    import pdb
 
-    pdb.set_trace()
     assert results == expected_results


### PR DESCRIPTION
Problem:

cfDNA samples are not released publicly.

Solution:
Make cfDNA samples public in main GENIE releases by removing sample_class_filter.

Testing:
Unit test has been added. And integration test has been done. Comparison report between `syn11611431.111` (with sample_class_filter) and `syn11611431.117` (without sample_class_filter) has been generated and got the expected result: two cfDNA sample rows are propagated.

<img width="1266" alt="Screenshot 2024-11-25 at 9 53 21 PM" src="https://github.com/user-attachments/assets/bc313129-be98-4567-bdcd-ff5b0156fef8">
