### PR TITLE
[GEN-2285] resolve dtype not understood issue

### DIFF
--- a/genie_registry/maf.py
+++ b/genie_registry/maf.py
@@ -113,7 +113,7 @@ def _check_allele_col_validity(df: pd.DataFrame) -> str:
     if (
         tsa2_col_exist
         and ref_col_exist
-        and not df.query("REFERENCE_ALLELE == TUMOR_SEQ_ALLELE2").empty
+        and any(df["REFERENCE_ALLELE"] == df["TUMOR_SEQ_ALLELE2"])
     ):
         error = (
             f"{error}maf: Contains instances where values in REFERENCE_ALLELE match values in TUMOR_SEQ_ALLELE2. "

--- a/genie_registry/maf.py
+++ b/genie_registry/maf.py
@@ -119,7 +119,7 @@ def _check_allele_col_validity(df: pd.DataFrame) -> str:
             f"{error}maf: Contains instances where values in REFERENCE_ALLELE match values in TUMOR_SEQ_ALLELE2. "
             "This is invalid. Please correct.\n"
         )
-        row_index = df.query("REFERENCE_ALLELE == TUMOR_SEQ_ALLELE2").index.values
+        row_index = df[df["REFERENCE_ALLELE"] == df["TUMOR_SEQ_ALLELE2"]].index.values
     return error
 
 

