### PR TITLE
[GEN-1789]fix dtype not understood issue in maf validation step

### DIFF
--- a/genie_registry/maf.py
+++ b/genie_registry/maf.py
@@ -113,7 +113,7 @@ def _check_allele_col_validity(df: pd.DataFrame) -> str:
     if (
         tsa2_col_exist
         and ref_col_exist
-        and not df.query("REFERENCE_ALLELE == TUMOR_SEQ_ALLELE2").empty
+        and any(df["REFERENCE_ALLELE"] == df["TUMOR_SEQ_ALLELE2"])
     ):
         error = (
             f"{error}maf: Contains instances where values in REFERENCE_ALLELE match values in TUMOR_SEQ_ALLELE2. "

--- a/genie_registry/maf.py
+++ b/genie_registry/maf.py
@@ -119,7 +119,7 @@ def _check_allele_col_validity(df: pd.DataFrame) -> str:
             f"{error}maf: Contains instances where values in REFERENCE_ALLELE match values in TUMOR_SEQ_ALLELE2. "
             "This is invalid. Please correct.\n"
         )
-        row_index = df.query("REFERENCE_ALLELE == TUMOR_SEQ_ALLELE2").index.values
+        row_index = df[df["REFERENCE_ALLELE"] == df["TUMOR_SEQ_ALLELE2"]].index.values
     return error
 
 


### PR DESCRIPTION
# **Problem:**

We ran into when calling `not df.query("REFERENCE_ALLELE == TUMOR_SEQ_ALLELE2").empty`
```    
File "/usr/local/lib/python3.10/dist-packages/pandas/core/dtypes/common.py", line 1684, in pandas_dtype
      raise TypeError(f"dtype '{dtype}' not understood")
  TypeError: dtype 'COMMENTS    float64
  COMMENTS    float64
  COMMENTS    float64
  dtype: object' not understood
```
when testing 17.0 package for staging project. 

# **Solution:**

Use `any` instead to check if there are any rows meet the condition. 

# **Test:**

Unit test cases have been added to simulate duplicate columns in MSK data and all tests passed. 
