### PR TITLE
[GEN-2224] Fix dashboard bugs in consortium and public release steps

### DIFF
--- a/R/dashboard_markdown_generator.R
+++ b/R/dashboard_markdown_generator.R
@@ -20,6 +20,10 @@ template_path <- args$template_path
 suppressPackageStartupMessages(library(synapser))
 suppressPackageStartupMessages(library(rmarkdown))
 
+# clear synapse cache
+cache_dir <- file.path(Sys.getenv("HOME"), ".synapseCache")
+unlink(file.path(cache_dir, "*"), recursive = TRUE, force = TRUE)
+
 synLogin()
 
 if (args$staging) {

--- a/templates/dashboardTemplate.Rmd
+++ b/templates/dashboardTemplate.Rmd
@@ -24,7 +24,6 @@ title: '`r release`'
 ---
 
 ```{r intro}
-Sys.setenv(SYNAPSE_CACHE_DIR = file.path(Sys.getenv("HOME"), ".synapseCache_r"))
 suppressMessages(library(synapser))
 foo = capture.output(synLogin())
 suppressMessages(library(ggplot2))

--- a/templates/dashboardTemplate.Rmd
+++ b/templates/dashboardTemplate.Rmd
@@ -24,6 +24,7 @@ title: '`r release`'
 ---
 
 ```{r intro}
+Sys.setenv(SYNAPSE_CACHE_DIR = file.path(Sys.getenv("HOME"), ".synapseCache_r"))
 suppressMessages(library(synapser))
 foo = capture.output(synLogin())
 suppressMessages(library(ggplot2))

--- a/templates/dashboardTemplate.Rmd
+++ b/templates/dashboardTemplate.Rmd
@@ -206,7 +206,7 @@ get_latest_public_release <- function(release) {
   # version of the public release folder here
   if (grepl("STAGING", release)){
     return("syn7871696")
-  } else if (grepl("TESTING", release)){
+  } else if (grepl("TEST", release)){
     return("syn12299959")
   } else{
       major_release = unlist(strsplit(release, "[.]"))[1]


### PR DESCRIPTION
# **Problem:**
There are a couple of bugs this PR takes care of:

### **Mismatch synapse versions in R vs Python env issue**
Due to our coupled R and Python code in the pipeline, and our R workflow having a different underlying `synapseclient` version (2.7) than our python code `synapseclient` version (4.9) we run into the `Error in value[[3L]](cond) : 'dict' object has no attribute 'endswith'` error which is known and found here in the R client troubleshooting guide: https://r-docs.synapse.org/articles/troubleshooting.html#poisoned-cache-and-endswith-error due to our different synapseclient versions.

###  **Looking for wrong release name**
When getting the latest public release synapse folder, it's looking for `TESTING` in the release name (param) but in our testing environment, our public release name is `TESTpublic`.

JIRA Ticket: https://sagebionetworks.jira.com/browse/GEN-2224

# **Solution:**

### **Mismatch synapse versions in R vs Python env issue**
Used [option1 solution in the synapser troubleshooting guide](R client troubleshooting guide: https://r-docs.synapse.org/articles/troubleshooting.html#poisoned-cache-and-endswith-error). This fix will clear the `synapseCache` location prior to running the R dashboarding code to be R specific. This way, the R dashboard code uses a fresh cache.

Since dashboarding is the final step in the general pipeline steps this is OK since it won't affect downstream steps. Downstream steps use their own environment and docker images (e.g: data guide). 

Note that this is just an issue with the dashboarding code. We don't run into this with maf in bed or mutation in cis I think mainly because for our table queries, we don't query requiring any of the md5 checksum/table index when doing so.

### **Looking for wrong release name**
Have it look for `TEST` in the release name instead of `TESTING`. 

# **Testing:**
- [X] Ran comparison reports between `develop` branch run and this branch run for public and consortium release files - no differences found
- [X] Tested locally in docker image and database to staging and consortium to public ran through
- [X] Integration tests ran

Testing dashboard outputted for consortium release:
<img width="1385" height="635" alt="image" src="https://github.com/user-attachments/assets/5e47b8a3-67de-4a5b-8a43-ceb6e07228b3" />

Testing dashboard outputted for public release: 
<img width="1374" height="640" alt="image" src="https://github.com/user-attachments/assets/300d89a1-fb5d-4e97-ba7a-462c09e394f2" />

