### PR TITLE
[GEN-1653] Add integration tests to GH actions workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ name: build
 on:
   push:
     branches: [main, develop, 'GEN*', 'gen*']
+    paths-ignore:
+      - '**.md'                # All Markdown files
+      - '**/docs/**'           # Documentation directory
 
   pull_request:
       types:
@@ -154,15 +157,6 @@ jobs:
         docker exec genie-container \
         python3 /root/Genie/bin/input_to_database.py main --project_id ${{ env.TEST_PROJECT_SYNID }} --deleteOld
 
-    - name: Run processing on mutation data in test pipeline (new MAF database creation on PR creation)
-      if: github.event_name == 'pull_request' && (github.event.action == 'opened' || github.event.action == 'reopened')
-      run: |
-        docker exec genie-container \
-        python3 /root/Genie/bin/input_to_database.py mutation --project_id ${{ env.TEST_PROJECT_SYNID }} \
-            --deleteOld \
-            --genie_annotation_pkg /root/annotation-tools \
-            --createNewMafDatabase
-
     - name: Run processing on mutation data in test pipeline
       if: github.event_name == 'push'
       run: |
@@ -170,6 +164,7 @@ jobs:
         python3 /root/Genie/bin/input_to_database.py mutation --project_id ${{ env.TEST_PROJECT_SYNID }} \
             --deleteOld \
             --genie_annotation_pkg /root/annotation-tools
+            --createNewMafDatabase
     
     - name: Run consortium release in test pipeline
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,6 +144,6 @@ jobs:
     
     - name: Run Tests in Docker Container
       run: |
-        docker run --rm ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.ref_name }}  \
+        docker run --rm ghcr.io/sage-bionetworks/${{ env.IMAGE_NAME }}:${{ github.ref_name }}  \
           python bin/input_to_database.py main --project_id syn7208886 --onlyValidate
   

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,8 @@ on:
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
-  TEST_PROJECT_SYNID: syn7208886
+  TEST_PROJECT_SYNID: syn7208886        # synapse_id of the test synapse project
+  TEST_SEQ_DATE: Jul-2022               # SEQ_DATE to use for test pipeline. Should match the one used in nf-genie.
 
 jobs:
 
@@ -198,12 +199,12 @@ jobs:
     - name: Run consortium release in test pipeline
       run: |
         docker exec genie-container \
-        python3 /root/Genie/bin/database_to_staging.py Jan-2017 ../cbioportal TEST --test
+        python3 /root/Genie/bin/database_to_staging.py ${{ env.TEST_SEQ_DATE }} ../cbioportal TEST --test
 
     - name: Run public release in test pipeline
       run: |
         docker exec genie-container \
-        python3 /root/Genie/bin/consortium_to_public.py Jan-2017 ../cbioportal TEST --test
+        python3 /root/Genie/bin/consortium_to_public.py  ${{ env.TEST_SEQ_DATE }} ../cbioportal TEST --test
 
     - name: Stop and Remove Docker Container
       run: docker stop genie-container && docker rm genie-container

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,14 +37,23 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v3
         with:
-          fetch-depth: 2
+          fetch-depth: 0
 
-      - name: Determine All Changes
-        id: all-changes
+      - name: Determine Changed Files
+        id: get-changes
         run: |
-          git fetch origin ${{ github.base_ref }}
-          ALL_CHANGED_FILES=$(git diff --name-only origin/${{ github.base_ref }} ${{ github.sha }})
-          echo "ALL_CHANGED_FILES=$ALL_CHANGED_FILES"
+          if [ "${{ github.event_name }}" == "push" ]; then
+            echo "Handling a push event..."
+            CURRENT_BRANCH=${{ github.ref_name }}
+            ALL_CHANGED_FILES=$(git diff --name-only HEAD^ HEAD)
+          elif [ "${{ github.event_name }}" == "pull_request" ]; then
+            echo "Handling a pull request event..."
+            BASE_BRANCH=${{ github.base_ref }}
+            HEAD_BRANCH=${{ github.head_ref }}
+            git fetch origin $BASE_BRANCH
+            ALL_CHANGED_FILES=$(git diff --name-only origin/$BASE_BRANCH HEAD)
+          fi
+          echo "All Changed Files: $ALL_CHANGED_FILES"
           echo "::set-output name=all-changes::$ALL_CHANGED_FILES"
 
       - name: Filter Non-Test Changes

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,9 @@ on:
     branches: [main, develop, 'GEN*', 'gen*']
 
   pull_request:
