### PR TITLE
[GEN-1704] Filter out germline variants from sv files

### DIFF
--- a/genie/database_to_staging.py
+++ b/genie/database_to_staging.py
@@ -682,6 +682,20 @@ def store_gene_panel_files(
     return genePanelEntities
 
 
+def filter_out_germline_variants(input_data : pd.DataFrame, status_col : str) -> pd.DataFrame:
+    """Filters out germline variants given a status col. Genie pipeline
+        cannot have any of these variants.
+
+    Args:
+        input_data (pd.DataFrame): input data with germline variants to filter out
+        status_col (str): status column for the data
+
+    Returns:
+        pd.DataFrame: filtered out germline variant data
+    """
+    return input_data[input_data[status_col] != "GERMLINE"].reset_index(drop=True)
+
+
 # TODO: add to load.py
 def store_sv_files(
     syn: synapseclient.Synapse,
@@ -735,6 +749,7 @@ def store_sv_files(
                 )
 
     sv_df = sv_df[sv_df["SAMPLE_ID"].isin(keep_for_merged_consortium_samples)]
+    sv_df = filter_out_germline_variants(input_data = sv_df, status_col = "SV_Status")
     sv_df.rename(columns=transform._col_name_to_titlecase, inplace=True)
     sv_text = process_functions.removePandasDfFloat(sv_df)
     sv_path = os.path.join(GENIE_RELEASE_DIR, "data_sv.txt")

--- a/genie/database_to_staging.py
+++ b/genie/database_to_staging.py
@@ -756,7 +756,7 @@ def store_sv_files(
                 )
 
     sv_df = sv_df[sv_df["SAMPLE_ID"].isin(keep_for_merged_consortium_samples)]
-    sv_df = filter_out_germline_variants(input_data=sv_df)
+    sv_df = filter_out_germline_variants(input_data=sv_df, status_col_str = "SV_STATUS")
     sv_df.rename(columns=transform._col_name_to_titlecase, inplace=True)
     sv_text = process_functions.removePandasDfFloat(sv_df)
     sv_path = os.path.join(GENIE_RELEASE_DIR, "data_sv.txt")

--- a/genie/database_to_staging.py
+++ b/genie/database_to_staging.py
@@ -732,7 +732,6 @@ def store_sv_files(
     # sv_df["ENTREZ_GENE_ID"].mask(
     #     sv_df["ENTREZ_GENE_ID"] == 0, float("nan"), inplace=True
     # )
-
     if not current_release_staging:
         sv_staging_df = sv_df[
             sv_df["SAMPLE_ID"].isin(keep_for_center_consortium_samples)
@@ -751,7 +750,7 @@ def store_sv_files(
                 )
 
     sv_df = sv_df[sv_df["SAMPLE_ID"].isin(keep_for_merged_consortium_samples)]
-    sv_df = filter_out_germline_variants(input_data=sv_df, status_col="SV_Status")
+    sv_df = filter_out_germline_variants(input_data=sv_df, status_col="SV_STATUS")
     sv_df.rename(columns=transform._col_name_to_titlecase, inplace=True)
     sv_text = process_functions.removePandasDfFloat(sv_df)
     sv_path = os.path.join(GENIE_RELEASE_DIR, "data_sv.txt")

--- a/genie/database_to_staging.py
+++ b/genie/database_to_staging.py
@@ -686,7 +686,7 @@ def filter_out_germline_variants(
     input_data: pd.DataFrame, status_col_str: str
 ) -> pd.DataFrame:
     """Filters out germline variants given a status col str. Genie pipeline
-        cannot have any of these variants. NOTE: We have to search for the 
+        cannot have any of these variants. NOTE: We have to search for the
         status column because there's no column name validation in the release
         steps so the status column may have different casing.
 

--- a/genie/database_to_staging.py
+++ b/genie/database_to_staging.py
@@ -756,7 +756,7 @@ def store_sv_files(
                 )
 
     sv_df = sv_df[sv_df["SAMPLE_ID"].isin(keep_for_merged_consortium_samples)]
-    sv_df = filter_out_germline_variants(input_data=sv_df, status_col_str = "SV_STATUS")
+    sv_df = filter_out_germline_variants(input_data=sv_df, status_col_str="SV_STATUS")
     sv_df.rename(columns=transform._col_name_to_titlecase, inplace=True)
     sv_text = process_functions.removePandasDfFloat(sv_df)
     sv_path = os.path.join(GENIE_RELEASE_DIR, "data_sv.txt")

--- a/genie/database_to_staging.py
+++ b/genie/database_to_staging.py
@@ -683,18 +683,24 @@ def store_gene_panel_files(
 
 
 def filter_out_germline_variants(
-    input_data: pd.DataFrame, status_col: str
+    input_data: pd.DataFrame, status_col_str: str
 ) -> pd.DataFrame:
-    """Filters out germline variants given a status col. Genie pipeline
-        cannot have any of these variants.
+    """Filters out germline variants given a status col str. Genie pipeline
+        cannot have any of these variants. NOTE: We have to search for the 
+        status column because there's no column name validation in the release
+        steps so the status column may have different casing.
 
     Args:
         input_data (pd.DataFrame): input data with germline variants to filter out
-        status_col (str): status column for the data
+        status_col_str (str): search string for the status column for the data
 
     Returns:
         pd.DataFrame: filtered out germline variant data
     """
+    # find status col SV_Status
+    status_col = [
+        col for col in input_data.columns if col.lower() == status_col_str.lower()
+    ][0]
     return input_data[input_data[status_col] != "GERMLINE"].reset_index(drop=True)
 
 
@@ -750,7 +756,7 @@ def store_sv_files(
                 )
 
     sv_df = sv_df[sv_df["SAMPLE_ID"].isin(keep_for_merged_consortium_samples)]
-    sv_df = filter_out_germline_variants(input_data=sv_df, status_col="SV_STATUS")
+    sv_df = filter_out_germline_variants(input_data=sv_df)
     sv_df.rename(columns=transform._col_name_to_titlecase, inplace=True)
     sv_text = process_functions.removePandasDfFloat(sv_df)
     sv_path = os.path.join(GENIE_RELEASE_DIR, "data_sv.txt")

--- a/genie/database_to_staging.py
+++ b/genie/database_to_staging.py
@@ -682,7 +682,9 @@ def store_gene_panel_files(
     return genePanelEntities
 
 
-def filter_out_germline_variants(input_data : pd.DataFrame, status_col : str) -> pd.DataFrame:
+def filter_out_germline_variants(
+    input_data: pd.DataFrame, status_col: str
+) -> pd.DataFrame:
     """Filters out germline variants given a status col. Genie pipeline
         cannot have any of these variants.
 
@@ -749,7 +751,7 @@ def store_sv_files(
                 )
 
     sv_df = sv_df[sv_df["SAMPLE_ID"].isin(keep_for_merged_consortium_samples)]
-    sv_df = filter_out_germline_variants(input_data = sv_df, status_col = "SV_Status")
+    sv_df = filter_out_germline_variants(input_data=sv_df, status_col="SV_Status")
     sv_df.rename(columns=transform._col_name_to_titlecase, inplace=True)
     sv_text = process_functions.removePandasDfFloat(sv_df)
     sv_path = os.path.join(GENIE_RELEASE_DIR, "data_sv.txt")

--- a/tests/test_database_to_staging.py
+++ b/tests/test_database_to_staging.py
@@ -147,4 +147,4 @@ def test_that_filter_out_germline_variants_returns_expected(
     input_data, filter_col, expected_result
 ):
     result = database_to_staging.filter_out_germline_variants(input_data, filter_col)
-    assert_frame_equal(result, expected_result, check_index_type = False)
+    assert_frame_equal(result, expected_result, check_index_type=False)

--- a/tests/test_database_to_staging.py
+++ b/tests/test_database_to_staging.py
@@ -116,28 +116,28 @@ def test_store_assay_info_files(syn):
         (
             pd.DataFrame(
                 dict(
-                    SV_Status=["GERMLINE", "GERMLINE"], Sample_ID=["GENIE-1", "GENIE-2"]
+                    SV_STATUS=["GERMLINE", "GERMLINE"], Sample_ID=["GENIE-1", "GENIE-2"]
                 )
             ),
-            "SV_Status",
-            pd.DataFrame(columns=["SV_Status", "Sample_ID"]),
+            "SV_STATUS",
+            pd.DataFrame(columns=["SV_STATUS", "Sample_ID"]),
         ),
         (
             pd.DataFrame(
                 dict(
-                    SV_Status=["GERMLINE", "SOMATIC"], Sample_ID=["GENIE-1", "GENIE-2"]
+                    SV_STATUS=["GERMLINE", "SOMATIC"], Sample_ID=["GENIE-1", "GENIE-2"]
                 )
             ),
-            "SV_Status",
-            pd.DataFrame(dict(SV_Status=["SOMATIC"], Sample_ID=["GENIE-2"])),
+            "SV_STATUS",
+            pd.DataFrame(dict(SV_STATUS=["SOMATIC"], Sample_ID=["GENIE-2"])),
         ),
         (
             pd.DataFrame(
-                dict(SV_Status=["SOMATIC", "SOMATIC"], Sample_ID=["GENIE-1", "GENIE-2"])
+                dict(SV_STATUS=["SOMATIC", "SOMATIC"], Sample_ID=["GENIE-1", "GENIE-2"])
             ),
-            "SV_Status",
+            "SV_STATUS",
             pd.DataFrame(
-                dict(SV_Status=["SOMATIC", "SOMATIC"], Sample_ID=["GENIE-1", "GENIE-2"])
+                dict(SV_STATUS=["SOMATIC", "SOMATIC"], Sample_ID=["GENIE-1", "GENIE-2"])
             ),
         ),
     ],

--- a/tests/test_database_to_staging.py
+++ b/tests/test_database_to_staging.py
@@ -3,8 +3,10 @@
 import os
 from unittest import mock
 from unittest.mock import patch
+import pytest
 
 import pandas as pd
+from pandas.testing import assert_frame_equal
 import synapseclient
 
 from genie import database_to_staging, extract, load
@@ -106,3 +108,43 @@ def test_store_assay_info_files(syn):
             used=f"{FILEVIEW_SYNID}.2",
         )
         assert wes_ids == ["A"]
+
+
+@pytest.mark.parametrize(
+    "input_data, filter_col, expected_result",
+    [
+        (
+            pd.DataFrame(
+                dict(
+                    SV_Status=["GERMLINE", "GERMLINE"], Sample_ID=["GENIE-1", "GENIE-2"]
+                )
+            ),
+            "SV_Status",
+            pd.DataFrame(columns=["SV_Status", "Sample_ID"]),
+        ),
+        (
+            pd.DataFrame(
+                dict(
+                    SV_Status=["GERMLINE", "SOMATIC"], Sample_ID=["GENIE-1", "GENIE-2"]
+                )
+            ),
+            "SV_Status",
+            pd.DataFrame(dict(SV_Status=["SOMATIC"], Sample_ID=["GENIE-2"])),
+        ),
+        (
+            pd.DataFrame(
+                dict(SV_Status=["SOMATIC", "SOMATIC"], Sample_ID=["GENIE-1", "GENIE-2"])
+            ),
+            "SV_Status",
+            pd.DataFrame(
+                dict(SV_Status=["SOMATIC", "SOMATIC"], Sample_ID=["GENIE-1", "GENIE-2"])
+            ),
+        ),
+    ],
+    ids=["all_germline", "some_germline", "no_germline"],
+)
+def test_that_filter_out_germline_variants_returns_expected(
+    input_data, filter_col, expected_result
+):
+    result = database_to_staging.filter_out_germline_variants(input_data, filter_col)
+    assert_frame_equal(result, expected_result, check_index_type = False)

--- a/tests/test_database_to_staging.py
+++ b/tests/test_database_to_staging.py
@@ -142,12 +142,12 @@ def test_store_assay_info_files(syn):
         ),
         (
             pd.DataFrame(
-                dict(SV_Status=["GERMLINE", "SOMATIC"], Sample_ID=["GENIE-1", "GENIE-2"])
+                dict(
+                    SV_Status=["GERMLINE", "SOMATIC"], Sample_ID=["GENIE-1", "GENIE-2"]
+                )
             ),
             "SV_STATUS",
-            pd.DataFrame(
-                dict(SV_Status=["SOMATIC"], Sample_ID=["GENIE-2"])
-            ),
+            pd.DataFrame(dict(SV_Status=["SOMATIC"], Sample_ID=["GENIE-2"])),
         ),
     ],
     ids=["all_germline", "some_germline", "no_germline", "diff_status_col_case"],

--- a/tests/test_database_to_staging.py
+++ b/tests/test_database_to_staging.py
@@ -140,8 +140,17 @@ def test_store_assay_info_files(syn):
                 dict(SV_STATUS=["SOMATIC", "SOMATIC"], Sample_ID=["GENIE-1", "GENIE-2"])
             ),
         ),
+        (
+            pd.DataFrame(
+                dict(SV_Status=["GERMLINE", "SOMATIC"], Sample_ID=["GENIE-1", "GENIE-2"])
+            ),
+            "SV_STATUS",
+            pd.DataFrame(
+                dict(SV_Status=["SOMATIC"], Sample_ID=["GENIE-2"])
+            ),
+        ),
     ],
-    ids=["all_germline", "some_germline", "no_germline"],
+    ids=["all_germline", "some_germline", "no_germline", "diff_status_col_case"],
 )
 def test_that_filter_out_germline_variants_returns_expected(
     input_data, filter_col, expected_result


### PR DESCRIPTION
**Purpose:** This PR will be a hotfix to filter out germline variants from the sv file at the consortium release step (and subsequently the public release step since it just copies over the consortium release sv file) before we can release the germline variant validation rule.

**Changes:** Changes are isolated to the `store_sv_files` function in `database_to_staging.py`. Had to make it case-insensitive because I've found that `SV_STATUS` is in the testing pipeline's consortium release sv file while `SV_Status` is found in the production pipeline 's consortium release sv file.

**Testing:** Followed the standard validation of new features guide. The germline variants are filtered out.