### PR TITLE
[GEN-2027] Add staging for mutation in cis

### DIFF
--- a/R/mergeCheck.R
+++ b/R/mergeCheck.R
@@ -9,8 +9,8 @@ parser$add_argument("--staging",
                     action = "store_true",
                     help = "Use staging files")
 args <- parser$parse_args()
-testing <- args$testing
-staging <- args$staging
+testing <- as.logical(args$testing)
+staging <- as.logical(args$staging)
 
 library(synapser)
 library(VariantAnnotation)
@@ -39,13 +39,10 @@ variant_limit = 100000
 tbl_size_limit = 500
 
 #testing = as.logical(args[1])
-if (testing) {
-  databaseSynIdMappingId = 'syn11600968'
-} else if (staging) {
-  databaseSynIdMappingId = 'syn12094210'
-} else {
-  databaseSynIdMappingId = 'syn10967259'
-}
+databaseSynIdMappingId <- get_database_to_synapse_mapping_synid(
+  testing=testing, staging=staging
+)
+
 databaseSynIdMapping = synTableQuery(sprintf('select * from %s', databaseSynIdMappingId),
                                      includeRowIdAndRowVersion = F)
 databaseSynIdMappingDf = synapser::as.data.frame(databaseSynIdMapping)

--- a/R/mergecheck_functions.R
+++ b/R/mergecheck_functions.R
@@ -3,9 +3,9 @@
 #' @param testing (logical) running in testing mode
 #' @param staging (logical) running in staging mode
 get_database_to_synapse_mapping_synid <- function(testing, staging){
-  if (testing) {
+  if (testing && !staging) {
     databaseSynIdMappingId = 'syn11600968'
-  } else if (staging) {
+  } else if (staging && !testing) {
     databaseSynIdMappingId = 'syn12094210'
   } else if (staging && testing) {
     stop("Mutation in cis only available in staging or testing mode not both")

--- a/R/mergecheck_functions.R
+++ b/R/mergecheck_functions.R
@@ -1,3 +1,20 @@
+#' Gets the database to synapse mapping table's synapse id based on
+#' if running in production, testing or staging mode
+#' @param testing (logical) running in testing mode
+#' @param staging (logical) running in staging mode
+get_database_to_synapse_mapping_synid <- function(testing, staging){
+  if (testing) {
+    databaseSynIdMappingId = 'syn11600968'
+  } else if (staging) {
+    databaseSynIdMappingId = 'syn12094210'
+  } else if (staging && testing) {
+    stop("Mutation in cis only available in staging or testing mode not both")
+  } else {
+    databaseSynIdMappingId = 'syn10967259'
+  }
+  return(databaseSynIdMappingId)
+}
+
 # Update mutation in cis table
 uploadToTable <- function(tbl, databaseSynId, subSetSamples, centerMappingDf) {
   # Old samples

--- a/R/tests/testthat/test_mergecheck_functions.R
+++ b/R/tests/testthat/test_mergecheck_functions.R
@@ -1,0 +1,35 @@
+# tests for mergecheck_functions.R
+
+source("../../mergecheck_functions.R")
+
+library(testthat)
+
+
+test_that("get_database_to_synapse_mapping_synid_gets_correct_synid_for_testing", {
+  result <- get_database_to_synapse_mapping_synid(
+    testing = TRUE, staging = FALSE
+  )
+  expect_equal(result, "syn11600968")
+})
+
+test_that("get_database_to_synapse_mapping_synid_gets_correct_synid_for_staging", {
+  result <- get_database_to_synapse_mapping_synid(
+    testing = FALSE, staging = TRUE
+  )
+  expect_equal(result, "syn12094210")
+})
+
+test_that("get_database_to_synapse_mapping_synid_gets_correct_synid_for_prod", {
+  result <- get_database_to_synapse_mapping_synid(
+    testing = FALSE, staging = FALSE
+  )
+  expect_equal(result, "syn7208886")
+})
+
+test_that("get_database_to_synapse_mapping_synid_throws_error", {
+  expect_error(get_database_to_synapse_mapping_synid(testing = TRUE, staging = TRUE), 
+    "Mutation in cis only available in staging or testing mode not both")
+})
+
+
+

--- a/R/tests/testthat/test_mergecheck_functions.R
+++ b/R/tests/testthat/test_mergecheck_functions.R
@@ -23,7 +23,7 @@ test_that("get_database_to_synapse_mapping_synid_gets_correct_synid_for_prod", {
   result <- get_database_to_synapse_mapping_synid(
     testing = FALSE, staging = FALSE
   )
-  expect_equal(result, "syn7208886")
+  expect_equal(result, "syn10967259")
 })
 
 test_that("get_database_to_synapse_mapping_synid_throws_error", {


### PR DESCRIPTION
# **Problem:**
Staging is currently run with the [mutation in cis process](https://sagebionetworks.jira.com/wiki/spaces/APGD/pages/3976691723/Mutation+in+CIS+Process+WIP) disabled. This creates a discrepancy when comparing staging and production runs on the same data as production runs will often have a lot more variants filtered out compared to staging. 

See [background process](https://sagebionetworks.jira.com/wiki/spaces/APGD/pages/3976691723/Mutation+in+CIS+Process+WIP)

# **Solution:**
Staging is enabled when running mutation in cis process. 

# **Testing:**
- Unit tests are written to test that staging is called as expected
- Ran on testing pipeline to ensure no changes are present
- Real test is after merging, running staging on `develop` branch