+      types:
+        - opened
+        - reopened
 
   release:
     types:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,11 +148,11 @@ jobs:
         docker run -d --name genie-container \
           -e SYNAPSE_AUTH_TOKEN="${{ secrets.SYNAPSE_AUTH_TOKEN }}" \
           ghcr.io/sage-bionetworks/genie:${{ github.ref_name }} \
-          -c "while true; do sleep 1; done"
+          /bin/bash -c "while true; do sleep 1; done"
     
     - name: Run validation in test pipeline
       run: |
-        docker exec genie-container \
+        docker exec -it genie-container /bin/bash \
         python3 /root/Genie/bin/input_to_database.py \
             mutation \
             --project_id ${{ env.TEST_PROJECT_SYNID }} \
@@ -161,12 +161,12 @@ jobs:
     
     - name: Run processing on non-mutation data in test pipeline
       run: |
-        docker exec genie-container \
+        docker exec -it genie-container /bin/bash \
         python3 /root/Genie/bin/input_to_database.py main --project_id ${{ env.TEST_PROJECT_SYNID }} --deleteOld
 
     - name: Run processing on mutation data in test pipeline
       run: |
-        docker exec genie-container \
+        docker exec -it genie-container /bin/bash \
         python3 /root/Genie/bin/input_to_database.py mutation --project_id ${{ env.TEST_PROJECT_SYNID }} \
             --deleteOld \
             --genie_annotation_pkg /root/annotation-tools \
@@ -174,12 +174,12 @@ jobs:
     
     - name: Run consortium release in test pipeline
       run: |
-        docker exec genie-container \
+        docker exec -it genie-container /bin/bash \
         python3 /root/Genie/bin/database_to_staging.py Jan-2017 ../cbioportal TEST --test
 
     - name: Run public release in test pipeline
       run: |
-        docker exec genie-container \
+        docker exec -it genie-container /bin/bash \
         python3 /root/Genie/bin/consortium_to_public.py Jan-2017 ../cbioportal TEST --test
 
     - name: Stop and Remove Docker Container

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,16 +54,6 @@ jobs:
       # Use always() to always run this step to publish test results when there are test failures
       if: ${{ always() }}
 
-  integration-tests:
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout repository
-      uses: actions/checkout@v4
-
-    - name: Pull Public Docker Image from GHCR
-      run: |
-        docker pull ghcr.io/sage-bionetworks/genie:main
-
 
   lint:
     runs-on: ubuntu-latest
@@ -141,3 +131,19 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: ${{ steps.registry_refs.outputs.tags }},mode=max
           cache-to: ${{ steps.registry_refs.outputs.tags }},mode=max
+
+  integration-tests:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Pull Public Docker Image from GHCR
+      run: |
+        docker pull ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.ref_name }}
+    
+    - name: Run Tests in Docker Container
+      run: |
+        docker run --rm ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.ref_name }}  \
+          python bin/input_to_database.py main --project_id syn7208886 --onlyValidate
+  

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,7 +144,7 @@ jobs:
     
     - name: Run Tests in Docker Container
       run: >
-        docker run --rm -e SYNAPSE_AUTH_TOKEN="${{ secrets.SYNAPSE_AUTH_TOKEN }}" -it \
+        docker run --rm -it -e SYNAPSE_AUTH_TOKEN="${{ secrets.SYNAPSE_AUTH_TOKEN }}" \
         ghcr.io/sage-bionetworks/genie:${{ github.ref_name }} \
         python bin/input_to_database.py main --project_id syn7208886 --onlyValidate
   

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,8 +143,8 @@ jobs:
         docker pull ghcr.io/sage-bionetworks/genie:${{ github.ref_name }}
     
     - name: Run Tests in Docker Container
