### PR TITLE
[GEN 1262] Enable dashboard generation for testing mode

### DIFF
--- a/R/dashboard_markdown_generator.R
+++ b/R/dashboard_markdown_generator.R
@@ -15,6 +15,7 @@ parser$add_argument("--testing",
 
 args <- parser$parse_args()
 release <- args$release
+testing <- args$testing
 template_path <- args$template_path
 suppressPackageStartupMessages(library(synapser))
 suppressPackageStartupMessages(library(rmarkdown))
@@ -42,7 +43,7 @@ rmarkdown_path = sprintf('%s.Rmd', release)
 file.copy(template_path, rmarkdown_path, overwrite = T)
 rmarkdown::render(rmarkdown_path,
                   params = list("database_synid_mappingid" = database_synid_mappingid,
-                                "release" = release))
+                                "release" = release, "testing" = testing))
 # Obtain release folder
 database_synid_mapping = synTableQuery(sprintf('select * from %s',
                                                database_synid_mappingid))

--- a/bin/consortium_to_public.py
+++ b/bin/consortium_to_public.py
@@ -20,7 +20,9 @@ PWD = os.path.dirname(os.path.abspath(__file__))
 
 
 # TODO: Move to genie.database_to_staging.py
-def generate_dashboard_html(genie_version: str, staging=False, testing=False):
+def generate_dashboard_html(
+    genie_version: str, staging: bool = False, testing: bool = False
+):
     """Generates dashboard html writeout that gets uploaded to the
     release folder
 

--- a/bin/consortium_to_public.py
+++ b/bin/consortium_to_public.py
@@ -20,7 +20,7 @@ PWD = os.path.dirname(os.path.abspath(__file__))
 
 
 # TODO: Move to genie.database_to_staging.py
-def generate_dashboard_html(genie_version, staging=False, testing=False):
+def generate_dashboard_html(genie_version: str, staging=False, testing=False):
     """Generates dashboard html writeout that gets uploaded to the
     release folder
 

--- a/bin/consortium_to_public.py
+++ b/bin/consortium_to_public.py
@@ -18,7 +18,7 @@ PWD = os.path.dirname(os.path.abspath(__file__))
 
 
 # TODO: Move to genie.database_to_staging.py
