### PR TITLE
[GEN-2332] Add workflow to build genome nexus annotator

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -117,7 +117,7 @@ For more background on the truststore and troubleshooting, please see:
 This workflow will update and build the Genome Nexus `annotator.jar` file from a
 user inputted param: `commit_hash`. This `commit_hash` value comes from pulling from a specific commit in the [genome-nexus-annotation-pipeline](github.com/genome-nexus/genome-nexus-annotation-pipeline).
 
-This workflow runs **on demand** [through triggering the workflow via Github Actions](https://github.com/Sage-Bionetworks/Genie/actions/workflows/build_genome_nexus_annotator.yml). 
+This workflow runs **on demand** [through triggering the workflow via a pull request to either modify the commit hash or updating something else](https://github.com/Sage-Bionetworks/Genie/actions/workflows/build_genome_nexus_annotator.yml).
 
 After a successful build, it will run the mutation processing step of the pipeline to annotate the test data. The manual part will be checking the annotated test data after this to make sure the results are expected.
 

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -104,9 +104,22 @@ Only triggers the `lint`, `tests`, `build-container`, `determine-changes` and `i
 
 ## automate_truststore.yml
 
-This workflow will update the Genome nexus truststor file on a schedule and then run the mutation processing AND consortium release steps of the pipeline to make sure the pipeline is workfing with the new truststore.
+This workflow will update the Genome nexus truststore file on a schedule and then run the mutation processing AND consortium release steps of the pipeline to make sure the pipeline is working with the new truststore.
 
 The truststore used in our pipeline to run the genome nexus annotator on MAF data.
 
 For more background on the truststore and troubleshooting, please see:
 [Updating Genome Nexus Annotator and Dependencies](https://sagebionetworks.jira.com/wiki/spaces/APGD/pages/3016687662/Updating+Genome+Nexus+Annotator+and+Dependencies#Updating-the-trust-ssl-file)
+
+
+## build_genome_nexus_annotator.yml
+
+This workflow will update and build the Genome Nexus `annotator.jar` file from a
+user inputted param: `commit_hash`. This `commit_hash` value comes from pulling from a specific commit in the [genome-nexus-annotation-pipeline](github.com/genome-nexus/genome-nexus-annotation-pipeline).
+
+This workflow runs **on demand** [through triggering the workflow via Github Actions](https://github.com/Sage-Bionetworks/Genie/actions/workflows/build_genome_nexus_annotator.yml). 
+
+After a successful build, it will run the mutation processing step of the pipeline to annotate the test data. The manual part will be checking the annotated test data after this to make sure the results are expected.
+
+For more background on the `annotator.jar`, validating the annotated results after the build and troubleshooting, please see:
+[Updating Genome Nexus Annotator and Dependencies](https://sagebionetworks.jira.com/wiki/spaces/APGD/pages/3016687662/Updating+Genome+Nexus+Annotator+and+Dependencies#Updating-the-annotator.jar)

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -119,7 +119,7 @@ user inputted param: `commit_hash`. This `commit_hash` value comes from pulling 
 
 This workflow runs **on demand** [through triggering the workflow via a pull request to either modify the commit hash or updating something else](https://github.com/Sage-Bionetworks/Genie/actions/workflows/build_genome_nexus_annotator.yml).
 
-After a successful build, it will run the mutation processing step of the pipeline to annotate the test data. The manual part will be checking the annotated test data after this to make sure the results are expected.
+After a successful build and upload to the [Genome Nexus Testing folder on synapse](https://www.synapse.org/Synapse:syn70781006), it will run the mutation processing step of the pipeline to annotate the test data. The manual part will be checking the annotated test data after this to make sure the results are expected.
 
 For more background on the `annotator.jar`, validating the annotated results after the build and troubleshooting, please see:
 [Updating Genome Nexus Annotator and Dependencies](https://sagebionetworks.jira.com/wiki/spaces/APGD/pages/3016687662/Updating+Genome+Nexus+Annotator+and+Dependencies#Updating-the-annotator.jar)

--- a/.github/workflows/build_genome_nexus_annotator.yml
+++ b/.github/workflows/build_genome_nexus_annotator.yml
@@ -14,7 +14,7 @@ on:
 env:
     # versions for dependencies used in annotator.jar build
     MAVEN_VERSION: '3.9.9'
-    COMMIT_HASH: 2e67ebd08cf7c26bf1f55f2baf4b73ac36531119
+    COMMIT_HASH: ${{ github.event.inputs.commit_hash || 'default_value' }}
     JAVA_VERSION: "21"
     JAVA_DISTRIBUTION: "corretto"
     # synapse id of the Genome Nexus folder

--- a/.github/workflows/build_genome_nexus_annotator.yml
+++ b/.github/workflows/build_genome_nexus_annotator.yml
@@ -4,13 +4,6 @@ on:
   push:
     paths:
       - '.github/workflows/build_genome_nexus_annotator.yml'
-  workflow_dispatch:
-    inputs:
-      commit_hash:
-        description: "Genome Nexus pipeline commit hash to use for version of annotator.jar"
-        required: true
-        default: "2e67ebd08cf7c26bf1f55f2baf4b73ac36531119"
-
 env:
     # versions for dependencies used in annotator.jar build
     MAVEN_VERSION: '3.9.9'

--- a/.github/workflows/build_genome_nexus_annotator.yml
+++ b/.github/workflows/build_genome_nexus_annotator.yml
@@ -1,0 +1,119 @@
+name: Build and Upload Genome Nexus Annotator
+
+on:
+  workflow_dispatch:
+    inputs:
+      commit_hash:
+        description: "Genome Nexus pipeline commit hash"
+        required: true
+        default: "main"
+
+jobs:
+  build-annotator:
+    runs-on: ubuntu-latest
+
+    env:
+      MAVEN_VERSION: 3.9.9
+      SYNAPSE_ENTITY_ID: syn22084320
+      SYNAPSE_AUTH_TOKEN: ${{ secrets.SYNAPSE_AUTH_TOKEN }}
+      PROD_DOCKER: ghcr.io/sage-bionetworks/genie:main
+      TEST_PROJECT_SYNID: syn7208886
+
+    steps:
+      - name: Checkout workflow repo
+        uses: actions/checkout@v4
+
+      - name: Set up Java (Amazon Corretto 21)
+        uses: actions/setup-java@v4
+        with:
+          java-version: "21"
+          distribution: "corretto"
+
+      - name: Install Maven
+        run: |
+          wget https://archive.apache.org/dist/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.zip
+          unzip apache-maven-${MAVEN_VERSION}-bin.zip
+          echo "$PWD/apache-maven-${MAVEN_VERSION}/bin" >> $GITHUB_PATH
+
+      - name: Install Python & Synapse client
+        run: |
+          python3 -m pip install --upgrade pip
+          pip install synapseclient chardet
+
+      - name: Clone Genome Nexus Annotation Pipeline
+        run: |
+          git clone genome-nexus-annotation-pipeline
+          cd genome-nexus-annotation-pipeline
+          git checkout ${{ github.event.inputs.commit_hash }}
+
+      - name: Configure application.properties and log4j.properties
+        run: |
+          cd genome-nexus-annotation-pipeline
+          CONFIG_PATH="annotationPipeline/src/main/resources"
+          mkdir -p $CONFIG_PATH
+
+          # Create or overwrite application.properties
+          cat <<EOF > ${CONFIG_PATH}/application.properties
+            spring.batch.job.enabled=false
+            spring.jmx.enabled=false
+            chunk=100
+            genomenexus.enrichment_fields=annotation_summary,sift,polyphen,my_variant_info
+            genomenexus.isoform_query_parameter=isoformOverrideSource
+            genomenexus.base=https://genie.genomenexus.org/
+            EOF
+
+          # Create or overwrite log4j.properties
+          cat <<EOF > ${CONFIG_PATH}/log4j.properties
+            log4j.appender.a.File=/tmp/genomenexus-logfile.log
+            EOF
+
+          echo "[INFO] Application and log configs written."
+
+      - name: Build annotator.jar
+        run: |
+          cd genome-nexus-annotation-pipeline
+          mvn clean install -DskipTests
+          find . -name annotator.jar
+
+      - name: Upload annotator.jar to Synapse
+        env:
+          COMMIT_HASH: ${{ github.event.inputs.commit_hash }}
+        run: |
+          cd genome-nexus-annotation-pipeline
+          FILE_PATH=$(find . -name annotator.jar | head -n 1)
+          echo "Uploading $FILE_PATH to Synapse entity $SYNAPSE_ENTITY_ID..."
+
+          synapse login --authToken "$SYNAPSE_AUTH_TOKEN"
+          # Upload with version comment
+          synapse store "$FILE_PATH" \
+            --parentid "$SYNAPSE_ENTITY_ID" \
+            --versionComment "Automated Genome Nexus annotator build from commit $COMMIT_HASH"
+
+  check-truststore-update:
+    needs: update_truststore
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Pull Public Docker Image from GHCR
+      run: |
+        docker pull ${{ env.PROD_DOCKER }}
+
+    - name: Start Docker Container
+      run: |
+        docker run -d --name genie-container \
+            -e SYNAPSE_AUTH_TOKEN="${{ secrets.SYNAPSE_AUTH_TOKEN }}" \
+            ${{ env.PROD_DOCKER }} \
+            sh -c "while true; do sleep 1; done"
+    
+    - name: Run processing on mutation data in test pipeline
+      run: |
+        docker exec genie-container \
+        python3 /root/Genie/bin/input_to_database.py mutation \
+            --project_id ${{ env.TEST_PROJECT_SYNID }} \
+            --genie_annotation_pkg /root/annotation-tools \
+            --createNewMafDatabase
+
+    - name: Stop and Remove Docker Container
+      run: docker stop genie-container && docker rm genie-container

--- a/.github/workflows/build_genome_nexus_annotator.yml
+++ b/.github/workflows/build_genome_nexus_annotator.yml
@@ -89,8 +89,8 @@ jobs:
             --parentid "$SYNAPSE_ENTITY_ID" \
             --versionComment "Automated Genome Nexus annotator build from commit $COMMIT_HASH"
 
-  check-truststore-update:
-    needs: update_truststore
+  check-annotator-build:
+    needs: build-annotator
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repository
@@ -103,7 +103,7 @@ jobs:
     - name: Start Docker Container
       run: |
         docker run -d --name genie-container \
-            -e SYNAPSE_AUTH_TOKEN="${{ secrets.SYNAPSE_AUTH_TOKEN }}" \
+            -e SYNAPSE_AUTH_TOKEN="${{ env.SYNAPSE_AUTH_TOKEN }}" \
             ${{ env.PROD_DOCKER }} \
             sh -c "while true; do sleep 1; done"
     

--- a/.github/workflows/build_genome_nexus_annotator.yml
+++ b/.github/workflows/build_genome_nexus_annotator.yml
@@ -7,7 +7,7 @@ on:
       commit_hash:
         description: "Genome Nexus pipeline commit hash to use for version of annotator.jar"
         required: true
-        default: "main"
+        default: "2e67ebd08cf7c26bf1f55f2baf4b73ac36531119"
 
 jobs:
   build-annotator:
@@ -91,9 +91,7 @@ jobs:
           synapse login
           # Upload with version comment
           synapse store "$FILE_PATH" \
-            --parentid "$SYNAPSE_ENTITY_ID" \
-            --versionComment "Automated Genome Nexus annotator build from commit $COMMIT_HASH"
-
+            --parentid "$SYNAPSE_ENTITY_ID"
   check-annotator-build:
     needs: build-annotator
     runs-on: ubuntu-latest

--- a/.github/workflows/build_genome_nexus_annotator.yml
+++ b/.github/workflows/build_genome_nexus_annotator.yml
@@ -14,7 +14,7 @@ on:
 env:
     # versions for dependencies used in annotator.jar build
     MAVEN_VERSION: '3.9.9'
-    COMMIT_HASH: ${{ github.event.inputs.commit_hash || 'default_value' }}
+    COMMIT_HASH: "2e67ebd08cf7c26bf1f55f2baf4b73ac36531119"
     JAVA_VERSION: "21"
     JAVA_DISTRIBUTION: "corretto"
     # synapse id of the Genome Nexus folder

--- a/.github/workflows/build_genome_nexus_annotator.yml
+++ b/.github/workflows/build_genome_nexus_annotator.yml
@@ -9,22 +9,21 @@ on:
         required: true
         default: "2e67ebd08cf7c26bf1f55f2baf4b73ac36531119"
 
+env:
+    # versions for dependencies used in annotator.jar build
+    MAVEN_VERSION: '3.9.9'
+    COMMIT_HASH: 2e67ebd08cf7c26bf1f55f2baf4b73ac36531119
+    JAVA_VERSION: "21"
+    JAVA_DISTRIBUTION: "corretto"
+    # synapse id of the Genome Nexus folder
+    OUTPUT_FOLDER_SYNAPSE_ID: syn22105656
+    # env vars related to testing the annotator.jar
+    PROD_DOCKER: ghcr.io/sage-bionetworks/genie:main
+    SYNAPSE_AUTH_TOKEN: ${{ secrets.SYNAPSE_AUTH_TOKEN }}
+    TEST_PROJECT_SYNID: syn7208886
 jobs:
   build-annotator:
     runs-on: ubuntu-latest
-
-    env:
-      # versions for dependencies used in annotator.jar build
-      MAVEN_VERSION: '3.9.9'
-      COMMIT_HASH: ${{ github.event.inputs.commit_hash }}
-      JAVA_VERSION: "21"
-      JAVA_DISTRIBUTION: "corretto"
-      # synapse id of the Genome Nexus folder
-      OUTPUT_FOLDER_SYNAPSE_ID: syn22105656
-      # env vars related to testing the annotator.jar
-      PROD_DOCKER: ghcr.io/sage-bionetworks/genie:main
-      SYNAPSE_AUTH_TOKEN: ${{ secrets.SYNAPSE_AUTH_TOKEN }}
-      TEST_PROJECT_SYNID: syn7208886
 
     steps:
       - name: Checkout workflow repo
@@ -51,7 +50,7 @@ jobs:
         run: |
           git clone https://github.com/genome-nexus/genome-nexus-annotation-pipeline.git
           cd genome-nexus-annotation-pipeline
-          git checkout ${{ github.event.inputs.commit_hash }}
+          git checkout ${{ env.COMMIT_HASH }}
 
       - name: Configure application.properties and log4j.properties to be genie specific
         run: |
@@ -60,19 +59,22 @@ jobs:
           mkdir -p $CONFIG_PATH
 
           # Create or overwrite application.properties
-          cat <<EOF > ${CONFIG_PATH}/application.properties
-            spring.batch.job.enabled=false
-            spring.jmx.enabled=false
-            chunk=100
-            genomenexus.enrichment_fields=annotation_summary,sift,polyphen,my_variant_info
-            genomenexus.isoform_query_parameter=isoformOverrideSource
-            genomenexus.base=https://genie.genomenexus.org/
-            EOF
+          cat <<'EOF' > "${CONFIG_PATH}/application.properties"
+spring.batch.job.enabled=false
+spring.jmx.enabled=false
+chunk=100
+genomenexus.enrichment_fields=annotation_summary,sift,polyphen,my_variant_info
+genomenexus.isoform_query_parameter=isoformOverrideSource
+genomenexus.base=https://genie.genomenexus.org/
+EOF
 
           # Create or overwrite log4j.properties
-          cat <<EOF > ${CONFIG_PATH}/log4j.properties
-            log4j.appender.a.File=/tmp/genomenexus-logfile.log
-            EOF
+          cat <<'EOF' > "${CONFIG_PATH}/log4j.properties"
+log4j.appender.a.File=/tmp/genomenexus-logfile.log
+EOF
+
+          echo "[INFO] Application and log configs written."
+
 
           echo "[INFO] Application and log configs written."
 

--- a/.github/workflows/build_genome_nexus_annotator.yml
+++ b/.github/workflows/build_genome_nexus_annotator.yml
@@ -2,6 +2,8 @@ name: Build and Upload Genome Nexus Annotator
 
 on:
   push:
+    paths:
+      - '.github/workflows/build_genome_nexus_annotator.yml'
   workflow_dispatch:
     inputs:
       commit_hash:

--- a/.github/workflows/build_genome_nexus_annotator.yml
+++ b/.github/workflows/build_genome_nexus_annotator.yml
@@ -85,13 +85,24 @@ jobs:
       - name: Upload annotator.jar to Synapse
         run: |
           cd genome-nexus-annotation-pipeline
-          FILE_PATH=$(find . -name annotator.jar | head -n 1)
-          echo "Uploading $FILE_PATH to Synapse entity $SYNAPSE_ENTITY_ID..."
+          # Locate the built JAR dynamically
+          FILE_PATH=$(ls -t annotationPipeline/target/annotationPipeline-*.jar | head -n 1)
+
+          if [ ! -f "$FILE_PATH" ]; then
+            echo "Could not find annotationPipeline JAR under annotationPipeline/target/"
+            echo "Available .jar files:"
+            find annotationPipeline/target -type f -name "*.jar" || true
+            exit 1
+          fi
+
+          echo "Found JAR: $FILE_PATH"
+          echo "Uploading to Synapse entity $SYNAPSE_ENTITY_ID..."
 
           synapse login
-          # Upload with version comment
+
+          # Apload!
           synapse store "$FILE_PATH" \
-            --parentid "$SYNAPSE_ENTITY_ID"
+            --parentid "$SYNAPSE_ENTITY_ID" \
   check-annotator-build:
     needs: build-annotator
     runs-on: ubuntu-latest

--- a/.github/workflows/build_genome_nexus_annotator.yml
+++ b/.github/workflows/build_genome_nexus_annotator.yml
@@ -19,8 +19,8 @@ jobs:
       COMMIT_HASH: ${{ github.event.inputs.commit_hash }}
       JAVA_VERSION: "21"
       JAVA_DISTRIBUTION: "corretto"
-      # synapse id of the annotator.jar
-      SYNAPSE_ENTITY_ID: syn22084320
+      # synapse id of the Genome Nexus folder
+      OUTPUT_FOLDER_SYNAPSE_ID: syn22105656
       # env vars related to testing the annotator.jar
       PROD_DOCKER: ghcr.io/sage-bionetworks/genie:main
       SYNAPSE_AUTH_TOKEN: ${{ secrets.SYNAPSE_AUTH_TOKEN }}
@@ -96,13 +96,20 @@ jobs:
           fi
 
           echo "Found JAR: $FILE_PATH"
-          echo "Uploading to Synapse entity $SYNAPSE_ENTITY_ID..."
+
+          # Rename to annotator.jar
+          TARGET_PATH="annotationPipeline/target/annotator.jar"
+          cp "$FILE_PATH" "$TARGET_PATH"
+
+          echo "Renamed to: $TARGET_PATH"
+          ls -lh "$TARGET_PATH"
+
+          echo "Uploading to Synapse entity ${{ env.OUTPUT_FOLDER_SYNAPSE_ID }}..."
 
           synapse login
 
-          # Apload!
-          synapse store "$FILE_PATH" \
-            --parentid "$SYNAPSE_ENTITY_ID" \
+          # Upload!
+          synapse store "$TARGET_PATH" --parentid ${{ env.OUTPUT_FOLDER_SYNAPSE_ID }}
   check-annotator-build:
     needs: build-annotator
     runs-on: ubuntu-latest

--- a/.github/workflows/build_genome_nexus_annotator.yml
+++ b/.github/workflows/build_genome_nexus_annotator.yml
@@ -49,7 +49,7 @@ jobs:
 
       - name: Clone Genome Nexus Annotation Pipeline and check out commit hash
         run: |
-          git clone genome-nexus-annotation-pipeline
+          git clone https://github.com/genome-nexus/genome-nexus-annotation-pipeline.git
           cd genome-nexus-annotation-pipeline
           git checkout ${{ github.event.inputs.commit_hash }}
 

--- a/.github/workflows/build_genome_nexus_annotator.yml
+++ b/.github/workflows/build_genome_nexus_annotator.yml
@@ -1,10 +1,11 @@
 name: Build and Upload Genome Nexus Annotator
 
 on:
+  push:
   workflow_dispatch:
     inputs:
       commit_hash:
-        description: "Genome Nexus pipeline commit hash"
+        description: "Genome Nexus pipeline commit hash to use for version of annotator.jar"
         required: true
         default: "main"
 
@@ -13,21 +14,27 @@ jobs:
     runs-on: ubuntu-latest
 
     env:
-      MAVEN_VERSION: 3.9.9
+      # versions for dependencies used in annotator.jar build
+      MAVEN_VERSION: '3.9.9'
+      COMMIT_HASH: ${{ github.event.inputs.commit_hash }}
+      JAVA_VERSION: "21"
+      JAVA_DISTRIBUTION: "corretto"
+      # synapse id of the annotator.jar
       SYNAPSE_ENTITY_ID: syn22084320
-      SYNAPSE_AUTH_TOKEN: ${{ secrets.SYNAPSE_AUTH_TOKEN }}
+      # env vars related to testing the annotator.jar
       PROD_DOCKER: ghcr.io/sage-bionetworks/genie:main
+      SYNAPSE_AUTH_TOKEN: ${{ secrets.SYNAPSE_AUTH_TOKEN }}
       TEST_PROJECT_SYNID: syn7208886
 
     steps:
       - name: Checkout workflow repo
         uses: actions/checkout@v4
 
-      - name: Set up Java (Amazon Corretto 21)
+      - name: Set up Java
         uses: actions/setup-java@v4
         with:
-          java-version: "21"
-          distribution: "corretto"
+          java-version: ${{ env.JAVA_VERSION }}
+          distribution: ${{ env.JAVA_DISTRIBUTION }}
 
       - name: Install Maven
         run: |
@@ -40,13 +47,13 @@ jobs:
           python3 -m pip install --upgrade pip
           pip install synapseclient chardet
 
-      - name: Clone Genome Nexus Annotation Pipeline
+      - name: Clone Genome Nexus Annotation Pipeline and check out commit hash
         run: |
           git clone genome-nexus-annotation-pipeline
           cd genome-nexus-annotation-pipeline
           git checkout ${{ github.event.inputs.commit_hash }}
 
-      - name: Configure application.properties and log4j.properties
+      - name: Configure application.properties and log4j.properties to be genie specific
         run: |
           cd genome-nexus-annotation-pipeline
           CONFIG_PATH="annotationPipeline/src/main/resources"
@@ -69,21 +76,19 @@ jobs:
 
           echo "[INFO] Application and log configs written."
 
-      - name: Build annotator.jar
+      - name: Build annotator.jar (skips tests)
         run: |
           cd genome-nexus-annotation-pipeline
           mvn clean install -DskipTests
           find . -name annotator.jar
 
       - name: Upload annotator.jar to Synapse
-        env:
-          COMMIT_HASH: ${{ github.event.inputs.commit_hash }}
         run: |
           cd genome-nexus-annotation-pipeline
           FILE_PATH=$(find . -name annotator.jar | head -n 1)
           echo "Uploading $FILE_PATH to Synapse entity $SYNAPSE_ENTITY_ID..."
 
-          synapse login --authToken "$SYNAPSE_AUTH_TOKEN"
+          synapse login
           # Upload with version comment
           synapse store "$FILE_PATH" \
             --parentid "$SYNAPSE_ENTITY_ID" \

--- a/.github/workflows/build_genome_nexus_annotator.yml
+++ b/.github/workflows/build_genome_nexus_annotator.yml
@@ -4,14 +4,15 @@ on:
   push:
     paths:
       - '.github/workflows/build_genome_nexus_annotator.yml'
+
 env:
     # versions for dependencies used in annotator.jar build
     MAVEN_VERSION: '3.9.9'
     COMMIT_HASH: "2e67ebd08cf7c26bf1f55f2baf4b73ac36531119"
     JAVA_VERSION: "21"
     JAVA_DISTRIBUTION: "corretto"
-    # synapse id of the Genome Nexus folder
-    OUTPUT_FOLDER_SYNAPSE_ID: syn22105656
+    # synapse id of the Genome Nexus Testing folder
+    OUTPUT_FOLDER_SYNAPSE_ID: syn70781006
     # env vars related to testing the annotator.jar
     PROD_DOCKER: ghcr.io/sage-bionetworks/genie:main
     SYNAPSE_AUTH_TOKEN: ${{ secrets.SYNAPSE_AUTH_TOKEN }}
@@ -47,28 +48,32 @@ jobs:
           cd genome-nexus-annotation-pipeline
           git checkout ${{ env.COMMIT_HASH }}
 
-      - name: Configure application.properties and log4j.properties to be genie specific
+      - name: Configure application.properties and log4j.properties to be GENIE-specific
         run: |
-          cd genome-nexus-annotation-pipeline
-          CONFIG_PATH="annotationPipeline/src/main/resources"
-          mkdir -p $CONFIG_PATH
+            cd genome-nexus-annotation-pipeline
+            CONFIG_PATH="annotationPipeline/src/main/resources"
+            mkdir -p "$CONFIG_PATH"
 
-          # Create or overwrite application.properties
-          cat <<'EOF' > "${CONFIG_PATH}/application.properties"
-          spring.batch.job.enabled=false
-          spring.jmx.enabled=false
-          chunk=100
-          genomenexus.enrichment_fields=annotation_summary,sift,polyphen,my_variant_info
-          genomenexus.isoform_query_parameter=isoformOverrideSource
-          genomenexus.base=https://genie.genomenexus.org/
-          EOF
+            # Copy example configs first
+            cp "${CONFIG_PATH}/application.properties.EXAMPLE" "${CONFIG_PATH}/application.properties"
+            cp "${CONFIG_PATH}/log4j.properties.EXAMPLE" "${CONFIG_PATH}/log4j.properties"
 
-          # Create or overwrite log4j.properties
-          cat <<'EOF' > "${CONFIG_PATH}/log4j.properties"
-          log4j.appender.a.File=/tmp/genomenexus-logfile.log
-          EOF
+            # Modify application.properties lines in place
+            sed -i \
+            -e 's|^spring.batch.job.enabled=.*|spring.batch.job.enabled=false|' \
+            -e 's|^spring.jmx.enabled=.*|spring.jmx.enabled=false|' \
+            -e 's|^chunk=.*|chunk=100|' \
+            -e 's|^genomenexus.enrichment_fields=.*|genomenexus.enrichment_fields=annotation_summary,sift,polyphen,my_variant_info|' \
+            -e 's|^genomenexus.isoform_query_parameter=.*|genomenexus.isoform_query_parameter=isoformOverrideSource|' \
+            -e 's|^genomenexus.base=.*|genomenexus.base=https://genie.genomenexus.org/|' \
+            "${CONFIG_PATH}/application.properties"
 
-          echo "[INFO] Application and log configs written."
+            # Modify log4j.properties line
+            sed -i \
+            -e 's|^log4j.appender.a.File.*|log4j.appender.a.File=/tmp/genomenexus-logfile.log|' \
+            "${CONFIG_PATH}/log4j.properties"
+
+            echo "[INFO] Application and log configs updated from EXAMPLE files."
 
       - name: Build annotator.jar (skips tests)
         run: |
@@ -76,7 +81,7 @@ jobs:
           mvn clean install -DskipTests
           find . -name annotator.jar
 
-      - name: Upload annotator.jar to Synapse
+      - name: Upload annotator.jar, application.properties and log4j.properties to Synapse
         run: |
           cd genome-nexus-annotation-pipeline
           # Locate the built JAR dynamically
@@ -102,8 +107,14 @@ jobs:
 
           synapse login
 
-          # Upload!
+          # Upload annotator.jar file!
           synapse store "$TARGET_PATH" --parentid ${{ env.OUTPUT_FOLDER_SYNAPSE_ID }}
+          
+          # Upload application and log4j files
+          CONFIG_PATH="annotationPipeline/src/main/resources"
+          synapse store "${CONFIG_PATH}/application.properties" --parentid ${{ env.OUTPUT_FOLDER_SYNAPSE_ID }}
+          synapse store "${CONFIG_PATH}/log4j.properties" --parentid ${{ env.OUTPUT_FOLDER_SYNAPSE_ID }}
+          
   check-annotator-build:
     needs: build-annotator
     runs-on: ubuntu-latest

--- a/.github/workflows/build_genome_nexus_annotator.yml
+++ b/.github/workflows/build_genome_nexus_annotator.yml
@@ -60,21 +60,18 @@ jobs:
 
           # Create or overwrite application.properties
           cat <<'EOF' > "${CONFIG_PATH}/application.properties"
-spring.batch.job.enabled=false
-spring.jmx.enabled=false
-chunk=100
-genomenexus.enrichment_fields=annotation_summary,sift,polyphen,my_variant_info
-genomenexus.isoform_query_parameter=isoformOverrideSource
-genomenexus.base=https://genie.genomenexus.org/
-EOF
+          spring.batch.job.enabled=false
+          spring.jmx.enabled=false
+          chunk=100
+          genomenexus.enrichment_fields=annotation_summary,sift,polyphen,my_variant_info
+          genomenexus.isoform_query_parameter=isoformOverrideSource
+          genomenexus.base=https://genie.genomenexus.org/
+          EOF
 
           # Create or overwrite log4j.properties
           cat <<'EOF' > "${CONFIG_PATH}/log4j.properties"
-log4j.appender.a.File=/tmp/genomenexus-logfile.log
-EOF
-
-          echo "[INFO] Application and log configs written."
-
+          log4j.appender.a.File=/tmp/genomenexus-logfile.log
+          EOF
 
           echo "[INFO] Application and log configs written."
 


### PR DESCRIPTION
# **Problem:**
We build the Genome Nexus annotator.jar file used in our main genie maf processing pipeline manually following instructions here: https://sagebionetworks.jira.com/wiki/spaces/APGD/pages/3016687662/Updating+Genome+Nexus+Annotator+and+Dependencies#Updating-the-annotator.jar

This creates room for human error as well as no guarantee in the reproducible environment that we are using each time we manually rebuild
 
# **Solution:**
Create a github actions workflow for building the annotator.jar now that we have all of the main factors down. This will ensure consistent environment each time the annotator.jar is built. 

This workflow is meant to be triggered manually whenever we have a new commit hash for the [genome-nexus-pipeline](https://github.com/genome-nexus/genome-nexus-annotation-pipeline) that we want to use to rebuild our [annotator.jar](https://www.synapse.org/Synapse:syn22084320), we'd go to this workflow and user input the commit hash.

The goal eventually is to also add in user defined inputs for the maven and java versions as well as those are the most subject to change 2nd to the commit hash but due to the known github bug, this will have to wait.

# **Testing:**
- [x] Integration tests pass
- [x] Result of annotated test data matches previous test data (No differences found!)
- [x] Run on actual prod data example and make sure result matches previous annotated data for that center (test on WAKE)