-      run: >
-        docker run --rm -it -e SYNAPSE_AUTH_TOKEN="${{ secrets.SYNAPSE_AUTH_TOKEN }}" \
+      run: |
+        docker run --rm -e SYNAPSE_AUTH_TOKEN="${{ secrets.SYNAPSE_AUTH_TOKEN }}" \
         ghcr.io/sage-bionetworks/genie:${{ github.ref_name }} \
-        python bin/input_to_database.py main --project_id syn7208886 --onlyValidate
+        python3 bin/input_to_database.py main --project_id syn7208886 --onlyValidate
   

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,7 +148,7 @@ jobs:
         docker run -d --name genie-container \
           -e SYNAPSE_AUTH_TOKEN="${{ secrets.SYNAPSE_AUTH_TOKEN }}" \
           ghcr.io/sage-bionetworks/genie:${{ github.ref_name }} \
-          tail -f /dev/null
+          tail -f /dev/nullg
     
     - name: Run validation in test pipeline
       run: |
@@ -175,7 +175,7 @@ jobs:
     - name: Run consortium release in test pipeline
       run: |
         docker exec genie-container \
-        pytho3 /root/Genie/bin/database_to_staging.py Jan-2017 ../cbioportal TEST --test
+        python3 /root/Genie/bin/database_to_staging.py Jan-2017 ../cbioportal TEST --test
 
     - name: Run public release in test pipeline
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -197,12 +197,11 @@ jobs:
         python3 /root/Genie/bin/input_to_database.py main --project_id ${{ env.TEST_PROJECT_SYNID }} --deleteOld
 
     - name: Run processing on mutation data in test pipeline
-      if: github.event_name == 'push'
       run: |
         docker exec genie-container \
         python3 /root/Genie/bin/input_to_database.py mutation --project_id ${{ env.TEST_PROJECT_SYNID }} \
             --deleteOld \
-            --genie_annotation_pkg /root/annotation-tools
+            --genie_annotation_pkg /root/annotation-tools \
             --createNewMafDatabase
     
     - name: Run consortium release in test pipeline

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,8 @@ jobs:
     steps:
       - name: Checkout Code
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0 # Fetch full history to ensure access to all branches
 
       - name: Determine All Changes
         id: all-changes

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,31 @@ env:
 
 jobs:
 
+  determine-changes:
+    runs-on: ubuntu-latest
+    outputs:
+      all-changes: ${{ steps.all-changes.outputs.all-changes }}
+      non-test-changes: ${{ steps.non-test-changes.outputs.non-test-changes }}
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v3
+
+      - name: Determine All Changes
+        id: all-changes
+        run: |
+          git fetch origin ${{ github.base_ref }} --depth=1
+          ALL_CHANGED_FILES=$(git diff --name-only origin/${{ github.base_ref }} ${{ github.sha }})
+          echo "ALL_CHANGED_FILES=$ALL_CHANGED_FILES"
+          echo "::set-output name=all-changes::$ALL_CHANGED_FILES"
+
+      - name: Filter Non-Test Changes
+        id: non-test-changes
+        run: |
+          echo "All Changed Files: ${{ steps.all-changes.outputs.all-changes }}"
+          NON_TEST_CHANGES=$(echo "${{ steps.all-changes.outputs.all-changes }}" | grep -v '^tests/' || true)
+          echo "NON_TEST_CHANGES=$NON_TEST_CHANGES"
+          echo "::set-output name=non-test-changes::$NON_TEST_CHANGES"
+
   test:
     runs-on: ubuntu-latest
     strategy:
@@ -120,8 +145,9 @@ jobs:
           cache-to: ${{ steps.registry_refs.outputs.tags }},mode=max
 
   integration-tests:
-    needs: [test, lint, build-container]
+    needs: [determine-changes, lint, test, build-container]
     runs-on: ubuntu-latest
