### PR TITLE
[GEN-1654] Trigger integration tests via github PR label

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,0 +1,112 @@
+# Github Workflows
+
+## ci.yml
+
+This is our main CI/CD workflow
+
+### Workflow Diagram
+
+The following diagram shows the steps in our `ci.yml` github workflow.
+
+```mermaid
+---
+title: GitHub Actions Build Workflow (with Conditions)
+config:
+  theme: "default"
+---
+
+flowchart TD
+    A([Trigger Event])
+    subgraph Triggers
+      direction TB
+      PR["Pull Request with label:<br/>'run_integration_tests'<br/>and open state"]
+      PUSH["Push to main<br/>or develop"]
+      REL["Release event"]
+    end
+
+    A --> PR
+    A --> PUSH
+    A --> REL
+
+    subgraph Jobs Order
+      direction TB
+      DET["determine-changes"]
+      TEST["test"]
+      LINT["lint"]
+      BUILD["build-container"]
+      INTEG["integration-tests"]
+      DEPLOY["deploy"]
+    end
+
+    %% determine-changes
+    PR -. "Runs if PR has label\nand is open" .-> DET
+    PUSH -. "Runs if push to main/develop" .-> DET
+    REL -. "Runs on release" .-> DET
+
+    %% test
+    DET -- "Always needed (runs in parallel)" --> TEST
+
+    %% lint
+    DET -- "Always needed (runs in parallel)" --> LINT
+
+    %% build-container
+    TEST -.-> BUILD
+    LINT -.-> BUILD
+    BUILD -. "Always, except PR events with incomplete jobs" .-> BUILD
+
+    %% integration-tests
+    BUILD -.-> INTEG
+    LINT -.-> INTEG
+    TEST -.-> INTEG
+    DET -. "Needs changes outside tests/" .-> INTEG
+
+    %% deploy job only for release
+    BUILD -.-> DEPLOY
+    LINT -.-> DEPLOY
+    TEST -.-> DEPLOY
+    REL -. "Only for release event" .-> DEPLOY
+
+    %% Job notes
+    INTEG:::cond_note
+    DEPLOY:::cond_note
+
+    classDef cond_note fill:#fffae1,stroke:#aaa,stroke-width:1px,color:#b06b00;
+    class INTEG,DEPLOY cond_note;
+
+    %% Legend
+    subgraph Legend [Legend]
+      direction LR
+      note1(( )):::cond_note
+      note2["Job only runs for special condition"]
+    end
+```
+
+### High Level Overview
+
+This workflow will install Python dependencies, run the CI/CD with a single version of Python
+
+For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
+
+Only triggers the `lint`, `tests`, `build-container`, `determine-changes` and `integration-tests` jobs for the following conditions:
+
+  - WHEN the PR has the github label `run_integration_tests` AND commits during when pull request is open 
+  - WHEN it's a push into main or develop branches
+  - WHEN it's a release event
+
+#### integration-tests
+
+ - In addition, the `integration-tests` job only runs when determine-changes job determines that there are non-unit tests changes
+
+#### deploy
+
+ - deploy job only runs when there is a release event
+
+
+## automate_truststore.yml
+
+This workflow will update the Genome nexus truststor file on a schedule and then run the mutation processing AND consortium release steps of the pipeline to make sure the pipeline is workfing with the new truststore.
+
+The truststore used in our pipeline to run the genome nexus annotator on MAF data.
+
+For more background on the truststore and troubleshooting, please see:
+[Updating Genome Nexus Annotator and Dependencies](https://sagebionetworks.jira.com/wiki/spaces/APGD/pages/3016687662/Updating+Genome+Nexus+Annotator+and+Dependencies#Updating-the-trust-ssl-file)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ name: build
 
 on:
   push:
-    branches: [main, develop, 'GEN*', 'gen*']
+    branches: [main, develop]
     paths-ignore:
       - '**.md'                            # All Markdown files
       - '**/docs/**'                       # Documentation directory
@@ -44,6 +44,9 @@ jobs:
         (
           github.event_name == 'push' &&
           (github.ref_name == 'main' || github.ref_name == 'develop')
+        ) ||
+        (
+          github.event_name == 'release'
         )
       )
     runs-on: ubuntu-latest
