### PR TITLE
[GEN-1616] Automate update of Genome Nexus truststore

### DIFF
--- a/.github/workflows/automate_truststore.yml
+++ b/.github/workflows/automate_truststore.yml
@@ -1,6 +1,7 @@
 name: Auto-update Genome Nexus Truststore file
 
 on:
+  push:
   schedule:
     - cron: "0 3 * * 1-5" # Runs at 3 AM UTC Monday to Friday
   workflow_dispatch:

--- a/.github/workflows/automate_truststore.yml
+++ b/.github/workflows/automate_truststore.yml
@@ -1,7 +1,6 @@
 name: Auto-update Genome Nexus Truststore file
 
 on:
-  push:
   schedule:
     - cron: "0 3 * * 1-5" # Runs at 3 AM UTC Monday to Friday
   workflow_dispatch:

--- a/.github/workflows/automate_truststore.yml
+++ b/.github/workflows/automate_truststore.yml
@@ -2,7 +2,7 @@ name: Auto-update Genome Nexus Truststore file
 
 on:
   schedule:
-    - cron: "0 3 * * 1-5" # Runs at 3 AM UTC Monday to Friday
+    - cron: "0 3 * * 2,5" # Runs at 3 AM UTC on Tuesday (2) and Friday (5)
   workflow_dispatch:
 
 env:

--- a/.github/workflows/automate_truststore.yml
+++ b/.github/workflows/automate_truststore.yml
@@ -9,7 +9,7 @@ on:
 env:
     PROD_DOCKER: ghcr.io/sage-bionetworks/genie:main
     SYNAPSE_AUTH_TOKEN: ${{ secrets.SYNAPSE_AUTH_TOKEN }}
-    TRUSTSTORE_PASSWORD: ${{ secrets.TRUSTSTORE_PASSWORD }}  # truststore password provided by GN team
+    TRUSTSTORE_PASSWORD: ${{ secrets.GENOME_NEXUS_TRUSTSTORE_PWD }}  # truststore password provided by GN team
     TEST_PROJECT_SYNID: syn7208886                           # synapse_id of the test synapse project
     TEST_SEQ_DATE: Jul-2022                                  # SEQ_DATE to use for test pipeline. Should match the one used in nf-genie.
   

--- a/.github/workflows/automate_truststore.yml
+++ b/.github/workflows/automate_truststore.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Upload updated truststore to Synapse
         run: |
           cd annotation-tools
-          synapse store ./AwsSsl.truststore --parentid syn22105656 --versionComment "Updated automatically via GH workflows using GN team's update truststore code"
+          synapse store ./AwsSsl.truststore --parentid syn22105656
 
 
   check-truststore-update:

--- a/.github/workflows/automate_truststore.yml
+++ b/.github/workflows/automate_truststore.yml
@@ -36,18 +36,18 @@ jobs:
         run: |
           git clone https://github.com/genome-nexus/annotation-tools.git
           cd annotation-tools
-          synapse get syn22053204 --downloadLocation ./AwsSsl.truststore
+          synapse get syn22053204
 
       - name: Update truststore file
         run: |
           cd annotation-tools
           git checkout automate-truststore
-          sh update_truststore.sh ./AwsSsl.truststore "$TRUSTSTORE_PASSWORD"
+          sh update_truststore.sh AwsSsl.truststore "$TRUSTSTORE_PASSWORD"
 
       - name: Upload updated truststore to Synapse
         run: |
           cd annotation-tools
-          synapse store ./AwsSsl.truststore --parentid syn22105656
+          synapse store AwsSsl.truststore --parentid syn22105656
 
 
   check-truststore-update:

--- a/.github/workflows/automate_truststore.yml
+++ b/.github/workflows/automate_truststore.yml
@@ -30,7 +30,7 @@ jobs:
 
       - name: Authenticate with Synapse using token
         run: |
-          synapse login --authToken "$SYNAPSE_AUTH_TOKEN"
+          synapse login -p "$SYNAPSE_AUTH_TOKEN"
 
       - name: Clone annotation-tools repository, checkout truststore branch and get truststore file
         run: |