+    if: ${{ needs.determine-changes.outputs.non-test-changes }}
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,8 +7,10 @@ on:
   push:
     branches: [main, develop, 'GEN*', 'gen*']
     paths-ignore:
-      - '**.md'                # All Markdown files
-      - '**/docs/**'           # Documentation directory
+      - '**.md'                            # All Markdown files
+      - '**/docs/**'                       # Documentation directory
+      - '.github/workflows/codeql.yml'     # Code scanner
+      - '.github/workflows/build_docs.yml' # mkdocs GH workflow
 
   pull_request:
       types:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,7 @@ on:
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
+  TEST_PROJECT_SYNID: syn7208886
 
 jobs:
 
@@ -141,10 +142,44 @@ jobs:
     - name: Pull Public Docker Image from GHCR
       run: |
         docker pull ghcr.io/sage-bionetworks/genie:${{ github.ref_name }}
-    
-    - name: Run Tests in Docker Container
+
+    - name: Start Docker Container
       run: |
-        docker run --rm -e SYNAPSE_AUTH_TOKEN="${{ secrets.SYNAPSE_AUTH_TOKEN }}" \
-        ghcr.io/sage-bionetworks/genie:${{ github.ref_name }} \
-        python3 bin/input_to_database.py main --project_id syn7208886 --onlyValidate
-  
+        docker run -d --name genie-container \
+          -e SYNAPSE_AUTH_TOKEN="${{ secrets.SYNAPSE_AUTH_TOKEN }}" \
+          ghcr.io/sage-bionetworks/genie:${{ github.ref_name }}
+    
+    - name: Run validation in test pipeline
+      run: |
+        docker exec genie-container \
+        python3 /root/Genie/bin/input_to_database.py \
+            mutation \
+            --project_id ${{ env.TEST_PROJECT_SYNID }} \
+            --onlyValidate \
+            --genie_annotation_pkg /root/annotation-tools
+    
+    - name: Run processing on non-mutation data in test pipeline
+      run: |
+        docker exec genie-container \
+        python3 /root/Genie/bin/input_to_database.py main --project_id ${{ env.TEST_PROJECT_SYNID }} --deleteOld
+
+    - name: Run processing on mutation data in test pipeline
+      run: |
+        docker exec genie-container \
+        python3 /root/Genie/bin/input_to_database.py mutation --project_id ${{ env.TEST_PROJECT_SYNID }} \
+            --deleteOld \
+            --genie_annotation_pkg /root/annotation-tools \
+            --createNewMafDatabase
+    
+    - name: Run consortium release in test pipeline
+      run: |
+        docker exec genie-container \
+        pytho3 /root/Genie/bin/database_to_staging.py Jan-2017 ../cbioportal TEST --test
+
+    - name: Run public release in test pipeline
+      run: |
+        docker exec genie-container \
+        python3 /root/Genie/bin/consortium_to_public.py Jan-2017 ../cbioportal TEST --test
+
+    - name: Stop and Remove Docker Container
+      run: docker stop genie-container && docker rm genie-container

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,28 +67,6 @@ jobs:
         with:
             version: "~=23.12"
 
-  deploy:
-    needs: [test, lint]
-    runs-on: ubuntu-latest
-    if: github.event_name == 'release'
-    permissions:
-      id-token: write
-    steps:
-    - uses: actions/checkout@v4
-    - name: Set up Python
-      uses: actions/setup-python@v5
-      with:
-        python-version: '3.x'
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install setuptools wheel build
-    - name: Build distributions
-      run: python -m build
-    - name: Publish to pypi
-      uses: pypa/gh-action-pypi-publish@release/v1
-
-
   build-container:
     needs: [test, lint]
     runs-on: ubuntu-latest
@@ -176,13 +154,22 @@ jobs:
         docker exec genie-container \
         python3 /root/Genie/bin/input_to_database.py main --project_id ${{ env.TEST_PROJECT_SYNID }} --deleteOld
 