@@ -73,7 +76,20 @@ jobs:
 
   test:
     runs-on: ubuntu-latest
-    if: github.event_name != 'pull_request'
+    if: >- 
+      (
+        (
+          contains(github.event.pull_request.labels.*.name, 'run_integration_tests') && 
+          github.event.pull_request.state == 'open'
+        ) ||
+        (
+          github.event_name == 'push' &&
+          (github.ref_name == 'main' || github.ref_name == 'develop')
+        ) ||
+        (
+          github.event_name == 'release'
+        )
+      )
     strategy:
       matrix:
         python-version: ['3.10', 3.11]
@@ -105,7 +121,20 @@ jobs:
 
   lint:
     runs-on: ubuntu-latest
-    if: github.event_name != 'pull_request'
+    if: >- 
+      (
+        (
+          contains(github.event.pull_request.labels.*.name, 'run_integration_tests') && 
+          github.event.pull_request.state == 'open'
+        ) ||
+        (
+          github.event_name == 'push' &&
+          (github.ref_name == 'main' || github.ref_name == 'develop')
+        ) ||
+        (
+          github.event_name == 'release'
+        )
+      )
     steps:
       - uses: actions/checkout@v4
       - uses: psf/black@stable
@@ -114,7 +143,20 @@ jobs:
 
   build-container:
     needs: [test, lint]
-    if: github.event_name != 'pull_request'
+    if: >- 
+      (
+        (
+          contains(github.event.pull_request.labels.*.name, 'run_integration_tests') && 
+          github.event.pull_request.state == 'open'
+        ) ||
+        (
+          github.event_name == 'push' &&
+          (github.ref_name == 'main' || github.ref_name == 'develop')
+        ) ||
+        (
+          github.event_name == 'release'
+        )
+      )
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -176,6 +218,9 @@ jobs:
         (
           github.event_name == 'push' &&
           (github.ref_name == 'main' || github.ref_name == 'develop')
+        ) ||
+        (
+          github.event_name == 'release'
         )
       )
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ on:
       # - '.github/workflows/**'             # Ignore all github workflow file changes
 
   pull_request:
-      types: [opened, reopened, labeled]
+      types: [opened, reopened, labeled, synchronize]
       paths-ignore:
         - '**.md'                            # All Markdown files
         - '**/docs/**'                       # Documentation directory
@@ -32,7 +32,20 @@ env:
 jobs:
 
   determine-changes:
-    if: contains(github.event.pull_request.labels.*.name, 'run_integration_tests')
+    # Only runs for the following conditions: 
+    #  - if github label "run_integration_tests"
+    #  - for commits during when pull request is open OR when it's a push into main or develop branches
+    if: >- 
+      (
+        (
+          contains(github.event.pull_request.labels.*.name, 'run_integration_tests') && 
+          github.event.pull_request.state == 'open'
+        ) ||
+        (
+          github.event_name == 'push' &&
+          (github.ref_name == 'main' || github.ref_name == 'develop')
+        )
+      )
     runs-on: ubuntu-latest
     outputs:
       non-test-changes: ${{ steps.get-changes.outputs.non-test-changes }}
@@ -60,6 +73,7 @@ jobs:
 
   test:
     runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request'
     strategy:
       matrix:
         python-version: ['3.10', 3.11]
@@ -91,6 +105,7 @@ jobs:
 
   lint:
     runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request'
     steps:
       - uses: actions/checkout@v4
       - uses: psf/black@stable
@@ -99,6 +114,7 @@ jobs:
 
   build-container:
     needs: [test, lint]
+    if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -145,9 +161,23 @@ jobs:
           cache-to: ${{ steps.registry_refs.outputs.tags }},mode=max
 
   integration-tests:
+    # Only runs for the following conditions: 
+    #  - if github label "run_integration_tests"
+    #  - for commits during when pull request is open OR when it's a push into main or develop branches
     needs: [determine-changes, lint, test, build-container]
     runs-on: ubuntu-latest
