### PR TITLE
Update truststore update cadence

### DIFF
--- a/.github/workflows/automate_truststore.yml
+++ b/.github/workflows/automate_truststore.yml
@@ -2,7 +2,7 @@ name: Auto-update Genome Nexus Truststore file
 
 on:
   schedule:
-    - cron: "0 3 * * 2,5" # Runs at 3 AM UTC on Tuesday (2) and Friday (5)
+    - cron: "0 3 * * 1-5"  # Runs at 3 AM UTC on Monday through Friday
   workflow_dispatch:
 
 env:


### PR DESCRIPTION
# **Problem:**
Currently we update the truststore (used in the genome nexus annotator for our mutation data processing) every ~3-4 days but we have had two occurences where the truststore certificate gets updated in the genome nexus servers in the time between updates and we run into errors in our various testing to prod pipeline runs because it produces all failed annotations in our mutations processing.

# **Solution:**
- There doesn't appear to be a consistent schedule to when the certificate gets reissued on their servers and we have to re-update the truststore. Asking the genome nexus team about their cert reissuing schedule
- Updating the cadence to updating daily to prevent the above

# **Testing:**
Tested manually