### PR TITLE
[GEN-2222] Fix failing timezone tests by using utc timezone

### DIFF
--- a/genie/dashboard_table_updater.py
+++ b/genie/dashboard_table_updater.py
@@ -7,7 +7,6 @@ import os
 
 import pandas as pd
 import synapseclient
-from synapseclient.core.utils import to_unix_epoch_time
 
 from genie import extract, load, process_functions
 
@@ -570,7 +569,7 @@ def string_to_unix_epoch_time_milliseconds(string_time):
     datetime_obj = datetime.datetime.strptime(
         string_time.split(".")[0], "%Y-%m-%dT%H:%M:%S"
     )
-    return to_unix_epoch_time(datetime_obj)
+    return process_functions.to_unix_epoch_time_utc(datetime_obj)
 
 
 def update_data_release_file_table(syn, database_mappingdf):

--- a/genie/dashboard_table_updater.py
+++ b/genie/dashboard_table_updater.py
@@ -555,7 +555,7 @@ def update_wiki(syn, database_mappingdf):
     syn.store(wikipage)
 
 
-def string_to_unix_epoch_time_milliseconds(string_time):
+def string_to_unix_epoch_time_milliseconds(string_time : str) -> int:
     """
     Takes dates in this format: 2018-10-25T20:16:07.959Z
     and turns it into unix epoch time in milliseconds
@@ -564,7 +564,7 @@ def string_to_unix_epoch_time_milliseconds(string_time):
         string_time: string in this format: 2018-10-25T20:16:07.959Z
 
     Returns:
-        unix epoch time in milliseconds
+        int: unix epoch time in milliseconds
     """
     datetime_obj = datetime.datetime.strptime(
         string_time.split(".")[0], "%Y-%m-%dT%H:%M:%S"

--- a/genie/dashboard_table_updater.py
+++ b/genie/dashboard_table_updater.py
@@ -555,7 +555,7 @@ def update_wiki(syn, database_mappingdf):
     syn.store(wikipage)
 
 
-def string_to_unix_epoch_time_milliseconds(string_time : str) -> int:
+def string_to_unix_epoch_time_milliseconds(string_time: str) -> int:
     """
     Takes dates in this format: 2018-10-25T20:16:07.959Z
     and turns it into unix epoch time in milliseconds

--- a/genie/input_to_database.py
+++ b/genie/input_to_database.py
@@ -35,11 +35,11 @@ To avoid the syn.get rest call later which doesn't actually download the file
 
 
 # TODO: add to transform.py
-def entity_date_to_unix_epoch_time(entity_date_time : str):
+def entity_date_to_unix_epoch_time(entity_date_time: str):
     """Convert Synapse object date/time string (from modifiedOn or createdOn properties) to UNIX time
 
     Args:
-        entity_date_time: Synapse object date/time string in this format: 
+        entity_date_time: Synapse object date/time string in this format:
             2018-10-25T20:16:07.959Z
 
     Returns:

--- a/genie/input_to_database.py
+++ b/genie/input_to_database.py
@@ -8,7 +8,6 @@ from typing import List, Optional
 
 import synapseclient
 from synapseclient import Synapse
-from synapseclient.core.utils import to_unix_epoch_time
 import pandas as pd
 
 from genie import (
@@ -41,7 +40,7 @@ def entity_date_to_timestamp(entity_date_time):
 
     date_and_time = entity_date_time.split(".")[0]
     date_time_obj = datetime.datetime.strptime(date_and_time, "%Y-%m-%dT%H:%M:%S")
-    return to_unix_epoch_time(date_time_obj)
+    return process_functions.to_unix_epoch_time_utc(date_time_obj)
 
 
 # TODO: Add to validation.py

--- a/genie/input_to_database.py
+++ b/genie/input_to_database.py
@@ -35,9 +35,16 @@ To avoid the syn.get rest call later which doesn't actually download the file
 
 
 # TODO: add to transform.py
-def entity_date_to_timestamp(entity_date_time):
-    """Convert Synapse object date/time string (from modifiedOn or createdOn properties) to a timestamp."""
+def entity_date_to_unix_epoch_time(entity_date_time : str):
+    """Convert Synapse object date/time string (from modifiedOn or createdOn properties) to UNIX time
 
+    Args:
+        entity_date_time: Synapse object date/time string in this format: 
+            2018-10-25T20:16:07.959Z
+
+    Returns:
+        int: unix epoch time
+    """
     date_and_time = entity_date_time.split(".")[0]
     date_time_obj = datetime.datetime.strptime(date_and_time, "%Y-%m-%dT%H:%M:%S")
     return process_functions.to_unix_epoch_time_utc(date_time_obj)
@@ -540,7 +547,7 @@ def build_validation_status_table(input_valid_statuses: List[dict]):
             "md5": entity.md5,
             "status": input_status["status"],
             "name": entity.name,
-            "modifiedOn": entity_date_to_timestamp(entity.properties.modifiedOn),
+            "modifiedOn": entity_date_to_unix_epoch_time(entity.properties.modifiedOn),
             "fileType": input_status["fileType"],
             "center": input_status["center"],
             "version": entity.versionNumber,

--- a/genie/process_functions.py
+++ b/genie/process_functions.py
@@ -14,6 +14,7 @@ import yaml
 from genie import extract
 from requests.adapters import HTTPAdapter
 from synapseclient import Synapse
+from synapseclient.core.utils import to_unix_epoch_time
 from urllib3.util import Retry
 
 pd.options.mode.chained_assignment = None
@@ -21,6 +22,18 @@ pd.options.mode.chained_assignment = None
 logger = logging.getLogger(__name__)
 # TODO: Add to constants.py
 SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+
+
+def to_unix_epoch_time_utc(dt: Union[datetime.date, datetime.datetime, str]) -> int:
+    """Wrapper for Synapse to_unix_epoch_time that forces UTC tzinfo
+
+    Args:
+        dt (Union[datetime.date, datetime.datetime, str]): input datetime time object
+
+    Returns:
+        int: Converted UTC datetime object to UNIX time
+    """
+    return to_unix_epoch_time(dt.replace(tzinfo=datetime.timezone.utc))
 
 
 def get_clinical_dataframe(filePathList: list) -> pd.DataFrame:

--- a/genie_registry/sampleRetraction.py
+++ b/genie_registry/sampleRetraction.py
@@ -3,10 +3,9 @@ import logging
 import os
 
 import pandas as pd
-from synapseclient.core.utils import to_unix_epoch_time
 
 from genie.example_filetype_format import FileTypeFormat
-from genie import load
+from genie import load, process_functions
 
 logger = logging.getLogger(__name__)
 
@@ -35,7 +34,7 @@ class sampleRetraction(FileTypeFormat):
             else "geniePatientId"
         )
         deleteSamplesDf.rename(columns={0: col}, inplace=True)
-        modifiedOn = to_unix_epoch_time(
+        modifiedOn = process_functions.to_unix_epoch_time_utc(
             datetime.datetime.strptime(modifiedOn, "%Y-%m-%dT%H:%M:%S")
         )
         deleteSamplesDf["retractionDate"] = modifiedOn

--- a/tests/test_dashboard_table_updater.py
+++ b/tests/test_dashboard_table_updater.py
@@ -7,9 +7,10 @@ from genie import dashboard_table_updater as dash_update
     "input_string_time, expected_output_time",
     [
         ("2018-10-25T20:16:07.959Z", 1540498567000),
+        ("2018-10-25T20:16:07.959", 1540498567000),
         ("2018-04-06T18:30:00", 1523039400000),
     ],
-    ids=["utc_time", "local_time_zone"],
+    ids=["utc_time", "local_time_zone", "no_milliseconds"],
 )
 def test_that_string_to_unix_epoch_time_milliseconds_gives_expected_time(
     input_string_time, expected_output_time

--- a/tests/test_dashboard_table_updater.py
+++ b/tests/test_dashboard_table_updater.py
@@ -1,0 +1,18 @@
+import pytest
+
+from genie import dashboard_table_updater as dash_update
+
+
+@pytest.mark.parametrize(
+    "input_string_time, expected_output_time",
+    [
+        ("2018-10-25T20:16:07.959Z", 1540498567000),
+        ("2018-04-06T18:30:00", 1523039400000),
+    ],
+    ids=["utc_time", "local_time_zone"],
+)
+def test_that_string_to_unix_epoch_time_milliseconds_gives_expected_time(
+    input_string_time, expected_output_time
+):
+    output = dash_update.string_to_unix_epoch_time_milliseconds(input_string_time)
+    assert output == expected_output_time

--- a/tests/test_input_to_database.py
+++ b/tests/test_input_to_database.py
@@ -100,10 +100,10 @@ emptydf = pd.DataFrame(columns=["id"], dtype=str)
     ],
     ids=["utc_time", "local_time", "no_miliseconds"],
 )
