### PR TITLE
[GEN-1654] Add fix to CI/CD for build docker image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -184,7 +184,6 @@ jobs:
       - name: Build and push Docker image
         id: build-and-push
         uses: docker/build-push-action@v5
-        if: github.event_name != 'pull_request'
         with:
           context: .
           push: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -173,6 +173,10 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          # Override the tag source for PRs
+          tags: |
+            type=ref,event=branch
+            type=raw,value=${{ github.head_ref || github.ref_name }}
 
       - name: Format tags as registry refs
         id: registry_refs


### PR DESCRIPTION
# **Problem:**
Our workflow will only trigger the CI/CD to build docker images and run integration tests if it's within a PR and has label `integration_tests` for feature branches (otherwise it triggers on push events for develop and main branches)

But there's an if statement that checks for a non-PR event to build and push the docker image which makes it impossible to build docker images for feature branches since we disabled that for the CI/CD for feature branches

We also need to tag the branch name instead of using the PR name when building the docker image.

# **Solution:**
- Remove impossible to access if statement from build docker image
- Use `github.head_ref` when in PR to build docker image from feature branch instead of PR name, use `github.ref_name` otherwise

# **Testing:**
Build here: https://github.com/Sage-Bionetworks/Genie/actions/runs/18965295444 should run successfully and build the entire docker image

Build is happening:
<img width="1023" height="484" alt="image" src="https://github.com/user-attachments/assets/e8758175-5810-487a-b37a-5fd75093acae" />

Successful building and pulling of correct image name: 
<img width="1036" height="293" alt="image" src="https://github.com/user-attachments/assets/b6679146-a18f-4175-b2e2-f06149cca0ae" />