-    if: ${{ needs.determine-changes.outputs.non-test-changes }} && contains(github.event.pull_request.labels.*.name, 'run_integration_tests')
+    if: >- 
+      needs.determine-changes.outputs.non-test-changes &&
+      (
+        (
+          contains(github.event.pull_request.labels.*.name, 'run_integration_tests') && 
+          github.event.pull_request.state == 'open'
+        ) ||
+        (
+          github.event_name == 'push' &&
+          (github.ref_name == 'main' || github.ref_name == 'develop')
+        )
+      )
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,7 @@ env:
 jobs:
 
   determine-changes:
+    if: contains(github.event.pull_request.labels.*.name, 'run_integration_tests')
     runs-on: ubuntu-latest
     outputs:
       non-test-changes: ${{ steps.get-changes.outputs.non-test-changes }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,7 +149,7 @@ jobs:
   integration-tests:
     needs: [determine-changes, lint, test, build-container]
     runs-on: ubuntu-latest
-    if: ${{ needs.determine-changes.outputs.non-test-changes }}
+    if: ${{ needs.determine-changes.outputs.non-test-changes }} && contains(github.event.pull_request.labels.*.name, 'run_integration_tests')
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,18 +1,3 @@
-# This workflow will install Python dependencies, run tests (unit and integration), lint, build env with a single version of Python
-# For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
-#
-# Only triggers the lint, tests, build container, determine-changes and integration tests jobs for the following conditions: 
-#  - When the PR has the github label "run_integration_tests" AND commits during when pull request is open 
-#  - When it's a push into main or develop branches
-#  - When it's a release event
-# 
-# integration-tests
-# - In addition, the integration-tests job only runs when determine-changes job determines that
-#   there are non-unit tests changes
-#
-# deploy
-# - deploy job only runs when there is a release event
-
 name: build
 
 on:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-# This workflow will install Python dependencies, run tests and lint with a single version of Python
+# This workflow will install Python dependencies, run tests (unit and integration), lint, build env with a single version of Python
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
 #
 # Only triggers the lint, tests, build container, determine-changes and integration tests jobs for the following conditions: 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,17 +12,14 @@ on:
       # - '.github/workflows/**'             # Ignore all github workflow file changes
 
   pull_request:
-      types:
-        - opened
-        - reopened
+      types: [opened, reopened, labeled]
       paths-ignore:
         - '**.md'                            # All Markdown files
         - '**/docs/**'                       # Documentation directory
         # - '.github/workflows/**'             # Ignore all github workflow file changes
 
   release:
-    types:
-      - created
+    types: [created]
 
   workflow_dispatch:
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,17 @@
 # This workflow will install Python dependencies, run tests and lint with a single version of Python
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
+#
+# Only triggers the lint, tests, build container, determine-changes and integration tests jobs for the following conditions: 
+#  - When the PR has the github label "run_integration_tests" AND commits during when pull request is open 
+#  - When it's a push into main or develop branches
+#  - When it's a release event
+# 
+# integration-tests
+# - In addition, the integration-tests job only runs when determine-changes job determines that
+#   there are non-unit tests changes
+#
+# deploy
+# - deploy job only runs when there is a release event
 
 name: build
 
@@ -9,14 +21,12 @@ on:
     paths-ignore:
       - '**.md'                            # All Markdown files
       - '**/docs/**'                       # Documentation directory
-      # - '.github/workflows/**'             # Ignore all github workflow file changes
 
   pull_request:
       types: [opened, reopened, labeled, synchronize]
       paths-ignore:
         - '**.md'                            # All Markdown files
         - '**/docs/**'                       # Documentation directory
-        # - '.github/workflows/**'             # Ignore all github workflow file changes
 
   release:
     types: [created]
@@ -32,9 +42,6 @@ env:
 jobs:
 
   determine-changes:
-    # Only runs for the following conditions: 
-    #  - if github label "run_integration_tests"
-    #  - for commits during when pull request is open OR when it's a push into main or develop branches
     if: >- 
       (
         (

--- a/README.md
+++ b/README.md
@@ -168,3 +168,7 @@ These are instructions on how you would develop and test the pipeline locally.
 ## Production
 
 The production pipeline is run on Nextflow Tower and the Nextflow workflow is captured in [nf-genie](https://github.com/Sage-Bionetworks-Workflows/nf-genie).  It is wise to create an ec2 via the Sage Bionetworks service catalog to work with the production data, because there is limited PHI in GENIE.
+
+## Github Workflows
+
+For technical details about our CI/CD, please see [the github workflows README](.github/workflows/README.md)


### PR DESCRIPTION
# **Problem:**
We only have one test synapse project in genie, and often times, we run into an concurrency issue with the CI/CD integration tests (which runs the test pipeline in synapse) because our synapse project cannot handle more than 1 ongoing pipeline run. 

Here are some of the situations we would get concurrency runs:
- push multiple commits within the span of an hour or so but maybe the integration tests in the test synapse project hasn't finished running from the 1st commit, so we have multiple ongoing 
- multiple people testing/working on the same pipeline
- we have a scheduled automate truststore ci/cd which runs parts of the test pipeline

JIRA Ticket: https://sagebionetworks.jira.com/browse/GEN-1654

Workflow mini design doc: https://sagebionetworks.jira.com/browse/GEN-1654?focusedCommentId=267713

# **Solution:**
Only trigger the lint, pytest, build-container and integration tests github action jobs when we have the following conditions:
- When github PR label is `run_integration_tests` AND the PR is open
- When there is a `push` to `develop` or `main` branches

The CI/CD for when a `release` event happens stays the same.

This gives us time to check for concurrent runs / builds / change the annotations / etc. This will change the workflow so that we have to open up at least a draft PR in order to get a container build as well for the feature branch we are developing on

```mermaid
---
title: GitHub Actions Build Workflow (with Conditions)
config:
  theme: "default"
---

flowchart TD
    A([Trigger Event])
    subgraph Triggers
      direction TB
      PR["Pull Request with label:<br/>'run_integration_tests'<br/>and open state"]
      PUSH["Push to main<br/>or develop"]
      REL["Release event"]
    end

    A --> PR
    A --> PUSH
    A --> REL

    subgraph Jobs Order
      direction TB
      DET["determine-changes"]
      TEST["test"]
      LINT["lint"]
      BUILD["build-container"]
      INTEG["integration-tests"]
      DEPLOY["deploy"]
    end

    %% determine-changes
    PR -. "Runs if PR has label\nand is open" .-> DET
    PUSH -. "Runs if push to main/develop" .-> DET
    REL -. "Runs on release" .-> DET

    %% test
    DET -- "Always needed (runs in parallel)" --> TEST

    %% lint
    DET -- "Always needed (runs in parallel)" --> LINT

    %% build-container
    TEST -.-> BUILD
    LINT -.-> BUILD
    BUILD -. "Always, except PR events with incomplete jobs" .-> BUILD

    %% integration-tests
    BUILD -.-> INTEG
    LINT -.-> INTEG
    TEST -.-> INTEG
    DET -. "Needs changes outside tests/" .-> INTEG

    %% deploy job only for release
    BUILD -.-> DEPLOY
    LINT -.-> DEPLOY
    TEST -.-> DEPLOY
    REL -. "Only for release event" .-> DEPLOY

    %% Job notes
    INTEG:::cond_note
    DEPLOY:::cond_note

    classDef cond_note fill:#fffae1,stroke:#aaa,stroke-width:1px,color:#b06b00;
    class INTEG,DEPLOY cond_note;

    %% Legend
    subgraph Legend [Legend]
      direction LR
      note1(( )):::cond_note
      note2["Job only runs for special condition"]
    end
```
# **Testing:**
- [X] Closed the PR and pushed commits to branch - no build run happens
- [X] Opened the PR (no github label) - no build run happens
- [X] Added the label `run_integration_tests` - build occurs: https://github.com/Sage-Bionetworks/Genie/actions/runs/17963691035
- [X] Push a commit to branch while PR is open and has the label `run_integration_tests` - build occurs: https://github.com/Sage-Bionetworks/Genie/actions/runs/17963996288
- [X] Push a commit to branch while PR is open and label `run_integration_tests`is removed  - no build, it is skipped: https://github.com/Sage-Bionetworks/Genie/actions/runs/17964020874