### PR TITLE
[GEN-1759] Fix deploy GH job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -210,7 +210,7 @@ jobs:
       run: docker stop genie-container && docker rm genie-container
 
   deploy:
-    needs: [test, lint, build-container, integration-tests]
+    needs: [test, lint, build-container]
     runs-on: ubuntu-latest
     if: github.event_name == 'release'
     permissions:


### PR DESCRIPTION
**Purpose:** Removes `integration-tests` GH job as a requirement from the `deploy` GH job when creating new package releases. Given our release process, there shouldn't be code changes as it's just creating a release. See [JIRA ticket description for details](https://sagebionetworks.jira.com/browse/GEN-1759). 