### PR TITLE
[GEN-2210] Fix setting of skip_mutationsincis flag for staging

### DIFF
--- a/bin/database_to_staging.py
+++ b/bin/database_to_staging.py
@@ -176,11 +176,14 @@ def main(
     syn = process_functions.synapse_login(debug=debug)
     # HACK: Use project id instead of this...
     if test:
+        skip_mutationsincis = False
         databaseSynIdMappingId = "syn11600968"
         genie_version = "TESTING"
     elif staging:
+        skip_mutationsincis = False
         databaseSynIdMappingId = "syn12094210"
     else:
+        skip_mutationsincis = False
         databaseSynIdMappingId = "syn10967259"
     # Database/folder syn id mapping
     databaseSynIdMapping = syn.tableQuery(

--- a/bin/database_to_staging.py
+++ b/bin/database_to_staging.py
@@ -179,7 +179,6 @@ def main(
         databaseSynIdMappingId = "syn11600968"
         genie_version = "TESTING"
     elif staging:
-        skip_mutationsincis = True
         databaseSynIdMappingId = "syn12094210"
     else:
         databaseSynIdMappingId = "syn10967259"

--- a/bin/database_to_staging.py
+++ b/bin/database_to_staging.py
@@ -176,14 +176,11 @@ def main(
     syn = process_functions.synapse_login(debug=debug)
     # HACK: Use project id instead of this...
     if test:
-        skip_mutationsincis = False
         databaseSynIdMappingId = "syn11600968"
         genie_version = "TESTING"
     elif staging:
-        skip_mutationsincis = False
         databaseSynIdMappingId = "syn12094210"
     else:
-        skip_mutationsincis = False
         databaseSynIdMappingId = "syn10967259"
     # Database/folder syn id mapping
     databaseSynIdMapping = syn.tableQuery(


### PR DESCRIPTION
# **Problem:**

The flag [skip_mutationsincis is set to True](https://github.com/Sage-Bionetworks/Genie/blob/9426c91528db2b55e2e9c12107c1a8fa62947680/bin/database_to_staging.py#L181-L183) for staging which skips the mutation in cis process for staging. 

This prevents us from having more of 1:1 comparison between staging vs production.

# **Solution:**
Remove`skip_mutationsincis` flag for staging. The [actual database_to_staging call (as `skip_mutationsincis `is a parameter there) in nf-genie](https://github.com/Sage-Bionetworks-Workflows/nf-genie/blob/main/modules/create_consortium_release.nf#L1-L49) states that as [long as `--skipMutationsInCis` is not set, it will run mutation in cis](https://github.com/Sage-Bionetworks/Genie/blob/9426c91528db2b55e2e9c12107c1a8fa62947680/bin/database_to_staging.py#L412-L416)

# **Testing:**
- Run on staging and mutation in cis files should be outputted for centers