### PR TITLE
[GEN-1332] add sv to gene panel matrix

### DIFF
--- a/genie/database_to_staging.py
+++ b/genie/database_to_staging.py
@@ -923,7 +923,7 @@ def store_sv_files(
         name="data_sv.txt",
         used=f"{synid}.{version}",
     )
-    return sv_text["SAMPLE_ID"].tolist()
+    return sv_df["Sample_Id"].tolist()
 
 
 # TODO: Add to transform.py

--- a/genie/database_to_staging.py
+++ b/genie/database_to_staging.py
@@ -1613,10 +1613,14 @@ def store_data_gene_matrix(
     data_gene_matrix = data_gene_matrix[~wes_panel_mut]
 
     # Add in CNA column into gene panel file
-    data_gene_matrix = process_functions.add_columns_to_data_gene_matrix(data_gene_matrix = data_gene_matrix, sample_list= cna_samples, column_name='cna')
+    data_gene_matrix = process_functions.add_columns_to_data_gene_matrix(
+        data_gene_matrix=data_gene_matrix, sample_list=cna_samples, column_name="cna"
+    )
 
     # Add SV column into gene panel file
-    data_gene_matrix = process_functions.add_columns_to_data_gene_matrix(data_gene_matrix = data_gene_matrix, sample_list= sv_samples, column_name='sv')
+    data_gene_matrix = process_functions.add_columns_to_data_gene_matrix(
+        data_gene_matrix=data_gene_matrix, sample_list=sv_samples, column_name="sv"
+    )
 
     data_gene_matrix.to_csv(data_gene_matrix_path, sep="\t", index=False)
 

--- a/genie/database_to_staging.py
+++ b/genie/database_to_staging.py
@@ -1607,26 +1607,16 @@ def store_data_gene_matrix(
     data_gene_matrix = data_gene_matrix.rename(columns={"SEQ_ASSAY_ID": "mutations"})
     data_gene_matrix = data_gene_matrix[data_gene_matrix["SAMPLE_ID"] != ""]
     data_gene_matrix.drop_duplicates("SAMPLE_ID", inplace=True)
-    # Gene panel file is written below CNA, because of the "cna" column
-    # Add in CNA column into gene panel file
-    cna_seqids = data_gene_matrix["mutations"][
-        data_gene_matrix["SAMPLE_ID"].isin(cna_samples)
-    ].unique()
-    data_gene_matrix["cna"] = data_gene_matrix["mutations"]
-    data_gene_matrix["cna"][~data_gene_matrix["cna"].isin(cna_seqids)] = "NA"
+
+    # exclude wes assay_ids
     wes_panel_mut = data_gene_matrix["mutations"].isin(wes_seqassayids)
     data_gene_matrix = data_gene_matrix[~wes_panel_mut]
-    wes_panel_cna = data_gene_matrix["cna"].isin(wes_seqassayids)
-    data_gene_matrix = data_gene_matrix[~wes_panel_cna]
+
+    # Add in CNA column into gene panel file
+    data_gene_matrix = process_functions.add_columns_to_data_gene_matrix(data_gene_matrix = data_gene_matrix, sample_list= cna_samples, column_name='cna')
 
     # Add SV column into gene panel file
-    sv_ids = data_gene_matrix["mutations"][
-        data_gene_matrix["SAMPLE_ID"].isin(sv_samples)
-    ].unique()
-    data_gene_matrix["sv"] = data_gene_matrix["mutations"]
-    data_gene_matrix["sv"][~data_gene_matrix["sv"].isin(sv_ids)] = "NA"
-    wes_panel_sv = data_gene_matrix["sv"].isin(wes_seqassayids)
-    data_gene_matrix = data_gene_matrix[~wes_panel_sv]
+    data_gene_matrix = process_functions.add_columns_to_data_gene_matrix(data_gene_matrix = data_gene_matrix, sample_list= sv_samples, column_name='sv')
 
     data_gene_matrix.to_csv(data_gene_matrix_path, sep="\t", index=False)
 

--- a/genie/process_functions.py
+++ b/genie/process_functions.py
@@ -1116,3 +1116,22 @@ def check_column_and_values_row_specific(
         )
 
     return (warning, error)
+
+def add_columns_to_data_gene_matrix(data_gene_matrix: pd.DataFrame, sample_list: list, column_name: str):
+    """Add  CNA and SV columns to data gene matrix 
+
+    Args:
+        data_gene_matrix (pd.DataFrame): data gene matrix
+        sample_list (list): The list of cna or sv samples
+        column_name (str): The column name to be added
+    """
+    # extract the sample list
+    seqids = data_gene_matrix["mutations"][
+        data_gene_matrix["SAMPLE_ID"].isin(sample_list)
+    ].unique()
+
+    # add the column to the data gene matrix and set the value to non-CNA or non-SV rows to NA
+    data_gene_matrix[column_name] = data_gene_matrix["mutations"]
+    data_gene_matrix[column_name][~data_gene_matrix[column_name].isin(seqids)] = "NA"
+
+    return data_gene_matrix

--- a/genie/process_functions.py
+++ b/genie/process_functions.py
@@ -1117,8 +1117,11 @@ def check_column_and_values_row_specific(
 
     return (warning, error)
 
-def add_columns_to_data_gene_matrix(data_gene_matrix: pd.DataFrame, sample_list: list, column_name: str):
-    """Add  CNA and SV columns to data gene matrix 
+
+def add_columns_to_data_gene_matrix(
+    data_gene_matrix: pd.DataFrame, sample_list: list, column_name: str
+):
+    """Add  CNA and SV columns to data gene matrix
 
     Args:
         data_gene_matrix (pd.DataFrame): data gene matrix

--- a/tests/test_database_to_staging.py
+++ b/tests/test_database_to_staging.py
@@ -982,7 +982,36 @@ def test_store_sv_files(syn, current_release_staging):
         assert sv_sample == ["GENIE-1", "GENIE-3"]
 
 
-def test_store_data_gene_matrix(syn):
+@pytest.mark.parametrize(
+    "wes_seqassayids, expected_output",
+    [
+        (
+            ["ID1"],
+        pd.DataFrame(
+            {
+                "SAMPLE_ID": ["GENIE-2"],
+                "mutations": ["ID2"],
+                "cna": ["NA"],
+                "sv": ["ID2"],
+            }
+        )
+        ),
+        (
+            ["ID3"],
+        pd.DataFrame(
+            {
+                "SAMPLE_ID": ["GENIE-1", "GENIE-2"],
+                "mutations": ["ID1", "ID2"],
+                "cna": ["ID1", "NA"],
+                "sv": ["ID1", "ID2"],
+            }
+        )
+        ),
+
+    ],
+    ids=["filter_wes_seqassayids", "no_filter_wes_seqassayids"]
+)
+def test_store_data_gene_matrix(syn, wes_seqassayids, expected_output):
     database_to_staging.GENIE_RELEASE_DIR = "./"
     clinicaldf = pd.DataFrame(
         {"SAMPLE_ID": ["GENIE-1", "GENIE-2"], "SEQ_ASSAY_ID": ["ID1", "ID2"]}
@@ -997,7 +1026,7 @@ def test_store_data_gene_matrix(syn):
             clinicaldf=clinicaldf,
             cna_samples=["GENIE-1"],
             release_synid="syn123",
-            wes_seqassayids=["ID1"],
+            wes_seqassayids=wes_seqassayids,
             sv_samples=["GENIE-1", "GENIE-2"],
         )
 
@@ -1014,14 +1043,4 @@ def test_store_data_gene_matrix(syn):
             version_comment="TESTING",
             name="data_gene_matrix.txt",
         )
-        assert_frame_equal(
-            data_gene_matrix.reset_index(drop=True),
-            pd.DataFrame(
-                {
-                    "SAMPLE_ID": ["GENIE-2"],
-                    "mutations": ["ID2"],
-                    "cna": ["NA"],
-                    "sv": ["ID2"],
-                }
-            ),
-        )
+        pd.testing.assert_frame_equal(data_gene_matrix.reset_index(drop=True),expected_output)

--- a/tests/test_database_to_staging.py
+++ b/tests/test_database_to_staging.py
@@ -987,29 +987,28 @@ def test_store_sv_files(syn, current_release_staging):
     [
         (
             ["ID1"],
-        pd.DataFrame(
-            {
-                "SAMPLE_ID": ["GENIE-2"],
-                "mutations": ["ID2"],
-                "cna": ["NA"],
-                "sv": ["ID2"],
-            }
-        )
+            pd.DataFrame(
+                {
+                    "SAMPLE_ID": ["GENIE-2"],
+                    "mutations": ["ID2"],
+                    "cna": ["NA"],
+                    "sv": ["ID2"],
+                }
+            ),
         ),
         (
             ["ID3"],
-        pd.DataFrame(
-            {
-                "SAMPLE_ID": ["GENIE-1", "GENIE-2"],
-                "mutations": ["ID1", "ID2"],
-                "cna": ["ID1", "NA"],
-                "sv": ["ID1", "ID2"],
-            }
-        )
+            pd.DataFrame(
+                {
+                    "SAMPLE_ID": ["GENIE-1", "GENIE-2"],
+                    "mutations": ["ID1", "ID2"],
+                    "cna": ["ID1", "NA"],
+                    "sv": ["ID1", "ID2"],
+                }
+            ),
         ),
-
     ],
-    ids=["filter_wes_seqassayids", "no_filter_wes_seqassayids"]
+    ids=["filter_wes_seqassayids", "no_filter_wes_seqassayids"],
 )
 def test_store_data_gene_matrix(syn, wes_seqassayids, expected_output):
     database_to_staging.GENIE_RELEASE_DIR = "./"
@@ -1043,4 +1042,6 @@ def test_store_data_gene_matrix(syn, wes_seqassayids, expected_output):
             version_comment="TESTING",
             name="data_gene_matrix.txt",
         )
