### PR TITLE
[GEN-1954] Add `Transcript_Exon` as new additional maf column

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -83,7 +83,7 @@ WORKDIR /root/
 # Must move this git clone to after the install of Genie,
 # because must update cbioportal
 RUN git clone https://github.com/cBioPortal/cbioportal.git -b v5.3.19
-RUN git clone https://github.com/Sage-Bionetworks/annotation-tools.git -b 0.0.5
+RUN git clone https://github.com/Sage-Bionetworks/annotation-tools.git -b 0.0.6
 
 
 WORKDIR /root/Genie

--- a/genie/process_mutation.py
+++ b/genie/process_mutation.py
@@ -116,6 +116,7 @@ KNOWN_STRING_COLS = [
     "genomic_location_explanation",
     "Annotation_Status",
     "Variant_Classification",
+    "Transcript_Exon",
 ]
 
 


### PR DESCRIPTION
# **Problem:**
A site had a new maf column `Transcript_Exon` in their input maf file that had a mix of mostly numeric with a few string values. Since our maf processing step guesses the data type of the columns by chunks, it [guessed that column to be numeric](https://github.com/Sage-Bionetworks/Genie/blob/90d54c54139a356423681f4bba5aec2b3cdc788c/genie/process_mutation.py#L134-L139) and tried to [convert it to type `float`](https://github.com/Sage-Bionetworks/Genie/blob/90d54c54139a356423681f4bba5aec2b3cdc788c/genie/process_mutation.py#L158) throwing a 
```
ValueError: could not convert string to float: '6-May'
```

Jira Ticket link: [GEN-1954](https://sagebionetworks.jira.com/browse/GEN-1954)

# **Solution:**
We will need to add `Transcript_Exon` to [KNOWN_STRING_COLS](https://github.com/Sage-Bionetworks/Genie/blob/90d54c54139a356423681f4bba5aec2b3cdc788c/genie/process_mutation.py#L91-L119) as it can have string values like `4-5` to allow it to process through with the correct data type.

Depends on [annotation-tools #10](https://github.com/Sage-Bionetworks/annotation-tools/pull/10) and creation of new release `0.0.6` on the repo.

# **Testing:**
1. [input maf file prior to processing](https://www.synapse.org/Synapse:syn52955202.19)
<img width="1377" alt="image" src="https://github.com/user-attachments/assets/14d6f970-03bd-43f5-9b52-7fd00963cfb7" />

2. [center maf file after processing](https://www.synapse.org/Synapse:syn52961563.211)
<img width="1343" alt="image" src="https://github.com/user-attachments/assets/1badebff-dadd-4db1-bb58-480fa1d9788e" />
Values for the `Transcript_Exon` are propagated through

3. [consortium release maf file](https://www.synapse.org/Synapse:syn11608859.428)
<img width="510" alt="image" src="https://github.com/user-attachments/assets/54f16f6f-6985-45ef-a237-9b170fbed1d2" />

No `Transcript_Exon` column present as expected

[GEN-1954]: https://sagebionetworks.jira.com/browse/GEN-1954?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