### PR TITLE
[GEN-1442] Fix GHCR build for package release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,7 +131,7 @@ jobs:
         env:
           TAGS: ${{ steps.meta.outputs.json }}
         run: |
-          echo tags=$(echo $TAGS | jq '.tags[] | "type=registry,ref=" + . + "_cache"| @text') >> $GITHUB_OUTPUT
+          echo "tags=$(echo $TAGS | jq -r '.tags[] | "type=registry,ref=\(.)_cache"')" >> $GITHUB_OUTPUT
 
       - name: Build and push Docker image
         id: build-and-push


### PR DESCRIPTION
**Purpose:** This PR fixes the docker image build when we do a package release that caused the following error:
```
buildx failed with: ERROR: parse error on line 1, column 64: extraneous or missing " in quoted-field
```

See differences in output of the new tags as registry refs command vs old:

New command:
```
echo '{"tags": ["gen-16372-something", "v16.4.0"]}' | jq -r '.tags[] | "type=registry,ref=\"\(.)_cache\""'
```

Output:
```
type=registry,ref="gen-16372-something_cache"
type=registry,ref="v16.4.0_cache"
```

Old command:
```
echo '{"tags": ["gen-16372-something", "v16.4.0"]}' | jq '.tags[] | "type=registry,ref=" + . + "_cache"| @text'
```

Output:
```
"type=registry,ref=gen-16372-something_cache"
"type=registry,ref=v16.4.0_cache"
```

Note that in the new command output, double quotes are correctly placed around the ref value. Because version tags contain `.`, this may be causing inside `jq` interpreting them as something else.

**Testing:** 
Here, I named the branch with the similar notation as a package release containing `.` and the [build-container step is successful](https://github.com/Sage-Bionetworks/Genie/actions/runs/13293788559).