### PR TITLE
[GEN-1890,GEN-869] Redact all age columns

### DIFF
--- a/genie/database_to_staging.py
+++ b/genie/database_to_staging.py
@@ -208,6 +208,8 @@ def redact_phi(
     to_redact_year_death = _to_redact_difference(
         clinicaldf["BIRTH_YEAR"], clinicaldf["YEAR_DEATH"]
     )
+
+    # get complete index list to redact
     complete_redact = (
         complete_redact
         | to_redact_birth_year
@@ -217,6 +219,16 @@ def redact_phi(
     # redact all age columns for >89
     clinicaldf.loc[
         complete_redact,
+        ["BIRTH_YEAR", "YEAR_CONTACT", "YEAR_DEATH"] + interval_cols_to_redact,
+    ] = "cannotReleaseHIPAA"
+
+    # get all impacted patient rows
+    patient_ids = clinicaldf.loc[
+        clinicaldf["BIRTH_YEAR"] == "cannotReleaseHIPAA", "PATIENT_ID"
+    ]
+
+    clinicaldf.loc[
+        clinicaldf["PATIENT_ID"].isin(patient_ids),
         ["BIRTH_YEAR", "YEAR_CONTACT", "YEAR_DEATH"] + interval_cols_to_redact,
     ] = "cannotReleaseHIPAA"
 

--- a/genie/database_to_staging.py
+++ b/genie/database_to_staging.py
@@ -152,7 +152,7 @@ def _redact_year(df_col):
 
 # TODO: Add to transform.py
 def _to_redact_difference(df_col_year1, df_col_year2):
-    """Determine if difference between year2 and year1 is > 89 or is < 18
+    """Determine if difference between year2 and year1 is > 89
 
     Args:
         df_col_year1: Dataframe column/pandas.Series of a year column

--- a/genie/database_to_staging.py
+++ b/genie/database_to_staging.py
@@ -159,7 +159,7 @@ def _to_redact_difference(df_col_year1, df_col_year2):
         df_col_year2: Dataframe column/pandas.Series of a year column
 
     Returns:
-        tuple: pandas.Series: to redact boolean vector
+        pandas.Series: to redact boolean vector
 
     """
     # Add in errors='coerce' to turn strings into NaN

--- a/tests/test_database_to_staging.py
+++ b/tests/test_database_to_staging.py
@@ -1206,6 +1206,8 @@ def get_redact_phi_test_cases():
             "name": "no_redaction",
             "input_df": pd.DataFrame(
                 {
+                    "PATIENT_ID": ["a", "a", "c", "d"],
+                    "SAMPLE_ID": ["a", "b", "c", "d"],
                     "BIRTH_YEAR": [1992, 1993, 1992, 1993],
                     "YEAR_CONTACT": [
                         2033,
@@ -1242,6 +1244,8 @@ def get_redact_phi_test_cases():
             ),
             "expected_df": pd.DataFrame(
                 {
+                    "PATIENT_ID": ["a", "a", "c", "d"],
+                    "SAMPLE_ID": ["a", "b", "c", "d"],
                     "BIRTH_YEAR": [1992, 1993, 1992, 1993],
                     "YEAR_CONTACT": [
                         2033,
@@ -1281,46 +1285,62 @@ def get_redact_phi_test_cases():
             "name": "has_column_to_be_redacted",
             "input_df": pd.DataFrame(
                 {
-                    "BIRTH_YEAR": [1992, 1992, 1992, 1992],
+                    "PATIENT_ID": ["a", "b", "c", "d", "e", "e"],  # redact b, d, e
+                    "SAMPLE_ID": ["a", "b", "c", "d", "e", "f"],
+                    "BIRTH_YEAR": [1992, 1992, 1992, 1992, 1992, 1992],
                     "YEAR_CONTACT": [
                         2008,
                         2080,
                         2008,
                         2082,
-                    ],  # difference to BIRTH_YEAR: 16, 88, 16, 90
+                        2080,
+                        2081,
+                    ],  # difference to BIRTH_YEAR: 16, 88, 16, 90, 88, 89
                     "YEAR_DEATH": [
                         2011,
                         2082,
                         2008,
                         2082,
-                    ],  # difference to BIRTH_YEAR: 19, 90, 16, 90
+                        2081,
+                        2081,
+                    ],  # difference to BIRTH_YEAR: 19, 90, 16, 90, 89, 89
                     "AGE_AT_SEQ_REPORT": [
                         6570,
                         32485,
                         5840,
                         32850,
-                    ],  # in years: 18*365, 89*365, 16*365, 90*365
+                        32120,
+                        32485,
+                    ],  # in years: 18*365, 89*365, 16*365, 90*365, 88*365, 89*365
                     "INT_CONTACT": [
                         5841,
                         32121,
                         5841,
                         32851,
-                    ],  # in years: 16*365+1, 88*365+1, 16*365+1, 90*365+1
+                        32121,
+                        32485,
+                    ],  # in years: 16*365+1, 88*365+1, 16*365+1, 90*365+1, 88*365+1, 89*365
                     "INT_DOD": [
                         6935,
                         32850,
                         5840,
                         32850,
-                    ],  # in years: 19*365, 90*365, 16*365, 90*365
-                    "Other_col": ["a", "b", "c", "d"],
+                        32485,
+                        32486,
+                    ],  # in years: 19*365, 90*365, 16*365, 90*365, 89*365, 89*365+1
+                    "Other_col": ["a", "b", "c", "d", "e", "f"],
                 }
             ),
             "expected_df": pd.DataFrame(
                 {
+                    "PATIENT_ID": ["a", "b", "c", "d", "e", "e"],
+                    "SAMPLE_ID": ["a", "b", "c", "d", "e", "f"],
                     "BIRTH_YEAR": [
                         "withheld",
                         "cannotReleaseHIPAA",
                         "withheld",
+                        "cannotReleaseHIPAA",
+                        "cannotReleaseHIPAA",
                         "cannotReleaseHIPAA",
                     ],
                     "YEAR_CONTACT": [
@@ -1328,32 +1348,42 @@ def get_redact_phi_test_cases():
                         "cannotReleaseHIPAA",
                         2008,
                         "cannotReleaseHIPAA",
-                    ],  # difference to BIRTH_YEAR: 16, 88, 16, 90
+                        "cannotReleaseHIPAA",
+                        "cannotReleaseHIPAA",
+                    ],  # difference to BIRTH_YEAR: 16, 88, 16, 90, 88, 89
                     "YEAR_DEATH": [
                         2011,
                         "cannotReleaseHIPAA",
                         2008,
                         "cannotReleaseHIPAA",
-                    ],  # difference to BIRTH_YEAR: 19, 90, 16, 90
+                        "cannotReleaseHIPAA",
+                        "cannotReleaseHIPAA",
+                    ],  # difference to BIRTH_YEAR: 19, 90, 16, 90,  89, 89
                     "AGE_AT_SEQ_REPORT": [
                         6570,
                         "cannotReleaseHIPAA",
                         "<6570",
                         "cannotReleaseHIPAA",
-                    ],  # in years: 18*365, 89*365, 16*365, 90*365
+                        "cannotReleaseHIPAA",
+                        "cannotReleaseHIPAA",
+                    ],  # in years: 18*365, 89*365, 16*365, 90*365, 88*365, 89*365
                     "INT_CONTACT": [
                         "<6570",
                         "cannotReleaseHIPAA",
                         "<6570",
                         "cannotReleaseHIPAA",
-                    ],  # in years: 16*365+1, 88*365+1, 16*365+1, 90*365+1
+                        "cannotReleaseHIPAA",
+                        "cannotReleaseHIPAA",
+                    ],  # in years: 16*365+1, 88*365+1, 16*365+1, 90*365+1, 88*365+1, 89*365
                     "INT_DOD": [
                         6935,
                         "cannotReleaseHIPAA",
                         "<6570",
                         "cannotReleaseHIPAA",
-                    ],  # in years: 19*365, 90*365, 16*365, 90*365
-                    "Other_col": ["a", "b", "c", "d"],
+                        "cannotReleaseHIPAA",
+                        "cannotReleaseHIPAA",
+                    ],  # in years: 19*365, 90*365, 16*365, 90*365, 89*365, 89*365+1
+                    "Other_col": ["a", "b", "c", "d", "e", "f"],
                 }
             ),
         },
@@ -1361,6 +1391,8 @@ def get_redact_phi_test_cases():
             "name": "has_range_values",
             "input_df": pd.DataFrame(
                 {
+                    "PATIENT_ID": ["a", "b", "c", "d"],
+                    "SAMPLE_ID": ["a", "b", "c", "d"],
                     "BIRTH_YEAR": [1992, 1992, 1992, 1992],
                     "YEAR_CONTACT": [
                         "<18",
@@ -1397,6 +1429,8 @@ def get_redact_phi_test_cases():
             ),
             "expected_df": pd.DataFrame(
                 {
+                    "PATIENT_ID": ["a", "b", "c", "d"],
+                    "SAMPLE_ID": ["a", "b", "c", "d"],
                     "BIRTH_YEAR": [
                         "withheld",
                         "cannotReleaseHIPAA",
@@ -1441,6 +1475,8 @@ def get_redact_phi_test_cases():
             "name": "has_NAs",
             "input_df": pd.DataFrame(
                 {
+                    "PATIENT_ID": ["a", "b", "c", "d", "e", "f"],
+                    "SAMPLE_ID": ["a", "b", "c", "d", "e", "f"],
                     "BIRTH_YEAR": [1992, 1992, 1992, 1992, 1993, 1994],
                     "YEAR_CONTACT": [
                         "<18",
@@ -1487,6 +1523,8 @@ def get_redact_phi_test_cases():
             ),
             "expected_df": pd.DataFrame(
                 {
+                    "PATIENT_ID": ["a", "b", "c", "d", "e", "f"],
+                    "SAMPLE_ID": ["a", "b", "c", "d", "e", "f"],
                     "BIRTH_YEAR": [
                         "withheld",
                         "cannotReleaseHIPAA",
@@ -1543,6 +1581,8 @@ def get_redact_phi_test_cases():
             "name": "has_range_in_birth_year",
             "input_df": pd.DataFrame(
                 {
+                    "PATIENT_ID": ["a", "b"],
+                    "SAMPLE_ID": ["a", "b"],
                     "BIRTH_YEAR": ["<18", ">89"],
                     "YEAR_CONTACT": [
                         2011,
@@ -1569,6 +1609,8 @@ def get_redact_phi_test_cases():
             ),
             "expected_df": pd.DataFrame(
                 {
+                    "PATIENT_ID": ["a", "b"],
+                    "SAMPLE_ID": ["a", "b"],
                     "BIRTH_YEAR": [
                         "withheld",
                         "cannotReleaseHIPAA",

--- a/tests/test_database_to_staging.py
+++ b/tests/test_database_to_staging.py
@@ -1172,40 +1172,32 @@ def test__redact_year(input_col, expected_col):
 
 
 @pytest.mark.parametrize(
-    "df_col_year1,df_col_year2, expected_to_redact,expected_to_redact_ped",
+    "df_col_year1,df_col_year2, expected_to_redact",
     [
         (
             pd.Series([1892, 1993, 1993]),
             pd.Series([2033, 2033, 2009]),  # in years: 141, 40, 16
             pd.Series([True, False, False]),
-            pd.Series([False, False, True]),
         ),
         (
             pd.Series(["Not Collected", "Unknown", ">89", "<18"]),
             pd.Series([1992, 1993, 1992, 1993]),
-            pd.Series([False, False, False, False]),
             pd.Series([False, False, False, False]),
         ),
         (
             pd.Series(["Not Collected", np.nan]),
             pd.Series([1992, 1993]),
             pd.Series([False, False]),
-            pd.Series([False, False]),
         ),
     ],
     ids=["numeric_values", "non_numeric_values", "has_NAs"],
 )
-def test_to_redact_difference(
-    df_col_year1, df_col_year2, expected_to_redact, expected_to_redact_ped
-):
+def test_to_redact_difference(df_col_year1, df_col_year2, expected_to_redact):
     # call the function
-    to_redact, to_redact_ped = database_to_staging._to_redact_difference(
-        df_col_year1, df_col_year2
-    )
+    to_redact = database_to_staging._to_redact_difference(df_col_year1, df_col_year2)
 
     # validate the calls
     assert to_redact.equals(expected_to_redact)
-    assert to_redact_ped.equals(expected_to_redact_ped)
 
 
 def get_redact_phi_test_cases():
@@ -1332,33 +1324,33 @@ def get_redact_phi_test_cases():
                         "cannotReleaseHIPAA",
                     ],
                     "YEAR_CONTACT": [
-                        "withheld",
+                        2008,
                         "cannotReleaseHIPAA",
-                        "withheld",
+                        2008,
                         "cannotReleaseHIPAA",
                     ],  # difference to BIRTH_YEAR: 16, 88, 16, 90
                     "YEAR_DEATH": [
-                        "withheld",
+                        2011,
                         "cannotReleaseHIPAA",
-                        "withheld",
+                        2008,
                         "cannotReleaseHIPAA",
                     ],  # difference to BIRTH_YEAR: 19, 90, 16, 90
                     "AGE_AT_SEQ_REPORT": [
-                        "withheld",
+                        6570,
                         "cannotReleaseHIPAA",
-                        "withheld",
+                        "<6570",
                         "cannotReleaseHIPAA",
                     ],  # in years: 18*365, 89*365, 16*365, 90*365
                     "INT_CONTACT": [
-                        "withheld",
+                        "<6570",
                         "cannotReleaseHIPAA",
-                        "withheld",
+                        "<6570",
                         "cannotReleaseHIPAA",
                     ],  # in years: 16*365+1, 88*365+1, 16*365+1, 90*365+1
                     "INT_DOD": [
-                        "withheld",
+                        6935,
                         "cannotReleaseHIPAA",
-                        "withheld",
+                        "<6570",
                         "cannotReleaseHIPAA",
                     ],  # in years: 19*365, 90*365, 16*365, 90*365
                     "Other_col": ["a", "b", "c", "d"],
@@ -1412,33 +1404,33 @@ def get_redact_phi_test_cases():
                         "cannotReleaseHIPAA",
                     ],
                     "YEAR_CONTACT": [
-                        "withheld",
+                        "<18",
                         "cannotReleaseHIPAA",
-                        "withheld",
+                        2008,
                         "cannotReleaseHIPAA",
                     ],  # difference to BIRTH_YEAR: 16, 88, 16, 90
                     "YEAR_DEATH": [
-                        "withheld",
+                        2011,
                         "cannotReleaseHIPAA",
-                        "withheld",
+                        2008,
                         "cannotReleaseHIPAA",
                     ],  # difference to BIRTH_YEAR: 19, 90, 16, 90
                     "AGE_AT_SEQ_REPORT": [
-                        "withheld",
+                        6570,
                         "cannotReleaseHIPAA",
-                        "withheld",
+                        "<6570",
                         "cannotReleaseHIPAA",
                     ],  # in years: 18*365, 89*365, 16*365, 90*365
                     "INT_CONTACT": [
-                        "withheld",
+                        "<6570",
                         "cannotReleaseHIPAA",
-                        "withheld",
+                        "<6570",
                         "cannotReleaseHIPAA",
                     ],  # in years: 16*365+1, 88*365+1, 16*365+1, 90*365+1
                     "INT_DOD": [
-                        "withheld",
+                        6935,
                         "cannotReleaseHIPAA",
-                        "withheld",
+                        "<6570",
                         "cannotReleaseHIPAA",
                     ],  # in years: 19*365, 90*365, 16*365, 90*365
                     "Other_col": ["a", "b", "c", "d"],
@@ -1504,41 +1496,41 @@ def get_redact_phi_test_cases():
                         1994,
                     ],
                     "YEAR_CONTACT": [
-                        "withheld",
+                        "<18",
                         "cannotReleaseHIPAA",
-                        "withheld",
+                        2008,
                         "cannotReleaseHIPAA",
                         2023,
                         np.nan,
                     ],  # difference to BIRTH_YEAR: 16, 88, 16, 90, 30
                     "YEAR_DEATH": [
-                        "withheld",
+                        2011,
                         "cannotReleaseHIPAA",
-                        "withheld",
+                        2008,
                         "cannotReleaseHIPAA",
                         2025,
                         2025,
                     ],  # difference to BIRTH_YEAR: 19, 90, 16, 90, 32, 31
                     "AGE_AT_SEQ_REPORT": [
-                        "withheld",
+                        6570,
                         "cannotReleaseHIPAA",
-                        "withheld",
+                        "<6570",
                         "cannotReleaseHIPAA",
                         11315,
                         np.nan,
                     ],  # in years: 18*365, 89*365, 16*365, 90*365, 31*365
                     "INT_CONTACT": [
-                        "withheld",
+                        "<6570",
                         "cannotReleaseHIPAA",
-                        "withheld",
+                        "<6570",
                         "cannotReleaseHIPAA",
                         10951,
                         np.nan,
                     ],  # in years: 16*365+1, 88*365+1, 16*365+1, 90*365+1, 30*365+1
                     "INT_DOD": [
-                        "withheld",
+                        6935,
                         "cannotReleaseHIPAA",
-                        "withheld",
+                        "<6570",
                         "cannotReleaseHIPAA",
                         11680,
                         11315,
@@ -1551,7 +1543,7 @@ def get_redact_phi_test_cases():
             "name": "has_range_in_birth_year",
             "input_df": pd.DataFrame(
                 {
-                    "BIRTH_YEAR": ["<16", ">89"],
+                    "BIRTH_YEAR": ["<18", ">89"],
                     "YEAR_CONTACT": [
                         2011,
                         2010,
@@ -1582,23 +1574,23 @@ def get_redact_phi_test_cases():
                         "cannotReleaseHIPAA",
                     ],
                     "YEAR_CONTACT": [
-                        "withheld",
+                        2011,
                         "cannotReleaseHIPAA",
                     ],
                     "YEAR_DEATH": [
-                        "withheld",
+                        2013,
                         "cannotReleaseHIPAA",
                     ],
                     "AGE_AT_SEQ_REPORT": [
-                        "withheld",
+                        np.nan,
                         "cannotReleaseHIPAA",
                     ],
                     "INT_CONTACT": [
-                        "withheld",
+                        np.nan,
                         "cannotReleaseHIPAA",
                     ],
                     "INT_DOD": [
-                        "withheld",
+                        np.nan,
                         "cannotReleaseHIPAA",
                     ],
                     "Other_col": ["a", "b"],

--- a/tests/test_database_to_staging.py
+++ b/tests/test_database_to_staging.py
@@ -6,6 +6,7 @@ import subprocess
 from unittest import mock
 from unittest.mock import patch
 
+import numpy as np
 import pandas as pd
 import pytest
 import synapseclient
@@ -1045,3 +1046,331 @@ def test_store_data_gene_matrix(syn, wes_seqassayids, expected_output):
         pd.testing.assert_frame_equal(
             data_gene_matrix.reset_index(drop=True), expected_output
         )
+
+@pytest.mark.parametrize(
+    "input_col,expected_to_redact_vector,expected_to_redact_pediatric_vector",
+    [
+        (
+            pd.Series(
+                [4380, 23725, 32120, 33215] # in years: 12, 65, 88, 91, 
+            ),
+            pd.Series(
+                [False, False, False, True]
+            ),
+            pd.Series(
+                [True, False, False, False]
+            )
+        ),
+        (
+            pd.Series(
+                [6570, 32485] # in years: 18, 89
+            ),
+            pd.Series(
+                [False, False]
+            ),
+            pd.Series(
+                [False, False]
+            )
+        ),
+        (
+            pd.Series(
+                [">32485", "<6570", "Not Collected", "Unknown", "Not Applicable"] # in years: ">89", "<18"
+            ),
+            pd.Series(
+                [True, False, False, False, False]
+            ),
+            pd.Series(
+                [False, True, False, False, False]
+            )
+        ),
+        (
+            pd.Series(
+                [">32485", "<6570", "Not Collected", "Unknown", "Not Applicable", np.nan] # in years: ">89", "<18"
+            ),
+            pd.Series(
+                [True, False, False, False, False, False]
+            ),
+            pd.Series(
+                [False, True, False, False, False, False]
+            )
+        ),
+         
+    ],
+    ids=["no_cutoff_value", "has_cutoff_value", "non_numeric_values", "has_NAs"],
+)
+def test_to_redact_interval(input_col, expected_to_redact_vector, expected_to_redact_pediatric_vector):
+    # call the function
+    to_redact, to_redact_pediatric = database_to_staging._to_redact_interval(input_col)
+
+    # validate the calls
+    assert to_redact.equals(expected_to_redact_vector)
+    assert to_redact_pediatric.equals(expected_to_redact_pediatric_vector)
+    
+@pytest.mark.parametrize(
+    "input_col,expected_col",
+    [
+        (
+            pd.Series(
+                [4380, 23725, 32120, 33215, 32485, 6570] # in years: 12, 65, 88, 91, 89, 18 
+            ),
+            pd.Series(
+                [4380, 23725, 32120, 33215, 32485, 6570]
+            )
+        ),
+        (
+            pd.Series(
+                [">32485", "<6570", "Not Collected", "Unknown", "Not Applicable"] # in years: ">89", "<18"
+            ),
+            pd.Series(
+                ["cannotReleaseHIPAA", "withheld", "Not Collected", "Unknown", "Not Applicable"]
+            )
+        ),
+        (
+            pd.Series(
+                [">32485", "<6570", "Not Collected", "Unknown", "Not Applicable", np.nan] # in years: ">89", "<18"
+            ),
+            pd.Series(
+                ["cannotReleaseHIPAA", "withheld", "Not Collected", "Unknown", "Not Applicable", np.nan]
+            )
+        ),
+         
+    ],
+    ids=["numeric_values", "non_numeric_values", "has_NAs"],
+)   
+def test__redact_year(input_col, expected_col):
+    # call the function
+    output = database_to_staging._redact_year(input_col)
+
+    # validate the calls
+    assert output.equals(expected_col)
+
+@pytest.mark.parametrize(
+    "df_col_year1,df_col_year2, expected_vector",
+    [
+        (
+            pd.Series(
+                [1892, 1993] 
+            ),
+            pd.Series(
+                [2033, 2033]
+            ),
+            pd.Series(
+                [True, False] 
+            ),
+
+        ),
+        (
+            pd.Series(
+                ["Not Collected", "Unknown", ">89", "<18"]
+            ),
+            pd.Series(
+                [1992, 1993, 1992, 1993]
+            ),
+            pd.Series(
+                [False, False, False, False] 
+            ),
+        ),
+        (
+            pd.Series(
+                ["Not Collected", np.nan]
+            ),
+            pd.Series(
+                [1992, 1993]
+            ),
+            pd.Series(
+                [False, False] 
+            ),
+        ),
+         
+    ],
+    ids=["numeric_values", "non_numeric_values", "has_NAs"],
+)   
+def test_to_redact_difference(df_col_year1, df_col_year2, expected_vector):
+    # call the function
+    to_redact = database_to_staging._to_redact_difference(df_col_year1, df_col_year2)
+
+    # validate the calls
+    assert to_redact.equals(expected_vector)
+
+@pytest.mark.parametrize(
+    "input_df,expected_df",
+    [
+        (
+            pd.DataFrame(
+                {
+                    "BIRTH_YEAR": [1992, 1993, 1992, 1993],
+                    "YEAR_CONTACT": [2033, 2030, 2010, 2082], # difference to BIRTH_YEAR: 41, 37, 18, 89
+                    "YEAR_DEATH": [2044, 2047, 2012, 2082], # difference to BIRTH_YEAR: 52, 54, 20, 89
+                    "AGE_AT_SEQ_REPORT": [13870, 17885, 6935, 32485], # in years 38*365, 49*365, 19*365, 89*365
+                    "INT_CONTACT": [14966, 13506, 6571, 32485], # in years: 41*365+1, 37*365+1, 18*365+1, 89*365
+                    "INT_DOD": [18981, 19712, 7300, 32485], # in years: 52*365+1, 54*365+2, 20*365, 89*365
+                    "Other_col": ["a", "b", "c", "d"],
+                }
+                ),
+            pd.DataFrame(
+                {
+                    "BIRTH_YEAR": [1992, 1993, 1992, 1993],
+                    "YEAR_CONTACT": [2033, 2030, 2010, 2082], # difference to BIRTH_YEAR: 41, 37, 18, 89
+                    "YEAR_DEATH": [2044, 2047, 2012, 2082], # difference to BIRTH_YEAR: 52, 54, 20, 89
+                    "AGE_AT_SEQ_REPORT": [13870, 17885, 6935, 32485], # in years 38*365, 49*365, 19*365, 89*365
+                    "INT_CONTACT": [14966, 13506, 6571, 32485], # in years: 41*365+1, 37*365+1, 18*365+1, 89*365
+                    "INT_DOD": [18981, 19712, 7300, 32485], # in years: 52*365+1, 54*365+2, 20*365, 89*365
+                    "Other_col": ["a", "b", "c", "d"],
+                }
+                ),
+        ),
+        (
+            pd.DataFrame(
+                {
+                    "BIRTH_YEAR": [1992, 1992, 1992, 1992],
+                    "YEAR_CONTACT": [2008, 2080, 2008, 2082], # difference to BIRTH_YEAR: 16, 88, 16, 90
+                    "YEAR_DEATH": [2011, 2082, 2008, 2082], # difference to BIRTH_YEAR: 19, 90, 16, 90
+                    "AGE_AT_SEQ_REPORT": [6570, 32485, 5840, 32850], # in years: 18*365, 89*365, 16*365, 90*365
+                    "INT_CONTACT": [5841, 32121, 5841, 32851], # in years: 16*365+1, 88*365+1, 16*365+1, 90*365+1
+                    "INT_DOD": [6935, 32850, 5840, 32850], # in years: 19*365, 90*365, 16*365, 90*365
+                    "Other_col": ["a", "b", "c", "d"],
+                }
+
+        ),
+            pd.DataFrame(
+                {
+                    "BIRTH_YEAR": ["withheld", "cannotReleaseHIPAA", "withheld", "cannotReleaseHIPAA"],
+                    "YEAR_CONTACT": [2008, 2080, 2008, 2082], # difference to BIRTH_YEAR: 16, 88, 16, 90
+                    "YEAR_DEATH": [2011, 2082, 2008, 2082], # difference to BIRTH_YEAR: 19, 90, 16, 90
+                    "AGE_AT_SEQ_REPORT": [6570, 32485, "<6570", ">32485"],  # in years: 18*365, 89*365, 16*365, 90*365
+                    "INT_CONTACT": ["<6570", 32121, "<6570", ">32485"], # in years: 16*365+1, 88*365+1, 16*365+1, 90*365+1
+                    "INT_DOD": [6935, ">32485", "<6570", ">32485"], # in years: 19*365, 90*365, 16*365, 90*365
+                    "Other_col": ["a", "b", "c", "d"],
+                }
+
+        ),
+        ),
+        (
+            pd.DataFrame(
+                {
+                    "BIRTH_YEAR": [1992, 1992, 1992, 1992],
+                    "YEAR_CONTACT": ["<18", 2080, 2008, 2082], # difference to BIRTH_YEAR: 16, 88, 16, 90
+                    "YEAR_DEATH": [2011, ">89", 2008, 2082], # difference to BIRTH_YEAR: 19, 90, 16, 90
+                    "AGE_AT_SEQ_REPORT": [6570, 32485, "<6570", ">32485"], # in years: 18*365, 89*365, 16*365, 90*365
+                    "INT_CONTACT": ["<6570", 32121, 5841, 32851], # in years: 16*365+1, 88*365+1, 16*365+1, 90*365+1
+                    "INT_DOD": [6935, ">32485", 5840, 32850], # in years: 19*365, 90*365, 16*365, 90*365
+                    "Other_col": ["a", "b", "c", "d"],
+                }
+
+        ),
+            pd.DataFrame(
+                {
+                    "BIRTH_YEAR": ["withheld", "cannotReleaseHIPAA", "withheld", "cannotReleaseHIPAA"],
+                    "YEAR_CONTACT": ["<18", 2080, 2008, 2082], # difference to BIRTH_YEAR: 16, 88, 16, 90
+                    "YEAR_DEATH": [2011, ">89", 2008, 2082], # difference to BIRTH_YEAR: 19, 90, 16, 90
+                    "AGE_AT_SEQ_REPORT": [6570, 32485, "<6570", ">32485"],  # in years: 18*365, 89*365, 16*365, 90*365
+                    "INT_CONTACT": ["<6570", 32121, "<6570", ">32485"], # in years: 16*365+1, 88*365+1, 16*365+1, 90*365+1
+                    "INT_DOD": [6935, ">32485", "<6570", ">32485"], # in years: 19*365, 90*365, 16*365, 90*365
+                    "Other_col": ["a", "b", "c", "d"],
+                }
+
+        ),
+        ),
+         
+         
+    ],
+    ids=["no_redaction", "has_column_to_be_redacted", "has_range_values"],
+)   
+def test_redact_phi(input_df, expected_df):
+    # call the function
+    output = database_to_staging.redact_phi(input_df)
+
+    # validate_calss
+    assert_frame_equal(output, expected_df, check_dtype=False)
+
+
+@pytest.mark.parametrize(
+    "input_df,expected_df",
+    [
+        (
+            pd.DataFrame(
+                {
+                    "BIRTH_YEAR": [1992, 1993, 1992, 1993],
+                    "YEAR_CONTACT": [2033, 2030, 2010, 2082], # difference to BIRTH_YEAR: 41, 37, 18, 89
+                    "YEAR_DEATH": [2044, 2047, 2012, 2082], # difference to BIRTH_YEAR: 52, 54, 20, 89
+                    "AGE_AT_SEQ_REPORT": [13870, 17885, 6935, 32485], # in years 38*365, 49*365, 19*365, 89*365
+                    "INT_CONTACT": [14966, 13506, 6571, 32485], # in years: 41*365+1, 37*365+1, 18*365+1, 89*365
+                    "INT_DOD": [18981, 19712, 7300, 32485], # in years: 52*365+1, 54*365+2, 20*365, 89*365
+                    "Other_col": ["a", "b", "c", "d"],
+                }
+                ),
+            pd.DataFrame(
+                {
+                    "BIRTH_YEAR": [1992, 1993, 1992, 1993],
+                    "YEAR_CONTACT": [2033, 2030, 2010, 2082], # difference to BIRTH_YEAR: 41, 37, 18, 89
+                    "YEAR_DEATH": [2044, 2047, 2012, 2082], # difference to BIRTH_YEAR: 52, 54, 20, 89
+                    "AGE_AT_SEQ_REPORT": [13870, 17885, 6935, 32485], # in years 38*365, 49*365, 19*365, 89*365
+                    "INT_CONTACT": [14966, 13506, 6571, 32485], # in years: 41*365+1, 37*365+1, 18*365+1, 89*365
+                    "INT_DOD": [18981, 19712, 7300, 32485], # in years: 52*365+1, 54*365+2, 20*365, 89*365
+                    "Other_col": ["a", "b", "c", "d"],
+                }
+                ),
+        ),
+        (
+            pd.DataFrame(
+                {
+                    "BIRTH_YEAR": [1992, 1992, 1992, 1992],
+                    "YEAR_CONTACT": [2008, 2080, 2008, 2082], # difference to BIRTH_YEAR: 16, 88, 16, 90
+                    "YEAR_DEATH": [2011, 2082, 2008, 2082], # difference to BIRTH_YEAR: 19, 90, 16, 90
+                    "AGE_AT_SEQ_REPORT": [6570, 32485, 5840, 32850], # in years: 18*365, 89*365, 16*365, 90*365
+                    "INT_CONTACT": [5841, 32121, 5841, 32851], # in years: 16*365+1, 88*365+1, 16*365+1, 90*365+1
+                    "INT_DOD": [6935, 32850, 5840, 32850], # in years: 19*365, 90*365, 16*365, 90*365
+                    "Other_col": ["a", "b", "c", "d"],
+                }
+
+        ),
+            pd.DataFrame(
+                {
+                    "BIRTH_YEAR": ["withheld", "cannotReleaseHIPAA", "withheld", "cannotReleaseHIPAA"],
+                    "YEAR_CONTACT": ["withheld", "cannotReleaseHIPAA", "withheld", "cannotReleaseHIPAA"], # difference to BIRTH_YEAR: 16, 88, 16, 90
+                    "YEAR_DEATH": ["withheld", "cannotReleaseHIPAA", "withheld", "cannotReleaseHIPAA"], # difference to BIRTH_YEAR: 19, 90, 16, 90
+                    "AGE_AT_SEQ_REPORT": ["withheld", "cannotReleaseHIPAA", "<6570", ">32485"],  # in years: 18*365, 89*365, 16*365, 90*365
+                    "INT_CONTACT": ["<6570", "cannotReleaseHIPAA", "<6570", ">32485"], # in years: 16*365+1, 88*365+1, 16*365+1, 90*365+1
+                    "INT_DOD": ["withheld", ">32485", "<6570", ">32485"], # in years: 19*365, 90*365, 16*365, 90*365
+                    "Other_col": ["a", "b", "c", "d"],
+                }
+
+        ),
+        ),
+        (
+            pd.DataFrame(
+                {
+                    "BIRTH_YEAR": [1992, 1992, 1992, 1992],
+                    "YEAR_CONTACT": ["<18", 2080, 2008, 2082], # difference to BIRTH_YEAR: 16, 88, 16, 90
+                    "YEAR_DEATH": [2011, ">89", 2008, 2082], # difference to BIRTH_YEAR: 19, 90, 16, 90
+                    "AGE_AT_SEQ_REPORT": [6570, 32485, "<6570", ">32485"], # in years: 18*365, 89*365, 16*365, 90*365
+                    "INT_CONTACT": ["<6570", 32121, 5841, 32851], # in years: 16*365+1, 88*365+1, 16*365+1, 90*365+1
+                    "INT_DOD": [6935, ">32485", 5840, 32850], # in years: 19*365, 90*365, 16*365, 90*365
+                    "Other_col": ["a", "b", "c", "d"],
+                }
+
+        ),
+            pd.DataFrame(
+                {
+                    "BIRTH_YEAR": ["withheld", "cannotReleaseHIPAA", "withheld", "cannotReleaseHIPAA"],
+                    "YEAR_CONTACT": ["<18", "cannotReleaseHIPAA", "withheld", "cannotReleaseHIPAA"], # difference to BIRTH_YEAR: 16, 88, 16, 90
+                    "YEAR_DEATH": ["withheld", ">89", "withheld", "cannotReleaseHIPAA"], # difference to BIRTH_YEAR: 19, 90, 16, 90
+                    "AGE_AT_SEQ_REPORT": ["withheld", "cannotReleaseHIPAA", "<6570", ">32485"],  # in years: 18*365, 89*365, 16*365, 90*365
+                    "INT_CONTACT": ["<6570", "cannotReleaseHIPAA", "<6570", ">32485"], # in years: 16*365+1, 88*365+1, 16*365+1, 90*365+1
+                    "INT_DOD": ["withheld", ">32485", "<6570", ">32485"], # in years: 19*365, 90*365, 16*365, 90*365
+                    "Other_col": ["a", "b", "c", "d"],
+                }
+
+        ),
+        ),
+         
+         
+    ],
+    ids=["no_redaction", "has_column_to_be_redacted", "has_range_values"],
+)   
+def test_redact_phi_new(input_df, expected_df):
+    # call the function
+    output = database_to_staging.redact_phi_new(input_df)
+
+    # validate_calss
+    assert_frame_equal(output, expected_df, check_dtype=False)

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -10,10 +10,14 @@ from unittest.mock import patch
 import pandas as pd
 from genie import database_to_staging
 from genie.consortium_to_public import commonVariantFilter
-from genie.database_to_staging import (_redact_year, _to_redact_difference,
-                                       _to_redact_interval,
-                                       no_genepanel_filter, redact_phi,
-                                       seq_assay_id_filter)
+from genie.database_to_staging import (
+    _redact_year,
+    _to_redact_difference,
+    _to_redact_interval,
+    no_genepanel_filter,
+    redact_phi,
+    seq_assay_id_filter,
+)
 from genie.process_functions import seqDateFilter
 
 SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
@@ -119,6 +123,7 @@ def test_seqdatefilter():
     processingDate = datetime.datetime.strptime(SEQ_DATE, "%b-%Y")
     samples = seqDateFilter(clinicalDf, processingDate, 184)
     assert all(samples == expected)
+
 
 # def test_MAFinBED():
 #   syn = mock.create_autospec(synapseclient.Synapse)


### PR DESCRIPTION
# **Problem:**

Currently, 

1. BIRTH_YEAR is always redacted when the difference between BIRTH_YEAR and YEAR_CONTACT or YEAR_DEATH exceeds 89 years (or 32,485 days) or less than 18 years AND when AGE_AT_SEQ_REPORT, INT_CONTACT, INT_DOD greater than 32485 or less than 6570 or have < or > in the value.
2. YEAR_CONTACT and YEAR_DEATH are never redacted. 
3. AGE_AT_SEQ_REPORT, INT_CONTACT, INT_DOD are redacted when they are greater than 32485 or less than 6570 or have < or > in the value.

However, we want to all age variables are redacted if ONE variable in a sample/patient is flagged to be over 89.

# **Solution:**

Bind the boolean vector indicating which field to be redacted for all age column checks and replace actual values with redacted label: `cannotReleaseHIPAA` and `withheld`.

# **Testing:**

Unit tests have been added. 