### PR TITLE
[GEN-2283] Add to validation function docstring regarding text consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,14 @@ One of the features of the `aacrgenie` package is that is provides a local valid
 
 These instructions will install all the necessary components for you to run the validator locally on all of your files, including the Synapse client.
 
-1. Create a virtual environment using package manager of your choice (e.g: `conda`, `pipenv`)
+1. Create a virtual environment using package manager of your choice (e.g: `conda`, `pipenv`, `pip`)
+
+Example of creating a simple python environment
+
+```
+python3 -m venv <env_name>
+source <env_name>/bin/activate
+```
 
 2. Install the genie package
 

--- a/genie_registry/clinical.py
+++ b/genie_registry/clinical.py
@@ -116,54 +116,48 @@ def _check_int_year_consistency(
     Check if vital status interval and year columns are consistent in
     their values.
 
-    **TEXT CONSISTENCY**
-
     What determines text consistency:
         - IF exactly one column in the columns being checked is "Unknown" in that row,
             THEN that column with the "Unknown" value has to be the interval column
         - OTHERWISE values must be either all numeric or the SAME string value in
             for each row for all cols that are being checked
 
-    Examples of invalid vs valid text consistency:
+    Here we will show examples of invalid vs valid text consistency:
 
-    Here INT_CONTACT and YEAR_CONTACT are the columns being checked, and INT_CONTACT
+    ```
+    Note: INT_CONTACT and YEAR_CONTACT are the columns being checked, and INT_CONTACT
     is the interval column while YEAR_CONTACT is the year column.
+    ```
 
-    | INT_CONTACT | YEAR_CONTACT |
-    | ----------- | -------------|
-    |   Unknown   |      2012    |
+    Example: VALID Examples
+        | INT_CONTACT | YEAR_CONTACT |
+        | ----------- | -------------|
+        |   Unknown   |      2012    |
 
-    VALID
+        | INT_CONTACT | YEAR_CONTACT |
+        | ----------- | -------------|
+        |   Unknown   |    Unknown   |
 
-    | INT_CONTACT | YEAR_CONTACT |
-    | ----------- | -------------|
-    |   Unknown   |    Unknown   |
+        | INT_CONTACT | YEAR_CONTACT |
+        | ----------- | -------------|
+        |     2012    |      2012    |
 
-    VALID
+        | INT_CONTACT   | YEAR_CONTACT   |
+        | --------------| ---------------|
+        | Not Collected | Not Collected  |
 
-    | INT_CONTACT | YEAR_CONTACT |
-    | ----------- | -------------|
-    |     2012    |    Unknown   |
+    Example: INVALID Examples
+        | INT_CONTACT | YEAR_CONTACT |
+        | ----------- | -------------|
+        |     2012    |    Unknown   |
 
-    INVALID
+        | INT_CONTACT   | YEAR_CONTACT   |
+        | --------------| ---------------|
+        |     2012      | Not Collected  |
 
-    | INT_CONTACT | YEAR_CONTACT |
-    | ----------- | -------------|
-    |     2012    |      2012    |
-
-    VALID
-
-    | INT_CONTACT   | YEAR_CONTACT   |
-    | --------------| ---------------|
-    | Not Collected | Not Collected  |
-
-    VALID
-
-    | INT_CONTACT   | YEAR_CONTACT   |
-    | --------------| ---------------|
-    | 2012          | Not Collected  |
-
-    INVALID
+        | INT_CONTACT   | YEAR_CONTACT   |
+        | --------------| ---------------|
+        | Not collected | Not Released   |
 
     Args:
         clinicaldf (pd.DataFrame): input Clinical Data Frame

--- a/genie_registry/clinical.py
+++ b/genie_registry/clinical.py
@@ -115,59 +115,59 @@ def _check_int_year_consistency(
     """
     Check if vital status interval and year columns are consistent in
     their values.
-    
-    **TEXT CONSISTENCY** 
-    
+
+    **TEXT CONSISTENCY**
+
     What determines text consistency:
         - IF exactly one column in the columns being checked is "Unknown" in that row,
             THEN that column with the "Unknown" value has to be the interval column
-        - OTHERWISE values must be either all numeric or the SAME string value in 
+        - OTHERWISE values must be either all numeric or the SAME string value in
             for each row for all cols that are being checked
 
     Examples of invalid vs valid text consistency:
-    
+
     Here INT_CONTACT and YEAR_CONTACT are the columns being checked, and INT_CONTACT
     is the interval column while YEAR_CONTACT is the year column.
-    
+
     | INT_CONTACT | YEAR_CONTACT |
     | ----------- | -------------|
     |   Unknown   |      2012    |
 
     VALID
-    
+
     | INT_CONTACT | YEAR_CONTACT |
     | ----------- | -------------|
     |   Unknown   |    Unknown   |
 
     VALID
-    
+
     | INT_CONTACT | YEAR_CONTACT |
     | ----------- | -------------|
     |     2012    |    Unknown   |
 
     INVALID
-    
+
     | INT_CONTACT | YEAR_CONTACT |
     | ----------- | -------------|
     |     2012    |      2012    |
 
     VALID
-    
+
     | INT_CONTACT   | YEAR_CONTACT   |
     | --------------| ---------------|
     | Not Collected | Not Collected  |
-    
+
     VALID
-    
+
     | INT_CONTACT   | YEAR_CONTACT   |
     | --------------| ---------------|
     | 2012          | Not Collected  |
-    
+
     INVALID
-    
+
     Args:
         clinicaldf (pd.DataFrame): input Clinical Data Frame
-        cols (List[str]): Columns in the clinical data frame to be 
+        cols (List[str]): Columns in the clinical data frame to be
             checked for consistency
         string_vals (List[str]): String values that aren't integers
 

--- a/genie_registry/clinical.py
+++ b/genie_registry/clinical.py
@@ -5,7 +5,7 @@ import datetime
 import logging
 import os
 from io import StringIO
-from typing import Optional, Tuple
+from typing import List, Optional, Tuple
 
 import numpy as np
 import pandas as pd
@@ -110,19 +110,69 @@ def _check_int_dead_consistency(clinicaldf: pd.DataFrame) -> str:
 
 
 def _check_int_year_consistency(
-    clinicaldf: pd.DataFrame, cols: list, string_vals: list
+    clinicaldf: pd.DataFrame, cols: List[str], string_vals: List[str]
 ) -> str:
     """
     Check if vital status interval and year columns are consistent in
-    their values
+    their values.
+    
+    **TEXT CONSISTENCY** 
+    
+    What determines text consistency:
+        - IF exactly one column in the columns being checked is "Unknown" in that row,
+            THEN that column with the "Unknown" value has to be the interval column
+        - OTHERWISE values must be either all numeric or the SAME string value in 
+            for each row for all cols that are being checked
 
+    Examples of invalid vs valid text consistency:
+    
+    Here INT_CONTACT and YEAR_CONTACT are the columns being checked, and INT_CONTACT
+    is the interval column while YEAR_CONTACT is the year column.
+    
+    | INT_CONTACT | YEAR_CONTACT |
+    | ----------- | -------------|
+    |   Unknown   |      2012    |
+
+    VALID
+    
+    | INT_CONTACT | YEAR_CONTACT |
+    | ----------- | -------------|
+    |   Unknown   |    Unknown   |
+
+    VALID
+    
+    | INT_CONTACT | YEAR_CONTACT |
+    | ----------- | -------------|
+    |     2012    |    Unknown   |
+
+    INVALID
+    
+    | INT_CONTACT | YEAR_CONTACT |
+    | ----------- | -------------|
+    |     2012    |      2012    |
+
+    VALID
+    
+    | INT_CONTACT   | YEAR_CONTACT   |
+    | --------------| ---------------|
+    | Not Collected | Not Collected  |
+    
+    VALID
+    
+    | INT_CONTACT   | YEAR_CONTACT   |
+    | --------------| ---------------|
+    | 2012          | Not Collected  |
+    
+    INVALID
+    
     Args:
-        clinicaldf: Clinical Data Frame
-        cols: Columns in the clinical data frame
-        string_vals: String values that aren't integers
+        clinicaldf (pd.DataFrame): input Clinical Data Frame
+        cols (List[str]): Columns in the clinical data frame to be 
+            checked for consistency
+        string_vals (List[str]): String values that aren't integers
 
     Returns:
-        Error message if values and inconsistent or blank string
+        Error message if values are inconsistent or blank string
     """
     interval_col = ""
     year_col = ""
@@ -131,7 +181,7 @@ def _check_int_year_consistency(
         # INT/YEAR
         interval_col = col if col.startswith("INT") else interval_col
         year_col = col if col.startswith("YEAR") else year_col
-        # Return empty string is columns don't exist because this error
+        # Return empty string if columns don't exist because this error
         # is already handled.
         if not process_functions.checkColExist(clinicaldf, col):
             return ""


### PR DESCRIPTION
# **Problem:**
For the validation function: [_check_int_year_consistency](https://github.com/Sage-Bionetworks/Genie/blob/b589b316de60e1cafaeb130ba7de020b2498b3b5/genie_registry/clinical.py#L112), it's not very clear what determines if an input clinical file has valid text consistency rows or not. 

# **Solution:**
Add to the docstring with the two scenarios that determines text consistency and provide detailed examples

# **Testing:**
On my local `mkdocs serve` it shows: 

<img width="994" height="736" alt="image" src="https://github.com/user-attachments/assets/fe724249-87e4-42a0-a435-ef21cc101804" />