-    - name: Run processing on mutation data in test pipeline
+    - name: Run processing on mutation data in test pipeline (new MAF database creation on PR creation)
+      if: github.event_name == 'pull_request' && (github.event.action == 'opened' || github.event.action == 'reopened')
       run: |
         docker exec genie-container \
         python3 /root/Genie/bin/input_to_database.py mutation --project_id ${{ env.TEST_PROJECT_SYNID }} \
             --deleteOld \
             --genie_annotation_pkg /root/annotation-tools \
             --createNewMafDatabase
+
+    - name: Run processing on mutation data in test pipeline
+      if: github.event_name == 'push'
+      run: |
+        docker exec genie-container \
+        python3 /root/Genie/bin/input_to_database.py mutation --project_id ${{ env.TEST_PROJECT_SYNID }} \
+            --deleteOld \
+            --genie_annotation_pkg /root/annotation-tools
     
     - name: Run consortium release in test pipeline
       run: |
@@ -196,3 +183,24 @@ jobs:
 
     - name: Stop and Remove Docker Container
       run: docker stop genie-container && docker rm genie-container
+
+  deploy:
+    needs: [test, lint, build-container, integration-tests]
+    runs-on: ubuntu-latest
+    if: github.event_name == 'release'
+    permissions:
+      id-token: write
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.x'
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install setuptools wheel build
+    - name: Build distributions
+      run: python -m build
+    - name: Publish to pypi
+      uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,7 +140,7 @@ jobs:
 
     - name: Pull Public Docker Image from GHCR
       run: |
-        docker pull ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.ref_name }}
+        docker pull ghcr.io/sage-bionetworks/${{ env.IMAGE_NAME }}:${{ github.ref_name }}
     
     - name: Run Tests in Docker Container
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,7 +143,8 @@ jobs:
         docker pull ghcr.io/sage-bionetworks/genie:${{ github.ref_name }}
     
     - name: Run Tests in Docker Container
-      run: |
-        docker run --rm ghcr.io/sage-bionetworks/genie:${{ github.ref_name }}  \
-          python bin/input_to_database.py main --project_id syn7208886 --onlyValidate
+      run: >
+        docker run --rm -e SYNAPSE_AUTH_TOKEN="${{ secrets.SYNAPSE_AUTH_TOKEN }}" -it \
+        ghcr.io/sage-bionetworks/genie:${{ github.ref_name }} \
+        python bin/input_to_database.py main --project_id syn7208886 --onlyValidate
   

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -181,19 +181,20 @@ jobs:
             --onlyValidate \
             --genie_annotation_pkg /root/annotation-tools
     
-    - name: Run processing on non-mutation data in test pipeline
-      run: |
-        docker exec genie-container \
-        python3 /root/Genie/bin/input_to_database.py main --project_id ${{ env.TEST_PROJECT_SYNID }} --deleteOld
-
     - name: Run processing on mutation data in test pipeline
       run: |
         docker exec genie-container \
-        python3 /root/Genie/bin/input_to_database.py mutation --project_id ${{ env.TEST_PROJECT_SYNID }} \
-            --deleteOld \
+        python3 /root/Genie/bin/input_to_database.py mutation \
+            --project_id ${{ env.TEST_PROJECT_SYNID }} \
             --genie_annotation_pkg /root/annotation-tools \
             --createNewMafDatabase
-    
+
+    - name: Run processing on non-mutation data in test pipeline
+      run: |
+        docker exec genie-container \
+        python3 /root/Genie/bin/input_to_database.py main \
+            --project_id ${{ env.TEST_PROJECT_SYNID }}
+
     - name: Run consortium release in test pipeline
       run: |
         docker exec genie-container \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,17 @@ jobs:
       # Use always() to always run this step to publish test results when there are test failures
       if: ${{ always() }}
 
+  integration-tests:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Pull Public Docker Image from GHCR
+      run: |
+        docker pull docker pull ghcr.io/sage-bionetworks/genie:main
+
+
   lint:
     runs-on: ubuntu-latest
     steps:
