### PR TITLE
[GEN-2001] Set timeout for maf table upload

### DIFF
--- a/genie/process_mutation.py
+++ b/genie/process_mutation.py
@@ -197,6 +197,9 @@ def process_mutation_workflow(
         Annotated Maf Path. None if there are no valid mutation files.
 
     """
+    # setting maf table upload timeout time
+    syn.table_query_timeout = 50000
+
     # Get valid files
     mutation_files = validfiles["fileType"].isin(["maf", "vcf"])
     valid_mutation_files = validfiles["path"][mutation_files].tolist()


### PR DESCRIPTION
# **Problem:**
We are running into a `synapseclient.core.exceptions.SynapseTimeoutError` of ~615 seconds when we query our maf table in the [split_and_store_maf code](https://github.com/Sage-Bionetworks/Genie/blob/5d9bb31da3c744a376dae5bd2a1b2ae97dcdfffd/genie/process_mutation.py#L466). This is likely unavoidable as our maf table gets larger and larger as we get more and more variants.

# **Solution:**
Temp solution is to update the timeout query time for the synapse client connection before the maf table queries. This is mirroring previous solution stated [here](https://sagebionetworks.jira.com/browse/GEN-2001?focusedCommentId=250863). There was talk of a long term configurable timeout for perhaps the synapse table query.

# **Testing:**
- [Test run on process maf successful](https://github.com/Sage-Bionetworks/Genie/actions/runs/15171477275/job/42698444794). 