### PR TITLE
[GEN-2377] Remove set as index

### DIFF
--- a/genie/dashboard_table_updater.py
+++ b/genie/dashboard_table_updater.py
@@ -366,8 +366,8 @@ def update_oncotree_code_tables(syn, database_mappingdf):
 
     # ### DISTRIBUTION OF PRIMARY ONCOTREE CODE TABLE UPDATE
     primary_code_distributiondf = pd.DataFrame(
-        columns=sorted(list(clinicaldf["CENTER"])),
-        index=sorted(list(clinicaldf["PRIMARY_CODES"])),
+        columns=list(set(clinicaldf["CENTER"])),
+        index=list(set(clinicaldf["PRIMARY_CODES"])),
     )
 
     for center in primary_code_distributiondf.columns:

--- a/genie/dashboard_table_updater.py
+++ b/genie/dashboard_table_updater.py
@@ -312,7 +312,8 @@ def update_oncotree_code_tables(syn, database_mappingdf):
 
     # DISTRIBUTION OF ONCOTREE CODE TABLE UPDATE
     oncotree_code_distributiondf = pd.DataFrame(
-        columns=set(clinicaldf["CENTER"]), index=set(clinicaldf["ONCOTREE_CODE"])
+        columns=list(set(clinicaldf["CENTER"])),
+        index=list(set(clinicaldf["ONCOTREE_CODE"])),
     )
     for center in oncotree_code_distributiondf.columns:
         onc_counts = clinicaldf["ONCOTREE_CODE"][
@@ -365,7 +366,8 @@ def update_oncotree_code_tables(syn, database_mappingdf):
 
     # ### DISTRIBUTION OF PRIMARY ONCOTREE CODE TABLE UPDATE
     primary_code_distributiondf = pd.DataFrame(
-        columns=set(clinicaldf["CENTER"]), index=set(clinicaldf["PRIMARY_CODES"])
+        columns=sorted(list(clinicaldf["CENTER"])),
+        index=sorted(list(clinicaldf["PRIMARY_CODES"])),
     )
 
     for center in primary_code_distributiondf.columns:

--- a/genie/dashboard_table_updater.py
+++ b/genie/dashboard_table_updater.py
@@ -312,8 +312,8 @@ def update_oncotree_code_tables(syn, database_mappingdf):
 
     # DISTRIBUTION OF ONCOTREE CODE TABLE UPDATE
     oncotree_code_distributiondf = pd.DataFrame(
-        columns=list(set(clinicaldf["CENTER"])),
-        index=list(set(clinicaldf["ONCOTREE_CODE"])),
+        columns=sorted(set(clinicaldf["CENTER"])),
+        index=sorted(set(clinicaldf["ONCOTREE_CODE"])),
     )
     for center in oncotree_code_distributiondf.columns:
         onc_counts = clinicaldf["ONCOTREE_CODE"][
@@ -366,8 +366,8 @@ def update_oncotree_code_tables(syn, database_mappingdf):
 
     # ### DISTRIBUTION OF PRIMARY ONCOTREE CODE TABLE UPDATE
     primary_code_distributiondf = pd.DataFrame(
-        columns=list(set(clinicaldf["CENTER"])),
-        index=list(set(clinicaldf["PRIMARY_CODES"])),
+        columns=sorted(set(clinicaldf["CENTER"])),
+        index=sorted(set(clinicaldf["PRIMARY_CODES"])),
     )
 
     for center in primary_code_distributiondf.columns:

--- a/tests/test_dashboard_table_updater.py
+++ b/tests/test_dashboard_table_updater.py
@@ -231,19 +231,18 @@ def test_update_oncotree_code_tables_calls_update_with_expected_dataframes():
         # expected oncotree_code_distributiondf
         expected_df1 = pd.DataFrame(
             {
-                "Oncotree_Code": ["BRCA", "LUNG", "SKIN"],
                 "DFCI": [1, 1, 0],
                 "MSK": [0, 1, 1],
                 "Total": [1, 2, 1],
-            }
-        ).set_index("Oncotree_Code")
-        expected_df1 = expected_df1.reset_index()  # match the original index format
+                "Oncotree_Code": ["BRCA", "LUNG", "SKIN"],
+            },
+            index=["BRCA", "LUNG", "SKIN"],
+        )
 
         # sort by Oncotree_Code to ensure deterministic order
         assert_frame_equal(
-            new_df1.sort_values("Oncotree_Code").reset_index(drop=True),
-            expected_df1.sort_values("Oncotree_Code").reset_index(drop=True),
-            check_dtype=False,
+            new_df1,
+            expected_df1,
         )
 
         # Second call = primary_code_distributiondf update
@@ -263,18 +262,17 @@ def test_update_oncotree_code_tables_calls_update_with_expected_dataframes():
         # expected primary_code_distributiondf
         expected_df2 = pd.DataFrame(
             {
-                "Oncotree_Code": ["BREAST", "LUNG", "SKIN"],
                 "DFCI": [1, 1, 0],
                 "MSK": [0, 1, 1],
                 "Total": [1, 2, 1],
-            }
-        ).set_index("Oncotree_Code")
-        expected_df2 = expected_df2.reset_index()
+                "Oncotree_Code": ["BREAST", "LUNG", "SKIN"],
+            },
+            index=["BREAST", "LUNG", "SKIN"],
+        )
 
         assert_frame_equal(
-            new_df2.sort_values("Oncotree_Code").reset_index(drop=True),
-            expected_df2.sort_values("Oncotree_Code").reset_index(drop=True),
-            check_dtype=False,
+            new_df2,
+            expected_df2,
         )
 
         # Verify _update_table was called with to_delete=True


### PR DESCRIPTION
# **Problem:**
We are running into an issue in the dashboard updater step where you can no longer use `set`s in pandas as the index of a dataframe. 

JIRA Ticket: https://sagebionetworks.jira.com/browse/GEN-2377

# **Solution:**
Similar fix to https://github.com/Sage-Bionetworks/Genie/pull/554, where we remove `set` as the index determinant, but instead add `sorted(set())` as that's more robust than `list(set())` and gives you a guaranteed order each time rather than leaving it up to `set`

# **Testing:**
- Unit tests pass
- There is no testing or staging mode set for this so it can't be tested in integration testing at the moment