### PR TITLE
[GEN-1821] Provide genie user-agent string to synapse python client to track usage

### DIFF
--- a/genie/process_functions.py
+++ b/genie/process_functions.py
@@ -17,6 +17,8 @@ from synapseclient import Synapse
 from synapseclient.core.utils import to_unix_epoch_time
 from urllib3.util import Retry
 
+from . import __version__
+
 pd.options.mode.chained_assignment = None
 
 logger = logging.getLogger(__name__)
@@ -789,7 +791,7 @@ def synapse_login(debug: Optional[bool] = False) -> Synapse:
     """
     # If debug is True, then silent should be False
     silent = False if debug else False
-    syn = synapseclient.Synapse(debug=debug, silent=silent)
+    syn = synapseclient.Synapse(debug=debug, silent=silent, user_agent = f"aacrgenie/{__version__}")
     try:
         syn.login()
     except Exception:

--- a/genie/process_functions.py
+++ b/genie/process_functions.py
@@ -791,7 +791,9 @@ def synapse_login(debug: Optional[bool] = False) -> Synapse:
     """
     # If debug is True, then silent should be False
     silent = False if debug else False
-    syn = synapseclient.Synapse(debug=debug, silent=silent, user_agent = f"aacrgenie/{__version__}")
+    syn = synapseclient.Synapse(
+        debug=debug, silent=silent, user_agent=f"aacrgenie/{__version__}"
+    )
     try:
         syn.login()
     except Exception:

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,5 @@ httplib2>=0.11.3
 pyranges==0.1.4
 # known working version 6.0
 PyYAML>=5.1
-synapseclient[pandas]>=4.0.0, <5.0.0
+synapseclient[pandas]>=4.8.0, <5.0.0
 opentelemetry-semantic-conventions==0.56b0

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,7 +30,7 @@ project_urls =
 packages = find:
 install_requires =
     pyranges==0.1.4
-    synapseclient[pandas]>=4.0.0, <5.0.0
+    synapseclient[pandas]>=4.8.0, <5.0.0
     # pandas>=2.0.0, <3.0.0
     httplib2>=0.11.3
     PyYAML>=5.1

--- a/tests/test_database_to_staging.py
+++ b/tests/test_database_to_staging.py
@@ -1107,7 +1107,12 @@ def test_store_data_gene_matrix(syn, wes_seqassayids, expected_output):
             pd.Series([False, True, False, False, False, False]),
         ),
     ],
-    ids=["redact_89+_not_ped", "no_redaction_for_cutoff_value", "redact_range_values", "no_redaction_for_NAs"],
+    ids=[
+        "redact_89+_not_ped",
+        "no_redaction_for_cutoff_value",
+        "redact_range_values",
+        "no_redaction_for_NAs",
+    ],
 )
 def test_to_redact_interval(
     input_col, expected_to_redact_vector, expected_to_redact_pediatric_vector
@@ -1179,7 +1184,11 @@ def test_to_redact_interval(
             ),
         ),
     ],
-    ids=["no_redaction_for_numeric_values", "redact_range_values", "no_redaction_for_NAs"],
+    ids=[
+        "no_redaction_for_numeric_values",
+        "redact_range_values",
+        "no_redaction_for_NAs",
+    ],
 )
 def test__redact_year(input_col, expected_col):
     # call the function
@@ -1208,7 +1217,11 @@ def test__redact_year(input_col, expected_col):
             pd.Series([False, False]),
         ),
     ],
-    ids=["redact_89+_diff", "no_redaction_cuz_no_diff_calculated_for_string", "no_redaction_cuz_no_diff_calculated_for_NAs"],
+    ids=[
+        "redact_89+_diff",
+        "no_redaction_cuz_no_diff_calculated_for_string",
+        "no_redaction_cuz_no_diff_calculated_for_NAs",
+    ],
 )
 def test_to_redact_difference(df_col_year1, df_col_year2, expected_to_redact):
     # call the function


### PR DESCRIPTION
# **Problem:**

We would like to track sites/other user’s aacrgenie usage but right now there is no user_agent information being specified in the package. 

# **Solution:**

Utilize the new functionalities from syanapseclient 4.8.0 to add `user_agent` when initiating Synapse object  

# **Testing:**

Tested that user_agent information is added successfully when synapseclient is 4.9.0.
<img width="835" height="135" alt="Screenshot 2025-09-04 at 11 53 10 AM" src="https://github.com/user-attachments/assets/187c224c-f88f-4111-b09f-93bbc95843f0" />