@@ -61,6 +72,7 @@ jobs:
       - uses: psf/black@stable
         with:
             version: "~=23.12"
+
   deploy:
     needs: [test, lint]
     runs-on: ubuntu-latest
@@ -109,7 +121,7 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-
+      
       - name: Format tags as registry refs
         id: registry_refs
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,7 +147,8 @@ jobs:
       run: |
         docker run -d --name genie-container \
           -e SYNAPSE_AUTH_TOKEN="${{ secrets.SYNAPSE_AUTH_TOKEN }}" \
-          ghcr.io/sage-bionetworks/genie:${{ github.ref_name }}
+          ghcr.io/sage-bionetworks/genie:${{ github.ref_name }} \
+          tail -f /dev/null
     
     - name: Run validation in test pipeline
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,7 +148,7 @@ jobs:
         docker run -d --name genie-container \
           -e SYNAPSE_AUTH_TOKEN="${{ secrets.SYNAPSE_AUTH_TOKEN }}" \
           ghcr.io/sage-bionetworks/genie:${{ github.ref_name }} \
-          tail -f /dev/nullg
+          -c "while true; do sleep 1; done"
     
     - name: Run validation in test pipeline
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,11 +148,11 @@ jobs:
         docker run -d --name genie-container \
           -e SYNAPSE_AUTH_TOKEN="${{ secrets.SYNAPSE_AUTH_TOKEN }}" \
           ghcr.io/sage-bionetworks/genie:${{ github.ref_name }} \
-          /bin/bash -c "while true; do sleep 1; done"
+          sh -c "while true; do sleep 1; done"
     
     - name: Run validation in test pipeline
       run: |
-        docker exec -it genie-container /bin/bash \
+        docker exec genie-container \
         python3 /root/Genie/bin/input_to_database.py \
             mutation \
             --project_id ${{ env.TEST_PROJECT_SYNID }} \
@@ -161,12 +161,12 @@ jobs:
     
     - name: Run processing on non-mutation data in test pipeline
       run: |
-        docker exec -it genie-container /bin/bash \
+        docker exec genie-container \
         python3 /root/Genie/bin/input_to_database.py main --project_id ${{ env.TEST_PROJECT_SYNID }} --deleteOld
 
     - name: Run processing on mutation data in test pipeline
       run: |
-        docker exec -it genie-container /bin/bash \
+        docker exec genie-container \
         python3 /root/Genie/bin/input_to_database.py mutation --project_id ${{ env.TEST_PROJECT_SYNID }} \
             --deleteOld \
             --genie_annotation_pkg /root/annotation-tools \
@@ -174,12 +174,12 @@ jobs:
     
     - name: Run consortium release in test pipeline
       run: |
-        docker exec -it genie-container /bin/bash \
+        docker exec genie-container \
         python3 /root/Genie/bin/database_to_staging.py Jan-2017 ../cbioportal TEST --test
 
     - name: Run public release in test pipeline
       run: |
-        docker exec -it genie-container /bin/bash \
+        docker exec genie-container \
         python3 /root/Genie/bin/consortium_to_public.py Jan-2017 ../cbioportal TEST --test
 
     - name: Stop and Remove Docker Container

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,6 +134,7 @@ jobs:
           cache-to: ${{ steps.registry_refs.outputs.tags }},mode=max
 
   integration-tests:
+    needs: [test, lint, build-container]
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repository
@@ -146,7 +147,7 @@ jobs:
         else
           echo "BRANCH_NAME=${GITHUB_REF#refs/heads/}" >> $GITHUB_ENV
         fi
