### PR TITLE
[GEN-2311] Deprecate dockerhub info

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,5 @@
 {
-    "image": "sagebionetworks/genie:latest",
+    "image": "ghcr.io/sage-bionetworks/genie:main",
     "mounts": [
         "source=${localEnv:HOME}/.synapseConfig,target=/root/.synapseConfig,type=bind,consistency=cached"
     ]

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,5 @@
 {
-    "image": "ghcr.io/sage-bionetworks/genie:main",
+    "image": "ghcr.io/sage-bionetworks/genie:develop",
     "mounts": [
         "source=${localEnv:HOME}/.synapseConfig,target=/root/.synapseConfig,type=bind,consistency=cached"
     ]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -175,11 +175,8 @@ Follow this section when modifying the [Dockerfile](https://github.com/Sage-Bion
 1. ```docker run --rm -it -e SYNAPSE_AUTH_TOKEN=$YOUR_SYNAPSE_TOKEN <some_docker_image_name>```
 1. Run [test code](README.md#developing-locally) relevant to the dockerfile changes to make sure changes are present and working
 1. Once changes are tested, follow [genie contributing guidelines](#developing) for adding it to the repo
-1. Once deployed to main, make sure docker image was successfully deployed remotely (our docker image gets automatically deployed) [here](https://hub.docker.com/repository/docker/sagebionetworks/genie/builds)
-
-#### Dockerhub
-
-This repository does not use github actions to push docker images.  By adding the `sagebiodockerhub` github user as an Admin to this GitHub repository, we can configure an automated build in DockerHub.  You can view the builds [here](https://hub.docker.com/repository/docker/sagebionetworks/genie/builds).  To get admin access to the DockerHub repository, ask Sage IT to be added to the `genieadmin` DockerHub team.
+1. Once deployed to main, make sure the CI/CD build successfully completed (our docker image gets automatically deployed via Github Actions CI/CD) [here](https://github.com/Sage-Bionetworks/Genie/actions/workflows/ci.yml)
+1. Check that your docker image got successfully deployed [here](https://github.com/Sage-Bionetworks/Genie/pkgs/container/genie)
 
 ### Contributing to the docs
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,8 @@
 # AACR Project GENIE
 
 [![PyPi](https://img.shields.io/pypi/v/aacrgenie.svg?style=for-the-badge&label=PyPi&logo=PyPi)](https://pypi.org/project/aacrgenie)
-[![Docker Automated](https://img.shields.io/docker/automated/sagebionetworks/genie.svg?style=for-the-badge&logo=docker)](https://hub.docker.com/r/sagebionetworks/genie)
+[![Build & Push](https://github.com/sage-bionetworks/genie/actions/workflows/ci.yml/badge.svg?style=for-the-badge&logo=github)](https://github.com/sage-bionetworks/genie/actions/workflows/ci.yml)
+[![GHCR Docker Package](https://img.shields.io/badge/ghcr.io-sage--bionetworks%2Fgenie-blue?style=for-the-badge&logo=github)](https://github.com/orgs/sage-bionetworks/packages/container/package/genie)
 [![GitHub CI](https://img.shields.io/github/actions/workflow/status/Sage-Bionetworks/Genie/ci.yml?branch=develop&style=for-the-badge&logo=github)](https://github.com/Sage-Bionetworks/Genie)
 
 ## Introduction

--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 # AACR Project GENIE
 
 [![PyPi](https://img.shields.io/pypi/v/aacrgenie.svg?style=for-the-badge&label=PyPi&logo=PyPi)](https://pypi.org/project/aacrgenie)
-[![Build & Push](https://github.com/sage-bionetworks/genie/actions/workflows/ci.yml/badge.svg?style=for-the-badge&logo=github)](https://github.com/sage-bionetworks/genie/actions/workflows/ci.yml)
 [![GHCR Docker Package](https://img.shields.io/badge/ghcr.io-sage--bionetworks%2Fgenie-blue?style=for-the-badge&logo=github)](https://github.com/orgs/sage-bionetworks/packages/container/package/genie)
 [![GitHub CI](https://img.shields.io/github/actions/workflow/status/Sage-Bionetworks/Genie/ci.yml?branch=develop&style=for-the-badge&logo=github)](https://github.com/Sage-Bionetworks/Genie)
 


### PR DESCRIPTION
# **Problem:**
This is the start of clean-up to do for Genie repos that have migrated to using GHCR from dockerhub for docker deployment. We have already migrated to using GHCR but we still have dockerhub automatic deployment set up for this repository.

# **Solution:**
Deprecate and remove all traces of dockerhub in the documentation and switch to GHCR.

# **Testing:**
For just the `dev-container` portion verified that using VSCode's open in container feature will pull down the GHCR docker image
<img width="728" height="329" alt="image" src="https://github.com/user-attachments/assets/ec309370-e416-4944-bb74-e03cfc79dcf5" />


Successfully opened VSCode in the docker image, and then was able to successfully runs tests inside the dev container
<img width="1506" height="949" alt="image" src="https://github.com/user-attachments/assets/f127ba92-8e8e-4426-a8fc-5b3155c8d0da" />