--- a/.github/workflows/automate_truststore.yml
+++ b/.github/workflows/automate_truststore.yml
@@ -1,0 +1,84 @@
+name: Auto-update Genome Nexus Truststore file
+
+on:
+  schedule:
+    - cron: "0 3 * * 1-5" # Runs at 3 AM UTC Monday to Friday
+  workflow_dispatch:
+
+env:
+    PROD_DOCKER: ghcr.io/sage-bionetworks/genie:main
+    SYNAPSE_AUTH_TOKEN: ${{ secrets.SYNAPSE_AUTH_TOKEN }}
+    TRUSTSTORE_PASSWORD: ${{ secrets.TRUSTSTORE_PASSWORD }}  # truststore password provided by GN team
+    TEST_PROJECT_SYNID: syn7208886                           # synapse_id of the test synapse project
+    TEST_SEQ_DATE: Jul-2022                                  # SEQ_DATE to use for test pipeline. Should match the one used in nf-genie.
+  
+
+jobs:
+  update_truststore:
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y keychain openssl
+          pip install synapseclient
+
+      - name: Authenticate with Synapse using token
+        run: |
+          synapse login --authToken "$SYNAPSE_AUTH_TOKEN"
+
+      - name: Clone annotation-tools repository, checkout truststore branch and get truststore file
+        run: |
+          git clone https://github.com/genome-nexus/annotation-tools.git
+          cd annotation-tools
+          synapse get syn22053204 --downloadLocation ./AwsSsl.truststore
+
+      - name: Update truststore file
+        run: |
+          cd annotation-tools
+          git checkout automate-truststore
+          sh update_truststore.sh ./AwsSsl.truststore "$TRUSTSTORE_PASSWORD"
+
+      - name: Upload updated truststore to Synapse
+        run: |
+          cd annotation-tools
+          synapse store ./AwsSsl.truststore --parentid syn22105656 --versionComment "Updated automatically via GH workflows using GN team's update truststore code"
+
+
+  check-truststore-update:
+    needs: update_truststore
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Pull Public Docker Image from GHCR
+        run: |
+           docker pull ${{ env.PROD_DOCKER }}
+
+      - name: Start Docker Container
+        run: |
+          docker run -d --name genie-container \
+            -e SYNAPSE_AUTH_TOKEN="${{ secrets.SYNAPSE_AUTH_TOKEN }}" \
+            ${{ env.PROD_DOCKER }} \
+            sh -c "while true; do sleep 1; done"
+    
+      - name: Run processing on mutation data in test pipeline
+        run: |
+          docker exec genie-container \
+          python3 /root/Genie/bin/input_to_database.py mutation \
+              --project_id ${{ env.TEST_PROJECT_SYNID }} \
+              --genie_annotation_pkg /root/annotation-tools \
+              --createNewMafDatabase
+
+      - name: Run consortium release in test pipeline
+        run: |
+          docker exec genie-container \
+          python3 /root/Genie/bin/database_to_staging.py ${{ env.TEST_SEQ_DATE }} ../cbioportal TEST --test
+
+      - name: Stop and Remove Docker Container
+        run: docker stop genie-container && docker rm genie-container

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,8 +9,7 @@ on:
     paths-ignore:
       - '**.md'                            # All Markdown files
       - '**/docs/**'                       # Documentation directory
-      - '.github/workflows/codeql.yml'     # Code scanner
-      - '.github/workflows/build_docs.yml' # mkdocs GH workflow
+      - '.github/workflows/**'             # Ignore all markdown file chanes
 
   pull_request:
       types:
@@ -20,6 +19,8 @@ on:
   release:
     types:
       - created
+
+  workflow_dispatch:
 
 env:
   REGISTRY: ghcr.io

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,12 +9,16 @@ on:
     paths-ignore:
       - '**.md'                            # All Markdown files
       - '**/docs/**'                       # Documentation directory
-      - '.github/workflows/**'             # Ignore all markdown file chanes
+      - '.github/workflows/**'             # Ignore all github workflow file changes
 
   pull_request:
       types:
         - opened
         - reopened
+      paths-ignore:
+        - '**.md'                            # All Markdown files
+        - '**/docs/**'                       # Documentation directory
+        - '.github/workflows/**'             # Ignore all github workflow file changes
 
   release:
     types:


### PR DESCRIPTION
### **Problem** 
The GENIE pipeline depends on a truststore file that was provided by Genome Nexus team and this file would go out of date once every few months. Currently this update is done [manually via this procedure](https://sagebionetworks.jira.com/wiki/spaces/APGD/pages/3016687662/Updating+Genome+Nexus+Annotator+and+Dependencies#Updating-the-trust-ssl-file). 

The issue with manual is that we would get an [error that indicates that all mutation variants got annotated to be `FAILED`](https://sagebionetworks.jira.com/wiki/spaces/APGD/pages/2856943651/GENIE+Pipeline+Troubleshooting#Issue:-Genome-Nexus-annotator-produces-all-failed-annotations), and that was an indicator that the trust file needed updating but often that means we have to go through the entirety of mutation processing (~2 days) before this error gets triggered.

### **Solution** 
This PR will do the following:
1. Update the latest truststore file present [here](https://www.synapse.org/Synapse:syn22053204) - this is scheduled to run every day
2. Run the mutation processing and consortium release steps (should pass both steps without error) on the test pipeline to make sure the update was successful. 

This way we don't have to worry about running into an outdated trustfile while in the middle of processing given the frequency of updates.

### **Testing**
1. Successful test build (update and checking that the update succeeded) is here: https://github.com/Sage-Bionetworks/Genie/actions/runs/13798855778
2. See file update success [here](https://www.synapse.org/Synapse:syn22053204)
