### PR TITLE
[GEN-1953] save maf table to prod

### DIFF
--- a/bin/input_to_database.py
+++ b/bin/input_to_database.py
@@ -6,13 +6,8 @@ import argparse
 import logging
 from datetime import date
 
-from genie import (
-    config,
-    extract,
-    input_to_database,
-    process_functions,
-    write_invalid_reasons,
-)
+from genie import (config, extract, input_to_database, process_functions,
+                   write_invalid_reasons)
 
 logger = logging.getLogger(__name__)
 
@@ -104,7 +99,7 @@ def main(
         # filetype = "vcf2maf"
         # save maf table to production project
         new_tables = process_functions.create_new_fileformat_table(
-            syn, "vcf2maf", table_name, project_id, "syn3380222"
+            syn, "vcf2maf", table_name, project_id, project_id
         )
         syn.setPermissions(new_tables["newdb_ent"].id, 3326313, [])
         genie_config["vcf2maf"] = new_tables["newdb_ent"].id

--- a/bin/input_to_database.py
+++ b/bin/input_to_database.py
@@ -102,7 +102,7 @@ def main(
         today = date.today()
         table_name = f"Narrow MAF Database - {today}"
         # filetype = "vcf2maf"
-        # save maf table to production project
+        # save maf table to testing or production project as the mode
         new_tables = process_functions.create_new_fileformat_table(
             syn, "vcf2maf", table_name, project_id, project_id
         )

--- a/bin/input_to_database.py
+++ b/bin/input_to_database.py
@@ -3,8 +3,8 @@
 
 """
 import argparse
-from datetime import date
 import logging
+from datetime import date
 
 from genie import (
     config,
@@ -102,9 +102,9 @@ def main(
         today = date.today()
         table_name = f"Narrow MAF Database - {today}"
         # filetype = "vcf2maf"
-        # syn7208886 is the GENIE staging project to archive maf table
+        # save maf table to production project
         new_tables = process_functions.create_new_fileformat_table(
-            syn, "vcf2maf", table_name, project_id, "syn7208886"
+            syn, "vcf2maf", table_name, project_id, "syn3380222"
         )
         syn.setPermissions(new_tables["newdb_ent"].id, 3326313, [])
         genie_config["vcf2maf"] = new_tables["newdb_ent"].id

--- a/bin/input_to_database.py
+++ b/bin/input_to_database.py
@@ -6,8 +6,13 @@ import argparse
 import logging
 from datetime import date
 
-from genie import (config, extract, input_to_database, process_functions,
-                   write_invalid_reasons)
+from genie import (
+    config,
+    extract,
+    input_to_database,
+    process_functions,
+    write_invalid_reasons,
+)
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
# **Problem:**

During MAF processing, we generate a new MAF table and attempt to move it to the GENIE Testing project, which has more limited permissions. However, due to the new permission restrictions, this operation fails when transferring the entity from a project with more restrictive access to one with less restrictive access.

# **Solution:**

Update parent ID for table saving section. 