-        pd.testing.assert_frame_equal(data_gene_matrix.reset_index(drop=True),expected_output)
+        pd.testing.assert_frame_equal(
+            data_gene_matrix.reset_index(drop=True), expected_output
+        )

--- a/tests/test_process_functions.py
+++ b/tests/test_process_functions.py
@@ -5,8 +5,12 @@ import pandas as pd
 import pytest
 import synapseclient
 from genie import process_functions
-from pandas.api.types import (is_bool_dtype, is_float_dtype, is_integer_dtype,
-                              is_string_dtype)
+from pandas.api.types import (
+    is_bool_dtype,
+    is_float_dtype,
+    is_integer_dtype,
+    is_string_dtype,
+)
 from pandas.testing import assert_frame_equal
 
 DATABASE_DF = pd.DataFrame(
@@ -1033,51 +1037,70 @@ def test_check_col_and_values_row_specific(test_cases):
     assert warning == test_cases["expected_warning"]
     assert error == test_cases["expected_error"]
 
+
 @pytest.mark.parametrize(
     "data_gene_matrix, sample_list, column_name,expected_output",
     [
         (
             pd.DataFrame(
-                {"SAMPLE_ID": ["Sample_1", "Sample_2", "Sample_3"], "mutations": ["assay_1", "assay_2", "assay_3"]}
+                {
+                    "SAMPLE_ID": ["Sample_1", "Sample_2", "Sample_3"],
+                    "mutations": ["assay_1", "assay_2", "assay_3"],
+                }
             ),
-            ["Sample_1", "Sample_2","Sample_3"],
+            ["Sample_1", "Sample_2", "Sample_3"],
             "CNA",
             pd.DataFrame(
-                {"SAMPLE_ID": ["Sample_1", "Sample_2", "Sample_3"], "mutations": ["assay_1", "assay_2", "assay_3"], "CNA": ["assay_1", "assay_2", "assay_3"]}
+                {
+                    "SAMPLE_ID": ["Sample_1", "Sample_2", "Sample_3"],
+                    "mutations": ["assay_1", "assay_2", "assay_3"],
+                    "CNA": ["assay_1", "assay_2", "assay_3"],
+                }
             ),
         ),
         (
             pd.DataFrame(
-                {"SAMPLE_ID": ["Sample_1", "Sample_2", "Sample_3"], "mutations": ["assay_1", "assay_2", "assay_3"]}
+                {
+                    "SAMPLE_ID": ["Sample_1", "Sample_2", "Sample_3"],
+                    "mutations": ["assay_1", "assay_2", "assay_3"],
+                }
             ),
             ["Sample_1", "Sample_2"],
             "CNA",
             pd.DataFrame(
-                {"SAMPLE_ID": ["Sample_1", "Sample_2", "Sample_3"], "mutations": ["assay_1", "assay_2", "assay_3"], "CNA": ["assay_1", "assay_2", "NA"]}
+                {
+                    "SAMPLE_ID": ["Sample_1", "Sample_2", "Sample_3"],
+                    "mutations": ["assay_1", "assay_2", "assay_3"],
+                    "CNA": ["assay_1", "assay_2", "NA"],
+                }
             ),
         ),
         (
             pd.DataFrame(
-                {"SAMPLE_ID": ["Sample_1", "Sample_2", "Sample_3"], "mutations": ["assay_1", "assay_2", "assay_3"]}
+                {
+                    "SAMPLE_ID": ["Sample_1", "Sample_2", "Sample_3"],
+                    "mutations": ["assay_1", "assay_2", "assay_3"],
+                }
             ),
             ["Sample_4"],
             "CNA",
             pd.DataFrame(
-                {"SAMPLE_ID": ["Sample_1", "Sample_2", "Sample_3"], "mutations": ["assay_1", "assay_2", "assay_3"], "CNA": ["NA", "NA", "NA"]}
+                {
+                    "SAMPLE_ID": ["Sample_1", "Sample_2", "Sample_3"],
+                    "mutations": ["assay_1", "assay_2", "assay_3"],
+                    "CNA": ["NA", "NA", "NA"],
+                }
             ),
         ),
-
     ],
-    ids=[
-        "all_mutation_samples",
-        "partial_mutation_samples",
-        "none_mutation_samples"
-    ],
+    ids=["all_mutation_samples", "partial_mutation_samples", "none_mutation_samples"],
 )
-def test_add_columns_to_data_gene_matrix(data_gene_matrix, sample_list, column_name, expected_output):
-    output = process_functions.add_columns_to_data_gene_matrix(data_gene_matrix, sample_list, column_name)
+def test_add_columns_to_data_gene_matrix(
+    data_gene_matrix, sample_list, column_name, expected_output
+):
+    output = process_functions.add_columns_to_data_gene_matrix(
+        data_gene_matrix, sample_list, column_name
+    )
 
     # check the output
     pd.testing.assert_frame_equal(output, expected_output)
-
-

--- a/tests/test_process_functions.py
+++ b/tests/test_process_functions.py
@@ -1,20 +1,12 @@
 import uuid
-import uuid
 from unittest.mock import Mock, patch
 
 import pandas as pd
 import pytest
 import synapseclient
 from genie import process_functions
-import pytest
-import synapseclient
-from genie import process_functions
-from pandas.api.types import (
-    is_bool_dtype,
-    is_float_dtype,
-    is_integer_dtype,
-    is_string_dtype,
-)
+from pandas.api.types import (is_bool_dtype, is_float_dtype, is_integer_dtype,
+                              is_string_dtype)
 from pandas.testing import assert_frame_equal
 
 DATABASE_DF = pd.DataFrame(
@@ -1040,3 +1032,52 @@ def test_check_col_and_values_row_specific(test_cases):
     )
     assert warning == test_cases["expected_warning"]
     assert error == test_cases["expected_error"]
+
+@pytest.mark.parametrize(
+    "data_gene_matrix, sample_list, column_name,expected_output",
+    [
+        (
+            pd.DataFrame(
+                {"SAMPLE_ID": ["Sample_1", "Sample_2", "Sample_3"], "mutations": ["assay_1", "assay_2", "assay_3"]}
+            ),
+            ["Sample_1", "Sample_2","Sample_3"],
+            "CNA",
+            pd.DataFrame(
+                {"SAMPLE_ID": ["Sample_1", "Sample_2", "Sample_3"], "mutations": ["assay_1", "assay_2", "assay_3"], "CNA": ["assay_1", "assay_2", "assay_3"]}
+            ),
+        ),
+        (
+            pd.DataFrame(
+                {"SAMPLE_ID": ["Sample_1", "Sample_2", "Sample_3"], "mutations": ["assay_1", "assay_2", "assay_3"]}
+            ),
+            ["Sample_1", "Sample_2"],
+            "CNA",
+            pd.DataFrame(
+                {"SAMPLE_ID": ["Sample_1", "Sample_2", "Sample_3"], "mutations": ["assay_1", "assay_2", "assay_3"], "CNA": ["assay_1", "assay_2", "NA"]}
+            ),
+        ),
+        (
+            pd.DataFrame(
+                {"SAMPLE_ID": ["Sample_1", "Sample_2", "Sample_3"], "mutations": ["assay_1", "assay_2", "assay_3"]}
+            ),
+            ["Sample_4"],
+            "CNA",
+            pd.DataFrame(
+                {"SAMPLE_ID": ["Sample_1", "Sample_2", "Sample_3"], "mutations": ["assay_1", "assay_2", "assay_3"], "CNA": ["NA", "NA", "NA"]}
+            ),
+        ),
+
+    ],
+    ids=[
+        "all_mutation_samples",
+        "partial_mutation_samples",
+        "none_mutation_samples"
+    ],
+)
+def test_add_columns_to_data_gene_matrix(data_gene_matrix, sample_list, column_name, expected_output):
+    output = process_functions.add_columns_to_data_gene_matrix(data_gene_matrix, sample_list, column_name)
+
+    # check the output
+    pd.testing.assert_frame_equal(output, expected_output)
+
+


### PR DESCRIPTION
Problem:

There is a request to add SV column in the current gene panel matrix file

Solution:
1. Output sv_sample list in store_sv_files function
2. Add the sv column in the store_data_gene_matrix function

Testing:
Unit tests have been added and integration test has been done on my local. 