-        
+
     - name: Pull Public Docker Image from GHCR
       run: |
         docker pull ghcr.io/sage-bionetworks/genie:${{ env.BRANCH_NAME }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,15 +139,23 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v4
 
+    - name: Extract Branch Name
+      run: |
+        if [ "$GITHUB_HEAD_REF" != "" ]; then
+          echo "BRANCH_NAME=$GITHUB_HEAD_REF" >> $GITHUB_ENV
+        else
+          echo "BRANCH_NAME=${GITHUB_REF#refs/heads/}" >> $GITHUB_ENV
+        fi
+        
     - name: Pull Public Docker Image from GHCR
       run: |
-        docker pull ghcr.io/sage-bionetworks/genie:${{ github.ref_name }}
+        docker pull ghcr.io/sage-bionetworks/genie:${{ env.BRANCH_NAME }}
 
     - name: Start Docker Container
       run: |
         docker run -d --name genie-container \
           -e SYNAPSE_AUTH_TOKEN="${{ secrets.SYNAPSE_AUTH_TOKEN }}" \
-          ghcr.io/sage-bionetworks/genie:${{ github.ref_name }} \
+          ghcr.io/sage-bionetworks/genie:${{ env.BRANCH_NAME }} \
           sh -c "while true; do sleep 1; done"
     
     - name: Run validation in test pipeline

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,37 +31,27 @@ jobs:
   determine-changes:
     runs-on: ubuntu-latest
     outputs:
-      all-changes: ${{ steps.all-changes.outputs.all-changes }}
-      non-test-changes: ${{ steps.non-test-changes.outputs.non-test-changes }}
+      non-test-changes: ${{ steps.get-changes.outputs.non-test-changes }}
     steps:
       - name: Checkout Code
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
-      - name: Determine Changed Files
+      - name: Determine Changes
         id: get-changes
         run: |
           if [ "${{ github.event_name }}" == "push" ]; then
             echo "Handling a push event..."
-            CURRENT_BRANCH=${{ github.ref_name }}
             ALL_CHANGED_FILES=$(git diff --name-only HEAD^ HEAD)
           elif [ "${{ github.event_name }}" == "pull_request" ]; then
             echo "Handling a pull request event..."
-            BASE_BRANCH=${{ github.base_ref }}
-            HEAD_BRANCH=${{ github.head_ref }}
-            git fetch origin $BASE_BRANCH
-            ALL_CHANGED_FILES=$(git diff --name-only origin/$BASE_BRANCH HEAD)
+            git fetch origin ${{ github.base_ref }}
+            ALL_CHANGED_FILES=$(git diff --name-only origin/${{ github.base_ref }} HEAD)
           fi
           echo "All Changed Files: $ALL_CHANGED_FILES"
-          echo "::set-output name=all-changes::$ALL_CHANGED_FILES"
-
-      - name: Filter Non-Test Changes
-        id: non-test-changes
-        run: |
-          echo "All Changed Files: ${{ steps.all-changes.outputs.all-changes }}"
-          NON_TEST_CHANGES=$(echo "${{ steps.all-changes.outputs.all-changes }}" | grep -v '^tests/' || true)
-          echo "NON_TEST_CHANGES=$NON_TEST_CHANGES"
+          NON_TEST_CHANGES=$(echo "$ALL_CHANGED_FILES" | grep -v '^tests/' || true)
+          echo "Non-Test Changes: $NON_TEST_CHANGES"
           echo "::set-output name=non-test-changes::$NON_TEST_CHANGES"
 
   test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
 
     - name: Pull Public Docker Image from GHCR
       run: |
-        docker pull docker pull ghcr.io/sage-bionetworks/genie:main
+        docker pull ghcr.io/sage-bionetworks/genie:main
 
 
   lint:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Determine All Changes
         id: all-changes
         run: |
-          git fetch origin ${{ github.base_ref }} --depth=1
+          git fetch origin ${{ github.base_ref }}
           ALL_CHANGED_FILES=$(git diff --name-only origin/${{ github.base_ref }} ${{ github.sha }})
           echo "ALL_CHANGED_FILES=$ALL_CHANGED_FILES"
           echo "::set-output name=all-changes::$ALL_CHANGED_FILES"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v3
         with:
-          fetch-depth: 0 # Fetch full history to ensure access to all branches
+          fetch-depth: 2
 
       - name: Determine All Changes
         id: all-changes

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,10 +140,10 @@ jobs:
 
     - name: Pull Public Docker Image from GHCR
       run: |
-        docker pull ghcr.io/sage-bionetworks/${{ env.IMAGE_NAME }}:${{ github.ref_name }}
+        docker pull ghcr.io/sage-bionetworks/genie:${{ github.ref_name }}
     
     - name: Run Tests in Docker Container
       run: |
-        docker run --rm ghcr.io/sage-bionetworks/${{ env.IMAGE_NAME }}:${{ github.ref_name }}  \
+        docker run --rm ghcr.io/sage-bionetworks/genie:${{ github.ref_name }}  \
           python bin/input_to_database.py main --project_id syn7208886 --onlyValidate
   

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -42,7 +42,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
+      uses: github/codeql-action/init@v3
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -56,7 +56,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v2
+      uses: github/codeql-action/autobuild@v3
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
@@ -69,4 +69,4 @@ jobs:
     #   ./location_of_script_within_repo/buildscript.sh
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      uses: github/codeql-action/analyze@v3

--- a/README.md
+++ b/README.md
@@ -122,16 +122,16 @@ These are instructions on how you would develop and test the pipeline locally.
         python bin/input_to_database.py mutation --project_id syn7208886 --deleteOld --genie_annotation_pkg ../annotation-tools --createNewMafDatabase
         ```
 
-    1. Create a consortium release.  Be sure to add the `--test` parameter. Be sure to clone the cbioportal repo: https://github.com/cBioPortal/cbioportal and `git checkout` the version of the repo pinned to the [Dockerfile](https://github.com/Sage-Bionetworks/Genie/blob/main/Dockerfile)
+    1. Create a consortium release.  Be sure to add the `--test` parameter. Be sure to clone the cbioportal repo: https://github.com/cBioPortal/cbioportal and `git checkout` the version of the repo pinned to the [Dockerfile](https://github.com/Sage-Bionetworks/Genie/blob/main/Dockerfile). For consistency, the processingDate specified here should match the one used for TEST pipeline in [nf-genie.](https://github.com/Sage-Bionetworks-Workflows/nf-genie/blob/main/main.nf)
 
         ```
-        python bin/database_to_staging.py Jan-2017 ../cbioportal TEST --test
+        python bin/database_to_staging.py Jul-2022 ../cbioportal TEST --test
         ```
 
-    1. Create a public release.  Be sure to add the `--test` parameter.  Be sure to clone the cbioportal repo: https://github.com/cBioPortal/cbioportal and `git checkout` the version of the repo pinned to the [Dockerfile](https://github.com/Sage-Bionetworks/Genie/blob/main/Dockerfile)
+    1. Create a public release.  Be sure to add the `--test` parameter.  Be sure to clone the cbioportal repo: https://github.com/cBioPortal/cbioportal and `git checkout` the version of the repo pinned to the [Dockerfile](https://github.com/Sage-Bionetworks/Genie/blob/main/Dockerfile). For consistency, the processingDate specified here should match the one used for TEST pipeline in [nf-genie.](https://github.com/Sage-Bionetworks-Workflows/nf-genie/blob/main/main.nf)
 
         ```
-        python bin/consortium_to_public.py Jan-2017 ../cbioportal TEST --test
+        python bin/consortium_to_public.py Jul-2022 ../cbioportal TEST --test
         ```
 
 ## Production

--- a/tests/test_clinical.py
+++ b/tests/test_clinical.py
@@ -1,3 +1,5 @@
+"""Test GENIE Clinical class"""
+
 import datetime
 import json
 from collections import Counter


### PR DESCRIPTION
**Purpose:** This adds automated integration tests for each step of the genie pipeline into our GH actions workflow. Still need to do the following:

- add conditions for when this should occur so it doesn't run every time there is a code change.
- `build-container` step should be pre-req to this step

**Testing:** 
Ran all testing pipeline steps here: https://github.com/Sage-Bionetworks/Genie/actions/runs/12662104568. It took close to an hour (mainly validation and consortium release steps taking the longest). Still need to look into why the case (separate ticket)

- [x] Verify pipeline steps don't have any underlying data changes with comparison script