### PR TITLE
[GEN-2242] Update java to support newest annotator.jar

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,7 @@ RUN apt-get update && apt-get install -y --allow-unauthenticated --no-install-re
 		# texlive-generic-recommended \
 		texlive-latex-extra \
 		# genome nexus
-		openjdk-11-jre \
+		openjdk-21-jre \
 		# This is for reticulate
 		python3.8-venv && \
 	apt-get clean && \

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ This package contains both R, Python and cli tools.  These are tools or packages
 - R 4.2.2
     - `renv::install()`
     - Follow instructions [here](https://r-docs.synapse.org/#note-for-windows-and-mac-users) to install synapser
-- [Java > 8](https://www.java.com/en/download/)
+- [Java = 21](https://www.java.com/en/download/)
     - For mac users, it seems to work better to run `brew install java`
 - [wget](https://www.gnu.org/software/wget/)
     - For mac users, have to run `brew install wget`


### PR DESCRIPTION
# **Problem:**
Due to getting more failed annotations than usual, Genome Nexus team suggested that we use the latest version of the `annotator.jar` (built from their `master` branch here: https://github.com/genome-nexus/genome-nexus-annotation-pipeline/commits/master/

Followed instructions [here to rebuild and test the jar file](https://sagebionetworks.jira.com/wiki/spaces/APGD/pages/3016687662/Updating+Genome+Nexus+Annotator+and+Dependencies#Updating-the-annotator.jar). 

JIRA Ticket: https://sagebionetworks.jira.com/browse/GEN-2242

# **Solution:**
As a result of this update, since genome nexus uses Java 21 for their annotator.jar file, we need to update the java version in our main genie docker image

# **Testing:**
- [x] Integration tests pass
- [X] [Tested on WAKE mutation data and got ~similar failed annotations as Genome nexus did](https://sagebionetworks.jira.com/browse/GEN-2242?focusedCommentId=264539)
- [x] Run comparisons to make sure there are differences in annotations -> expected number should go down