-def generate_dashboard_html(genie_version, staging=False):
+def generate_dashboard_html(genie_version, staging=False, testing=False):
     """Generates dashboard html writeout that gets uploaded to the
     release folder
 
@@ -36,6 +36,8 @@ def generate_dashboard_html(genie_version, staging=False):
     ]
     if staging:
         markdown_render_cmd.append("--staging")
+    if testing:
+        markdown_render_cmd.append("--testing")
     subprocess.check_call(markdown_render_cmd)
 
 
@@ -195,14 +197,13 @@ def main(args):
             start=False,
         )
 
-    if not args.test:
-        logger.info("DASHBOARD UPDATE")
-        dashboard_table_updater.run_dashboard(
-            syn, databaseSynIdMappingDf, args.genieVersion, staging=args.staging
-        )
-        generate_dashboard_html(args.genieVersion, staging=args.staging)
-        logger.info("DASHBOARD UPDATE COMPLETE")
-        logger.info("AUTO GENERATE DATA GUIDE")
+    logger.info("DASHBOARD UPDATE")
+    dashboard_table_updater.run_dashboard(
+        syn, databaseSynIdMappingDf, args.genieVersion, staging=args.staging, testing=args.test
+    )
+    generate_dashboard_html(args.genieVersion, staging=args.staging, testing=args.test)
+    logger.info("DASHBOARD UPDATE COMPLETE")
+    logger.info("AUTO GENERATE DATA GUIDE")
 
     # TODO: remove data guide code
     # onco_link = databaseSynIdMappingDf["Id"][
@@ -254,7 +255,7 @@ if __name__ == "__main__":
         "--staging", action="store_true", help="Store into staging folder"
     )
 
-    parser.add_argument("--test", action="store_true", help="Store into staging folder")
+    parser.add_argument("--test", action="store_true", help="Store into testing folder")
     parser.add_argument("--debug", action="store_true", help="Synapse debug feature")
     args = parser.parse_args()
     main(args)

--- a/bin/consortium_to_public.py
+++ b/bin/consortium_to_public.py
@@ -203,7 +203,6 @@ def main(args):
         databaseSynIdMappingDf,
         args.genieVersion,
         staging=args.staging,
-        testing=args.test,
     )
     generate_dashboard_html(args.genieVersion, staging=args.staging, testing=args.test)
     logger.info("DASHBOARD UPDATE COMPLETE")

--- a/bin/consortium_to_public.py
+++ b/bin/consortium_to_public.py
@@ -198,12 +198,14 @@ def main(args):
         )
 
     logger.info("DASHBOARD UPDATE")
-    dashboard_table_updater.run_dashboard(
-        syn,
-        databaseSynIdMappingDf,
-        args.genieVersion,
-        staging=args.staging,
-    )
+    # Only run dashboard update if not testing or staging
+    if not args.test and not args.staging:
+        dashboard_table_updater.run_dashboard(
+            syn,
+            databaseSynIdMappingDf,
+            args.genieVersion,
+            staging=args.staging,
+        )
     generate_dashboard_html(args.genieVersion, staging=args.staging, testing=args.test)
     logger.info("DASHBOARD UPDATE COMPLETE")
     logger.info("AUTO GENERATE DATA GUIDE")

--- a/bin/consortium_to_public.py
+++ b/bin/consortium_to_public.py
@@ -199,7 +199,11 @@ def main(args):
 
     logger.info("DASHBOARD UPDATE")
     dashboard_table_updater.run_dashboard(
-        syn, databaseSynIdMappingDf, args.genieVersion, staging=args.staging, testing=args.test
+        syn,
+        databaseSynIdMappingDf,
+        args.genieVersion,
+        staging=args.staging,
+        testing=args.test,
     )
     generate_dashboard_html(args.genieVersion, staging=args.staging, testing=args.test)
     logger.info("DASHBOARD UPDATE COMPLETE")

--- a/bin/consortium_to_public.py
+++ b/bin/consortium_to_public.py
@@ -2,15 +2,17 @@ import argparse
 import datetime
 import logging
 import os
-import synapseclient
 import subprocess
 
-from genie import dashboard_table_updater
-from genie import process_functions
-from genie import consortium_to_public
-from genie import database_to_staging
-from genie import extract
-from genie import load
+import synapseclient
+from genie import (
+    consortium_to_public,
+    dashboard_table_updater,
+    database_to_staging,
+    extract,
+    load,
+    process_functions,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -25,6 +27,7 @@ def generate_dashboard_html(genie_version, staging=False, testing=False):
     Args:
         genie_version: GENIE release
         staging: Use staging files. Default is False
+        testing: Use testing files. Default is False
 
     """
     markdown_render_cmd = [

--- a/bin/database_to_staging.py
+++ b/bin/database_to_staging.py
@@ -69,10 +69,8 @@ import datetime
 import logging
 import os
 import subprocess
+
 import synapseclient
-
-# import time
-
 from genie import (
     create_case_lists,
     dashboard_table_updater,
@@ -80,6 +78,9 @@ from genie import (
     load,
     process_functions,
 )
+
+# import time
+
 
 logger = logging.getLogger(__name__)
 
@@ -93,6 +94,7 @@ def generate_dashboard_html(genie_version, staging=False, testing=False):
     Args:
         genie_version: GENIE release
         staging: Use staging files. Default is False
+        testing: Use testing files. Default is False
 
     """
     markdown_render_cmd = [

--- a/bin/database_to_staging.py
+++ b/bin/database_to_staging.py
@@ -355,9 +355,11 @@ def main(
         )
 
     logger.info("DASHBOARD UPDATE")
-    dashboard_table_updater.run_dashboard(
-        syn, databaseSynIdMappingDf, genie_version, staging=staging
-    )
+    # Only run dashboard update if not testing or staging
+    if not args.test and not args.staging:
+        dashboard_table_updater.run_dashboard(
+            syn, databaseSynIdMappingDf, genie_version, staging=staging
+        )
     generate_dashboard_html(genie_version, staging=staging, testing=test)
     logger.info("DASHBOARD UPDATE COMPLETE")
     logger.info("AUTO GENERATE DATA GUIDE")

--- a/bin/database_to_staging.py
+++ b/bin/database_to_staging.py
@@ -87,7 +87,9 @@ logger = logging.getLogger(__name__)
 PWD = os.path.dirname(os.path.abspath(__file__))
 
 
-def generate_dashboard_html(genie_version: str, staging=False, testing=False):
+def generate_dashboard_html(
+    genie_version: str, staging: bool = False, testing: bool = False
+):
     """Generates dashboard html writeout that gets uploaded to the
     release folder
 

--- a/bin/database_to_staging.py
+++ b/bin/database_to_staging.py
@@ -356,7 +356,7 @@ def main(
 
     logger.info("DASHBOARD UPDATE")
     dashboard_table_updater.run_dashboard(
-        syn, databaseSynIdMappingDf, genie_version, staging=staging, testing=test
+        syn, databaseSynIdMappingDf, genie_version, staging=staging
     )
     generate_dashboard_html(genie_version, staging=staging, testing=test)
     logger.info("DASHBOARD UPDATE COMPLETE")

--- a/bin/database_to_staging.py
+++ b/bin/database_to_staging.py
@@ -86,7 +86,7 @@ logger = logging.getLogger(__name__)
 PWD = os.path.dirname(os.path.abspath(__file__))
 
 
-def generate_dashboard_html(genie_version, staging=False):
+def generate_dashboard_html(genie_version, staging=False, testing=False):
     """Generates dashboard html writeout that gets uploaded to the
     release folder
 
@@ -105,6 +105,8 @@ def generate_dashboard_html(genie_version, staging=False):
 
     if staging:
         markdown_render_cmd.append("--staging")
+    if testing:
+        markdown_render_cmd.append("--testing")
     subprocess.check_call(markdown_render_cmd)
 
 
@@ -352,14 +354,13 @@ def main(
             start=False,
         )
 
-    if not test:
-        logger.info("DASHBOARD UPDATE")
-        dashboard_table_updater.run_dashboard(
-            syn, databaseSynIdMappingDf, genie_version, staging=staging
-        )
-        generate_dashboard_html(genie_version, staging=staging)
-        logger.info("DASHBOARD UPDATE COMPLETE")
-        logger.info("AUTO GENERATE DATA GUIDE")
+    logger.info("DASHBOARD UPDATE")
+    dashboard_table_updater.run_dashboard(
+        syn, databaseSynIdMappingDf, genie_version, staging=staging, testing=test
+    )
+    generate_dashboard_html(genie_version, staging=staging, testing=test)
+    logger.info("DASHBOARD UPDATE COMPLETE")
+    logger.info("AUTO GENERATE DATA GUIDE")
 
     # TODO: remove data guide code
     # oncotree_version = oncotree_link.split("=")[1]

--- a/bin/database_to_staging.py
+++ b/bin/database_to_staging.py
@@ -87,7 +87,7 @@ logger = logging.getLogger(__name__)
 PWD = os.path.dirname(os.path.abspath(__file__))
 
 
-def generate_dashboard_html(genie_version, staging=False, testing=False):
+def generate_dashboard_html(genie_version: str, staging=False, testing=False):
     """Generates dashboard html writeout that gets uploaded to the
     release folder
 

--- a/templates/dashboardTemplate.Rmd
+++ b/templates/dashboardTemplate.Rmd
@@ -8,6 +8,8 @@ params:
     value: x
   release:
     value: x
+  testing:
+    value: x
 ---
 
 ```{r setup, include=FALSE}
@@ -276,7 +278,13 @@ Please confirm that the the number of samples and variants in this release is wh
 sampleCounts = table(this_samples$CENTER)
 samplesPerReleaseDf = as.data.frame(sampleCounts)
 colnames(samplesPerReleaseDf) = c("Center", "Samples")
-variant_counts = table(this_mut$Center)
+if (testing) {
+  # generate a temp variant_counts for later step
+  temp <- factor(rep(c("GOLD", "SAGE"), c(3,4)), levels = c("GOLD", "SAGE"))
+  variant_counts = table(temp)
+} else{
+  variant_counts = table(this_mut$Center)
+}
 variant_countsdf = as.data.frame(variant_counts)
 colnames(variant_countsdf) = c("Center", "Variants")
 release_infodf = merge.data.frame(samplesPerReleaseDf, variant_countsdf, by="Center", all=T)
@@ -551,7 +559,7 @@ filtered_mafdf <- filter_maf(this_mut)
 ```
 
 
-```{r top_5_mutated, echo=FALSE}
+```{r top_5_mutated, echo=FALSE, eval = !testing}
 mergeddf = merge.data.frame(filtered_mafdf[,c("Tumor_Sample_Barcode", "Hugo_Symbol")],
                             this_samples[,c("SAMPLE_ID", "SEQ_ASSAY_ID")],
                             by.x = "Tumor_Sample_Barcode",
@@ -579,7 +587,6 @@ final_matrix = cbind(transposed_matrix, table(mergeddf$SEQ_PIPELINE_ID)[row.name
 colnames(final_matrix) = c(1, 2, 3, 4, 5, "Total Variants")
 kable(final_matrix,
       caption = "Distribution of top 5 most frequently mutated genes per SEQ_PIPELINE_ID")
-
 ```
 
 
@@ -592,7 +599,8 @@ These are all the pipelines that cover TP53 that don't have TP53 as the top muta
 this_bed = merge.data.frame(this_bed,
                             assay_infodf[,c("SEQ_ASSAY_ID", "SEQ_PIPELINE_ID")],
                             by = "SEQ_ASSAY_ID")
-if (!is.null(this_bed)) {
+if (!testing){
+  if (!is.null(this_bed)) {
   panels_covering_tp53 = unique(this_bed$SEQ_PIPELINE_ID[this_bed$Hugo_Symbol == "TP53"])
   # Exclude panels if TP53 is top mutated
   tp53_not_top = sapply(names(top_5_mutated_genes), function(seq_assay) {
@@ -611,6 +619,7 @@ if (!is.null(this_bed)) {
   colnames(final_matrix) = c(1, 2, 3, 4, 5, "Total Variants")
   kable(final_matrix,
         caption = "Distribution of top 5 most frequently mutated genes per SEQ_PIPELINE_ID")
+}
 }
 ```
 

--- a/templates/dashboardTemplate.Rmd
+++ b/templates/dashboardTemplate.Rmd
@@ -204,6 +204,8 @@ get_latest_public_release <- function(release) {
   # version of the public release folder here
   if (grepl("STAGING", release)){
     return("syn7871696")
+  } else if (grepl("TESTING", release)){
+    return("syn12299959")
   } else{
       major_release = unlist(strsplit(release, "[.]"))[1]
       public_major_release = as.numeric(major_release) - 1


### PR DESCRIPTION
# **Problem:**

Currently, there’s no way to test updated dashboard code against the test version of the pipeline. The only time we can verify that our dashboard code works is when it runs on a staging or production consortium release.

To improve this, we should update the dashboard generator code to support running on the test data and pipeline as fully as possible. This would allow us to catch issues earlier and reduce dependency on production releases for validation.

# **Solution:**
1. Enable dashboard generator to pull test data
2. Add the ability to turn on dashboard generator for test pipeline
# **Testing:**
The script was run through by calling 
```
Rscript R/dashboard_markdown_generator.R TESTING --template_path templates/dashboardTemplate.Rmd --testing
```
and the output html is saved to the [expected folder](https://www.synapse.org/Synapse:syn12299959). 