### PR TITLE
[GEN-2094] Use customized _copyRecursive to enable to copy files with AR

### DIFF
--- a/genie/consortium_to_public.py
+++ b/genie/consortium_to_public.py
@@ -5,6 +5,7 @@ import os
 import sys
 
 import pandas as pd
+import synapseclient
 import synapseutils
 from genie import (
     create_case_lists,
@@ -13,11 +14,15 @@ from genie import (
     load,
     process_functions,
 )
+from synapseclient import Entity, File, Folder, Link, Project, Schema
 
 logger = logging.getLogger(__name__)
 stdout_handler = logging.StreamHandler(stream=sys.stdout)
 stdout_handler.setLevel(logging.INFO)
 logger.addHandler(stdout_handler)
+from typing import Dict
+
+import synapseutils as synu
 
 
 # TODO: Add to transform.py
@@ -32,6 +37,131 @@ def commonVariantFilter(mafDf):
     to_keep = ["common_variant" not in i for i in mafDf["FILTER"]]
     mafDf = mafDf[to_keep]
     return mafDf
+
+
+def _copyRecursive(
+    syn: synapseclient.Synapse,
+    entity: str,
+    destinationId: str,
+    mapping: Dict[str, str] = None,
+    skipCopyAnnotations: bool = False,
+    **kwargs,
+) -> Dict[str, str]:
+    """
+    NOTE: This is a copy of the function found here: https://github.com/Sage-Bionetworks/synapsePythonClient/blob/develop/synapseutils/copy_functions.py#L409
+    This was copied because there is a restriction that doesn't allow for copying entities with access requirements
+
+    Recursively copies synapse entites, but does not copy the wikis
+
+    Arguments:
+        syn: A Synapse object with user's login
+        entity: A synapse entity ID
+        destinationId: Synapse ID of a folder/project that the copied entity is being copied to
+        mapping: A mapping of the old entities to the new entities
+        skipCopyAnnotations: Skips copying the annotations
+                                Default is False
+
+    Returns:
+        a mapping between the original and copied entity: {'syn1234':'syn33455'}
+    """
+
+    version = kwargs.get("version", None)
+    setProvenance = kwargs.get("setProvenance", "traceback")
+    excludeTypes = kwargs.get("excludeTypes", [])
+    updateExisting = kwargs.get("updateExisting", False)
+    if mapping is None:
+        mapping = dict()
+    # Check that passed in excludeTypes is file, table, and link
+    if not isinstance(excludeTypes, list):
+        raise ValueError("Excluded types must be a list")
+    elif not all([i in ["file", "link", "table"] for i in excludeTypes]):
+        raise ValueError(
+            "Excluded types can only be a list of these values: file, table, and link"
+        )
+
+    ent = syn.get(entity, downloadFile=False)
+    if ent.id == destinationId:
+        raise ValueError("destinationId cannot be the same as entity id")
+
+    if (isinstance(ent, Project) or isinstance(ent, Folder)) and version is not None:
+        raise ValueError("Cannot specify version when copying a project of folder")
+
+    if not isinstance(ent, (Project, Folder, File, Link, Schema, Entity)):
+        raise ValueError("Not able to copy this type of file")
+
+    permissions = syn.restGET("/entity/{}/permissions".format(ent.id))
+    # Don't copy entities without DOWNLOAD permissions
+    if not permissions["canDownload"]:
+        syn.logger.warning(
+            "%s not copied - this file lacks download permission" % ent.id
+        )
+        return mapping
+
+    # HACK: These lines of code were removed to allow for data with access requirements to be copied
+    # https://github.com/Sage-Bionetworks/synapsePythonClient/blob/2909fa778e814f62f6fe6ce2d951ce58c0080a4e/synapseutils/copy_functions.py#L464-L470
+
+    copiedId = None
+
+    if isinstance(ent, Project):
+        project = syn.get(destinationId)
+        if not isinstance(project, Project):
+            raise ValueError(
+                "You must give a destinationId of a new project to copy projects"
+            )
+        copiedId = destinationId
+        # Projects include Docker repos, and Docker repos cannot be copied
+        # with the Synapse rest API. Entity views currently also aren't
+        # supported
+        entities = syn.getChildren(
+            entity, includeTypes=["folder", "file", "table", "link"]
+        )
+        for i in entities:
+            mapping = _copyRecursive(
+                syn,
+                i["id"],
+                destinationId,
+                mapping=mapping,
+                skipCopyAnnotations=skipCopyAnnotations,
+                **kwargs,
+            )
+
+        if not skipCopyAnnotations:
+            project.annotations = ent.annotations
+            syn.store(project)
+    elif isinstance(ent, Folder):
+        copiedId = synu.copy_functions._copyFolder(
+            syn,
+            ent.id,
+            destinationId,
+            mapping=mapping,
+            skipCopyAnnotations=skipCopyAnnotations,
+            **kwargs,
+        )
+    elif isinstance(ent, File) and "file" not in excludeTypes:
+        copiedId = synu.copy_functions._copyFile(
+            syn,
+            ent.id,
+            destinationId,
+            version=version,
+            updateExisting=updateExisting,
+            setProvenance=setProvenance,
+            skipCopyAnnotations=skipCopyAnnotations,
+        )
+    elif isinstance(ent, Link) and "link" not in excludeTypes:
+        copiedId = synu.copy_functions._copyLink(
+            syn, ent.id, destinationId, updateExisting=updateExisting
+        )
+    elif isinstance(ent, Schema) and "table" not in excludeTypes:
+        copiedId = synu.copy_functions._copyTable(
+            syn, ent.id, destinationId, updateExisting=updateExisting
+        )
+    # This is currently done because copyLink returns None sometimes
+    if copiedId is not None:
+        mapping[ent.id] = copiedId
+        syn.logger.info("Copied %s to %s" % (ent.id, copiedId))
+    else:
+        syn.logger.info("%s not copied" % ent.id)
+    return mapping
 
 
 # TODO: Add to etl.py
@@ -338,7 +468,7 @@ def consortiumToPublic(
             )
         else:
             ent = syn.get(entId, followLink=True, downloadFile=False)
-            copiedId = synapseutils.copy(
+            copiedId = _copyRecursive(
                 syn,
                 ent,
                 public_release_preview,

--- a/genie/consortium_to_public.py
+++ b/genie/consortium_to_public.py
@@ -14,7 +14,6 @@ from genie import (
     load,
     process_functions,
 )
-from synapseclient import Entity, File, Folder, Link, Project, Schema
 
 logger = logging.getLogger(__name__)
 stdout_handler = logging.StreamHandler(stream=sys.stdout)
@@ -22,7 +21,7 @@ stdout_handler.setLevel(logging.INFO)
 logger.addHandler(stdout_handler)
 from typing import Dict
 
-import synapseutils as synu
+from genie.load import _copyRecursive
 
 
 # TODO: Add to transform.py
@@ -37,131 +36,6 @@ def commonVariantFilter(mafDf):
     to_keep = ["common_variant" not in i for i in mafDf["FILTER"]]
     mafDf = mafDf[to_keep]
     return mafDf
-
-
-def _copyRecursive(
-    syn: synapseclient.Synapse,
-    entity: str,
-    destinationId: str,
-    mapping: Dict[str, str] = None,
-    skipCopyAnnotations: bool = False,
-    **kwargs,
-) -> Dict[str, str]:
-    """
-    NOTE: This is a copy of the function found here: https://github.com/Sage-Bionetworks/synapsePythonClient/blob/develop/synapseutils/copy_functions.py#L409
-    This was copied because there is a restriction that doesn't allow for copying entities with access requirements
-
-    Recursively copies synapse entites, but does not copy the wikis
-
-    Arguments:
-        syn: A Synapse object with user's login
-        entity: A synapse entity ID
-        destinationId: Synapse ID of a folder/project that the copied entity is being copied to
-        mapping: A mapping of the old entities to the new entities
-        skipCopyAnnotations: Skips copying the annotations
-                                Default is False
-
-    Returns:
-        a mapping between the original and copied entity: {'syn1234':'syn33455'}
-    """
-
-    version = kwargs.get("version", None)
-    setProvenance = kwargs.get("setProvenance", "traceback")
-    excludeTypes = kwargs.get("excludeTypes", [])
-    updateExisting = kwargs.get("updateExisting", False)
-    if mapping is None:
-        mapping = dict()
-    # Check that passed in excludeTypes is file, table, and link
-    if not isinstance(excludeTypes, list):
-        raise ValueError("Excluded types must be a list")
-    elif not all([i in ["file", "link", "table"] for i in excludeTypes]):
-        raise ValueError(
-            "Excluded types can only be a list of these values: file, table, and link"
-        )
-
-    ent = syn.get(entity, downloadFile=False)
-    if ent.id == destinationId:
-        raise ValueError("destinationId cannot be the same as entity id")
-
-    if (isinstance(ent, Project) or isinstance(ent, Folder)) and version is not None:
-        raise ValueError("Cannot specify version when copying a project of folder")
-
-    if not isinstance(ent, (Project, Folder, File, Link, Schema, Entity)):
-        raise ValueError("Not able to copy this type of file")
-
-    permissions = syn.restGET("/entity/{}/permissions".format(ent.id))
-    # Don't copy entities without DOWNLOAD permissions
-    if not permissions["canDownload"]:
-        syn.logger.warning(
-            "%s not copied - this file lacks download permission" % ent.id
-        )
-        return mapping
-
-    # HACK: These lines of code were removed to allow for data with access requirements to be copied
-    # https://github.com/Sage-Bionetworks/synapsePythonClient/blob/2909fa778e814f62f6fe6ce2d951ce58c0080a4e/synapseutils/copy_functions.py#L464-L470
-
-    copiedId = None
-
-    if isinstance(ent, Project):
-        project = syn.get(destinationId)
-        if not isinstance(project, Project):
-            raise ValueError(
-                "You must give a destinationId of a new project to copy projects"
-            )
-        copiedId = destinationId
-        # Projects include Docker repos, and Docker repos cannot be copied
-        # with the Synapse rest API. Entity views currently also aren't
-        # supported
-        entities = syn.getChildren(
-            entity, includeTypes=["folder", "file", "table", "link"]
-        )
-        for i in entities:
-            mapping = _copyRecursive(
-                syn,
-                i["id"],
-                destinationId,
-                mapping=mapping,
-                skipCopyAnnotations=skipCopyAnnotations,
-                **kwargs,
-            )
-
-        if not skipCopyAnnotations:
-            project.annotations = ent.annotations
-            syn.store(project)
-    elif isinstance(ent, Folder):
-        copiedId = synu.copy_functions._copyFolder(
-            syn,
-            ent.id,
-            destinationId,
-            mapping=mapping,
-            skipCopyAnnotations=skipCopyAnnotations,
-            **kwargs,
-        )
-    elif isinstance(ent, File) and "file" not in excludeTypes:
-        copiedId = synu.copy_functions._copyFile(
-            syn,
-            ent.id,
-            destinationId,
-            version=version,
-            updateExisting=updateExisting,
-            setProvenance=setProvenance,
-            skipCopyAnnotations=skipCopyAnnotations,
-        )
-    elif isinstance(ent, Link) and "link" not in excludeTypes:
-        copiedId = synu.copy_functions._copyLink(
-            syn, ent.id, destinationId, updateExisting=updateExisting
-        )
-    elif isinstance(ent, Schema) and "table" not in excludeTypes:
-        copiedId = synu.copy_functions._copyTable(
-            syn, ent.id, destinationId, updateExisting=updateExisting
-        )
-    # This is currently done because copyLink returns None sometimes
-    if copiedId is not None:
-        mapping[ent.id] = copiedId
-        syn.logger.info("Copied %s to %s" % (ent.id, copiedId))
-    else:
-        syn.logger.info("%s not copied" % ent.id)
-    return mapping
 
 
 # TODO: Add to etl.py


### PR DESCRIPTION
# **Problem:**
- Currently, we use `synapseutils.copy` to copy files to release preview folder. However, this function doesn't allow copying files with AR.


# **Solution:**
- Adapted solution from this PR: [[GEN-1909] Customize copy_recursive function because access requirements are now added to the data by thomasyu888 · Pull Request #33 · Sage-Bionetworks-Workflows/nf-genie](https://github.com/Sage-Bionetworks-Workflows/nf-genie/pull/33/files) to remove section in the [_copyRecursive](https://github.com/Sage-Bionetworks/synapsePythonClient/blob/2909fa778e814f62f6fe6ce2d951ce58c0080a4e/synapseutils/copy_functions.py#L464-L470) that blocks files with AR from copying. 

# **Testing:**

Tested the file that failed to be copied in this [job](https://tower.sagebionetworks.org/orgs/Sage-Bionetworks/workspaces/genie-bpc-project/watch/3a0lXuVZ8cmOOr) can be copied to testing folder now. 

<img width="1124" height="94" alt="Screenshot 2025-07-15 at 3 27 42 PM" src="https://github.com/user-attachments/assets/23f0b003-c187-4c05-b8e8-6ffe6690fe57" />


[GEN-1909]: https://sagebionetworks.jira.com/browse/GEN-1909?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