-def test_that_entity_date_to_timestamp_converts_as_expected(
+def test_that_entity_date_to_unix_epoch_time_converts_as_expected(
     input_entity_date, output_expected_timestamp
 ):
-    output = input_to_database.entity_date_to_timestamp(input_entity_date)
+    output = input_to_database.entity_date_to_unix_epoch_time(input_entity_date)
     assert output == output_expected_timestamp
 
 

--- a/tests/test_input_to_database.py
+++ b/tests/test_input_to_database.py
@@ -91,6 +91,22 @@ error_trackerdf = pd.DataFrame(
 emptydf = pd.DataFrame(columns=["id"], dtype=str)
 
 
+@pytest.mark.parametrize(
+    "input_entity_date, output_expected_timestamp",
+    [
+        ("2025-08-15T19:05:03.417Z", 1755284703000),
+        ("2025-08-15T19:05:03.417", 1755284703000),
+        ("2025-08-15T19:05:03", 1755284703000),
+    ],
+    ids=["utc_time", "local_time", "no_miliseconds"],
+)
+def test_that_entity_date_to_timestamp_converts_as_expected(
+    input_entity_date, output_expected_timestamp
+):
+    output = input_to_database.entity_date_to_timestamp(input_entity_date)
+    assert output == output_expected_timestamp
+
+
 class mock_csv_query_result(object):
     def __init__(self, df):
         self.df = df

--- a/tests/test_process_functions.py
+++ b/tests/test_process_functions.py
@@ -1,3 +1,4 @@
+import datetime
 import uuid
 from unittest.mock import Mock, patch
 
@@ -24,6 +25,27 @@ DATABASE_DF = pd.DataFrame(
 DATABASE_DF.index = ["1_3", "2_3", "3_5"]
 ENTITY = synapseclient.Project("foo", annotations={"dbMapping": ["syn1234"]})
 ONCOTREE_ENT = "syn222"
+
+
+@pytest.mark.parametrize(
+    "input_string_time, expected_output_time",
+    [
+        (
+            datetime.datetime.strptime("2018-10-25T20:16:07", "%Y-%m-%dT%H:%M:%S"),
+            1540498567000,
+        ),
+        (
+            datetime.datetime.strptime("2018-04-06T18:30:00", "%Y-%m-%dT%H:%M:%S"),
+            1523039400000,
+        ),
+    ],
+    ids=["utc_time", "local_time_zone"],
+)
+def test_that_to_unix_epoch_time_utc_gives_expected_time(
+    input_string_time, expected_output_time
+):
+    output = process_functions.to_unix_epoch_time_utc(input_string_time)
+    assert output == expected_output_time
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
# **Problem:**
There are now failing tests that involve the `to_unix_epoch_time` function from synapseclient (used when we are trying to save the [modifiedOn timestamp for files like validation status synapse table](https://www.synapse.org/Synapse:syn8523326). 

The converted UNIX time doesn't match when running locally on mac vs running on docker image/github actions. This is because we upgraded the `synapseclient` from `2.7.2` to `4.9.0` where the client code changed for that function from [2.7.2](https://github.com/Sage-Bionetworks/synapsePythonClient/blob/v2.7.2/synapseclient/core/utils.py#L380-L388) to [now](https://github.com/Sage-Bionetworks/synapsePythonClient/blob/v4.9.0/synapseclient/core/utils.py#L679-L697) and it’s actually doing what it is supposed to do now - use local system time when doing the conversion when running on mac (PDT) vs docker time (UTC).

JIRA Ticket: https://sagebionetworks.jira.com/browse/GEN-2222

# **Solution:**
Wanted to have a discussion about this solution and if we care about making sure if tracking if we are running in PDT timezone or UTC timezone. For consistency's sake, I feel like we want to use one timezone (even though we use nextflow platform for all runs, just in case we run things locally) so I opted to convert from local to UTC for all scenarios before using the actual conversion to UNIX time. 

Other option is to just force the timezone to be UTC just for running the tests but we could have different time zones when uploading to synapse.

UPDATE: Make decision to convert to UTC timezone because there will be an obvious discrepancy in the modified on dates, see testing report for details

# **Testing:**
- [X] Unit Tests pass
- [X] Integration tests pass
- [X] Check that modifiedOn in validation status table match (after validation) when running locally on mac (local time) vs the integration tests (which is run in the docker using UTC time) and compare that to a run locally on mac (using the updated synapseclient version of 4.9 but **without** the fix.  Since the files haven't changed themselves, it should hopefully produce the same result.

Report is available here: https://sagebionetworks.jira.com/browse/GEN-2222?focusedCommentId=263423