--- a/tests/test_maf.py
+++ b/tests/test_maf.py
@@ -292,7 +292,7 @@ def test_error__check_allele_col():
         (
             pd.DataFrame(
                 dict(
-                    REFERENCE_ALLELE=["A", "A", "A","-"],
+                    REFERENCE_ALLELE=["A", "A", "A", "-"],
                     TUMOR_SEQ_ALLELE2=["A", "C", "C", "A"],
                 )
             ),
@@ -360,6 +360,7 @@ def test_error__check_allele_col():
 def test__check_allele_col_validity(test_df, expected_error):
     error = genie_registry.maf._check_allele_col_validity(test_df)
     assert error == expected_error
+
 
 @pytest.mark.parametrize(
     "test_df,expected_error",
@@ -511,15 +512,19 @@ def test__check_allele_col_validity_with_duplicate_cols(test_df, expected_error)
     error = genie_registry.maf._check_allele_col_validity(test_df)
     assert error == expected_error
 
+
 def test_that__cross_validate_does_not_read_files_if_no_clinical_files(maf_class):
-    with patch.object(
-        validate,
-        "parse_file_info_in_nested_list",
-        return_value={"files": {}, "file_info": {"name": "", "path": ""}},
-    ), patch.object(
-        process_functions,
-        "get_clinical_dataframe",
-    ) as patch_get_df:
+    with (
+        patch.object(
+            validate,
+            "parse_file_info_in_nested_list",
+            return_value={"files": {}, "file_info": {"name": "", "path": ""}},
+        ),
+        patch.object(
+            process_functions,
+            "get_clinical_dataframe",
+        ) as patch_get_df,
+    ):
         errors, warnings = maf_class._cross_validate(pd.DataFrame({}))
         assert warnings == ""
         assert errors == ""
@@ -529,17 +534,22 @@ def test_that__cross_validate_does_not_read_files_if_no_clinical_files(maf_class
 def test_that__cross_validate_does_not_call_check_col_exist_if_clinical_df_read_error(
     maf_class,
 ):
-    with patch.object(
-        validate,
-        "parse_file_info_in_nested_list",
-        return_value={"files": {"some_file"}, "file_info": {"name": "", "path": ""}},
-    ), patch.object(
-        process_functions,
-        "get_clinical_dataframe",
-        side_effect=Exception("mocked error"),
-    ), patch.object(
-        process_functions, "checkColExist"
-    ) as patch_check_col_exist:
+    with (
+        patch.object(
+            validate,
+            "parse_file_info_in_nested_list",
+            return_value={
+                "files": {"some_file"},
+                "file_info": {"name": "", "path": ""},
+            },
+        ),
+        patch.object(
+            process_functions,
+            "get_clinical_dataframe",
+            side_effect=Exception("mocked error"),
+        ),
+        patch.object(process_functions, "checkColExist") as patch_check_col_exist,
+    ):
         errors, warnings = maf_class._cross_validate(pd.DataFrame({}))
         assert warnings == ""
         assert errors == ""
@@ -549,19 +559,23 @@ def test_that__cross_validate_does_not_call_check_col_exist_if_clinical_df_read_
 def test_that__cross_validate_does_not_call_check_values_if_id_cols_do_not_exist(
     maf_class,
 ):
-    with patch.object(
-        validate,
-        "parse_file_info_in_nested_list",
-        return_value={"files": {"some_file"}, "file_info": {"name": "", "path": ""}},
-    ), patch.object(
-        process_functions,
-        "get_clinical_dataframe",
-        return_value=pd.DataFrame({"test_col": [2, 3, 4]}),
-    ), patch.object(
-        process_functions, "checkColExist", return_value=False
-    ), patch.object(
-        validate, "check_values_between_two_df"
-    ) as patch_check_values:
+    with (
+        patch.object(
+            validate,
+            "parse_file_info_in_nested_list",
+            return_value={
+                "files": {"some_file"},
+                "file_info": {"name": "", "path": ""},
+            },
+        ),
+        patch.object(
+            process_functions,
+            "get_clinical_dataframe",
+            return_value=pd.DataFrame({"test_col": [2, 3, 4]}),
+        ),
+        patch.object(process_functions, "checkColExist", return_value=False),
+        patch.object(validate, "check_values_between_two_df") as patch_check_values,
+    ):
         errors, warnings = maf_class._cross_validate(pd.DataFrame({}))
         assert warnings == ""
         assert errors == ""
@@ -602,17 +616,20 @@ def test_that__cross_validate_does_not_call_check_values_if_id_cols_do_not_exist
 def test_that__cross_validate_returns_expected_msg_if_valid(
     maf_class, valid_maf_df, test_clinical_df, expected_warning, expected_error
 ):
-    with patch.object(
-        validate,
-        "parse_file_info_in_nested_list",
-        return_value={
-            "files": {"some_file"},
-            "file_info": {"name": "data_clinical_supp.txt", "path": ""},
-        },
-    ), patch.object(
-        process_functions,
-        "get_clinical_dataframe",
-        return_value=test_clinical_df,
+    with (
+        patch.object(
+            validate,
+            "parse_file_info_in_nested_list",
+            return_value={
+                "files": {"some_file"},
+                "file_info": {"name": "data_clinical_supp.txt", "path": ""},
+            },
+        ),
+        patch.object(
+            process_functions,
+            "get_clinical_dataframe",
+            return_value=test_clinical_df,
+        ),
     ):
         errors, warnings = maf_class._cross_validate(mutationDF=valid_maf_df)
         assert warnings == expected_warning
@@ -712,9 +729,11 @@ def test_that__get_dataframe_uses_correct_columns_to_replace(
     maf_class, input, expected_columns
 ):
     file = "Hugo_Symbol\tEntrez_Gene_Id\tReference_Allele\n" "TEST\t3845\tNA"
-    with patch(OPEN_BUILTIN, mock_open(read_data=file)), patch.object(
-        pd, "read_csv", return_value=input
-    ), patch.object(transform, "_convert_values_to_na") as patch_convert_to_na:
+    with (
+        patch(OPEN_BUILTIN, mock_open(read_data=file)),
+        patch.object(pd, "read_csv", return_value=input),
+        patch.object(transform, "_convert_values_to_na") as patch_convert_to_na,
+    ):
         maf_class._get_dataframe(["some_path"])
         patch_convert_to_na.assert_called_once_with(
             input_df=input,


### PR DESCRIPTION
# **Problem:**

We ran into when calling `not df.query("REFERENCE_ALLELE == TUMOR_SEQ_ALLELE2").empty`
```    
File "/usr/local/lib/python3.10/dist-packages/pandas/core/dtypes/common.py", line 1684, in pandas_dtype
      raise TypeError(f"dtype '{dtype}' not understood")
  TypeError: dtype 'COMMENTS    float64
  COMMENTS    float64
  COMMENTS    float64
  dtype: object' not understood
```
when testing 17.0 package for staging project. 

# **Solution:**

Use `any` instead to check if there are any rows meet the condition. 

# **Test:**

Unit test cases have been added to simulate duplicate columns in MSK data and all tests passed. 
