### PR TITLE
[GEN-2324] Add VCF validation for expected columns

### DIFF
--- a/genie_registry/vcf.py
+++ b/genie_registry/vcf.py
@@ -133,9 +133,7 @@ class vcf(FileTypeFormat):
                 )
             if vcfdf["FORMAT"].isnull().values.any():
                 total_error += "vcf: Must not have missing values in FORMAT column.\n"
-        total_error += self.validate_tumor_and_normal_sample_columns_exist(
-            input_df=vcfdf
-        )
+        total_error += self.validate_tumor_and_normal_sample_columns(input_df=vcfdf)
         # Require that they report variants mapped to
         # either GRCh37 or hg19 without
         # the chr-prefix.
@@ -175,37 +173,33 @@ class vcf(FileTypeFormat):
         # and output with warnings or errors if the format is not adhered too
         return total_error, warning
 
-    def validate_tumor_and_normal_sample_columns_exist(
-        self, input_df: pd.DataFrame
-    ) -> str:
-        """Validates that the expected tumor sample column and optional normal
-            sample columns are present in the VCF depending on how many
-            columns you have present in the VCF and they have no missing values
+    def validate_tumor_and_normal_sample_columns(self, input_df: pd.DataFrame) -> str:
+        """
+        Validates that the expected tumor sample column and optional normal
+        sample columns are present in the VCF depending on how many
+        columns you have present in the VCF and they have no missing values
 
-            Rules:
-                - VCFs can only have a max of 11 columns including the 9 required columns
-                - For 11 columns VCFs, it is assumed this is a matched tumor normal vcf file
-                    which means there should be a tumor sample and normal sample
-                    column present
-                - For 10 column VCFs, it is assumed this is a single sample vcf file
-                    which means there should be a tumor sample column present
-                - Anything lower than 10 columns is INVALID because you must have at
-                least a tumor sample column on top of the 9 required VCF columns
+        Rules:
+            - VCFs can only have a max of 11 columns including the 9 required columns
+            - For 11 columns VCFs, it is assumed this is a matched tumor normal vcf file
+                which means there should be a tumor sample and normal sample
+                column present
+            - For 10 column VCFs, it is assumed this is a single sample vcf file
+                which means there should be a tumor sample column present
+            - Anything lower than 10 columns is INVALID because you must have at
+            least a tumor sample column on top of the 9 required VCF columns
+            - If tumor sample and/or normal sample columns are present, they must not have
+            any missing values.
 
-                - If tumor sample and normal sample columns are present, they must not have
-                any missing values.
+        Example: VCF with Matched Tumor Normal columns
+            | OTHER_VCF_COLUMNS | GENIE-GOLD-1-1-tumor | GENIE-GOLD-1-1-normal |
+            | ----------------- | -------------------- | --------------------- |
+            |        ...        |         ...          |          ...          |
 
-            Examples:
-
-            VCF with Matched Tumor Normal columns:
-            | GENIE-GOLD-1-1-tumor | GENIE-GOLD-1-1-normal |
-            | -------------------- | --------------------- |
-            |                      |                       |
-
-            VCF with Single Tumor VCF column:
-            | TUMOR |
-            | ----- |
-            |       |
+        Example: VCF with Single Tumor VCF column
+            | OTHER_VCF_COLUMNS | TUMOR |
+            | ----------------- | ----- |
+            |        ...        |  ...  |
 
         Args:
             input_df (pd.DataFrame): input vcf data to be validated

--- a/genie_registry/vcf.py
+++ b/genie_registry/vcf.py
@@ -196,10 +196,15 @@ class vcf(FileTypeFormat):
             | ----------------- | -------------------- | --------------------- |
             |        ...        |         ...          |          ...          |
 
-        Example: VCF with Single Tumor VCF column
+        Example: VCFs with Single Sample Column
             | OTHER_VCF_COLUMNS | TUMOR |
             | ----------------- | ----- |
             |        ...        |  ...  |
+            
+            | OTHER_VCF_COLUMNS | GENIE-GOLD-1-1 |
+            | ----------------- | -------------- |
+            |        ...        |       ...      |
+
 
         Args:
             input_df (pd.DataFrame): input vcf data to be validated

--- a/genie_registry/vcf.py
+++ b/genie_registry/vcf.py
@@ -259,10 +259,10 @@ class vcf(FileTypeFormat):
             )
 
         # validate the values in the tumor and/or normal sample columns if present
-        if sample_id:
+        if process_functions.checkColExist(input_df, key = sample_id):
             if input_df[sample_id].isnull().values.any():
                 error += f"vcf: Must not have missing values in {sample_id} column.\n"
-        if normal_id:
+        if process_functions.checkColExist(input_df, key = normal_id):
             if input_df[normal_id].isnull().values.any():
                 error += f"vcf: Must not have missing values in {normal_id} column.\n"
         return error

--- a/genie_registry/vcf.py
+++ b/genie_registry/vcf.py
@@ -200,7 +200,7 @@ class vcf(FileTypeFormat):
             | OTHER_VCF_COLUMNS | TUMOR |
             | ----------------- | ----- |
             |        ...        |  ...  |
-            
+
             | OTHER_VCF_COLUMNS | GENIE-GOLD-1-1 |
             | ----------------- | -------------- |
             |        ...        |       ...      |
@@ -264,10 +264,10 @@ class vcf(FileTypeFormat):
             )
 
         # validate the values in the tumor and/or normal sample columns if present
-        if process_functions.checkColExist(input_df, key = sample_id):
+        if process_functions.checkColExist(input_df, key=sample_id):
             if input_df[sample_id].isnull().values.any():
                 error += f"vcf: Must not have missing values in {sample_id} column.\n"
-        if process_functions.checkColExist(input_df, key = normal_id):
+        if process_functions.checkColExist(input_df, key=normal_id):
             if input_df[normal_id].isnull().values.any():
                 error += f"vcf: Must not have missing values in {normal_id} column.\n"
         return error

--- a/tests/test_vcf.py
+++ b/tests/test_vcf.py
@@ -27,26 +27,6 @@ def test__validate_filename(vcf_class):
     assert vcf_class.validateFilename(["GENIE-SAGE-ID1.vcf"]) == "vcf"
 
 
-def test_validation_valid_no_samples(vcf_class):
-    vcfDf = pd.DataFrame(
-        {
-            "#CHROM": ["2", "9", "12"],
-            "POS": [69688533, 99401860, 53701241],
-            "ID": ["AAK1", "AAED1", "AAAS"],
-            "REF": ["AANT", "AACG", "AAAN"],
-            "ALT": ["AAK1", "AAED1", "AAAS"],
-            "QUAL": ["AAK1", "AAED1", "AAAS"],
-            "FILTER": ["AAK1", "AAED1", "AAAS"],
-            "INFO": ["AAK1", "AAED1", "AAAS"],
-            "FORMAT": ["AAK1", "AAED1", "AAAS"],
-            "TUMOR": ["AAK1", "AAED1", "AAAS"],
-        }
-    )
-    error, warning = vcf_class._validate(vcfDf)
-    assert error == ""
-    assert warning == ""
-
-
 def test_validation_valid_one_sample_tumor(vcf_class):
     vcfDf = pd.DataFrame(
         {

--- a/tests/test_vcf.py
+++ b/tests/test_vcf.py
@@ -198,6 +198,26 @@ def test_validation_invalid_two_samples_normal(vcf_class):
     assert warning == ""
 
 
+def test_validation_invalid_format_has_nas(vcf_class):
+    vcfDf = pd.DataFrame(
+        {
+            "#CHROM": ["2", "9", "12"],
+            "POS": [69688533, 99401860, 53701241],
+            "ID": ["AAK1", "AAED1", "AAAS"],
+            "REF": ["AANT", "AACG", "AAAN"],
+            "ALT": ["AAK1", "AAED1", "AAAS"],
+            "QUAL": ["AAK1", "AAED1", "AAAS"],
+            "FILTER": ["AAK1", "AAED1", "AAAS"],
+            "INFO": ["AAK1", "AAED1", "AAAS"],
+            "FORMAT": [None, "AAED1", "AAAS"],
+            "TUMOR": ["AAK1", "AAED1", "AAAS"],
+        }
+    )
+    error, warning = vcf_class._validate(vcfDf)
+    assert error == "vcf: Must not have missing values in FORMAT column.\n"
+    assert warning == ""
+
+
 def test_validation_invalid_white_space(vcf_class):
     vcfDf = pd.DataFrame(
         {
@@ -427,11 +447,11 @@ def test_that__get_dataframe_uses_correct_columns_to_replace(
                 "FILTER",
                 "INFO",
                 "FORMAT",
-                "GENIE-SAGE-1-1-normal",
                 "GENIE-SAGE-1-1-tumor",
+                "GENIE-SAGE-1-1-normal",
             ],
             [[1, 2, 3, 4, 5, 6, 7, 8, 9, "a", None]],
-            "vcf: Must not have missing values in GENIE-SAGE-1-1-tumor column.\n",
+            "vcf: Must not have missing values in GENIE-SAGE-1-1-normal column.\n",
         ),
         # Case 7: 11 columns, wrong normal/tumor naming
         (
@@ -480,13 +500,14 @@ def test_that__get_dataframe_uses_correct_columns_to_replace(
         "invalid_tumor_sample_name",
         "tumor_sample_col_has_nas",
         "valid_matched_tumor_normal",
+        "normal_sample_col_has_nas",
         "invalid_normal_sample_name",
         "more_than_11_cols",
     ],
 )
-def test_validate_tumor_and_normal_sample_columns_exist(
+def test_validate_tumor_and_normal_sample_columns(
     columns, data, expected_in_error, vcf_class
 ):
     df = pd.DataFrame(data, columns=columns)
-    result = vcf_class.validate_tumor_and_normal_sample_columns_exist(df)
+    result = vcf_class.validate_tumor_and_normal_sample_columns(df)
     assert expected_in_error == result

--- a/tests/test_vcf.py
+++ b/tests/test_vcf.py
@@ -38,6 +38,8 @@ def test_validation_valid_no_samples(vcf_class):
             "QUAL": ["AAK1", "AAED1", "AAAS"],
             "FILTER": ["AAK1", "AAED1", "AAAS"],
             "INFO": ["AAK1", "AAED1", "AAAS"],
+            "FORMAT": ["AAK1", "AAED1", "AAAS"],
+            "TUMOR": ["AAK1", "AAED1", "AAAS"],
         }
     )
     error, warning = vcf_class._validate(vcfDf)
@@ -101,7 +103,12 @@ def test_validation_missing_format_col(vcf_class):
         }
     )
     error, warning = vcf_class._validate(vcfDf)
-    assert error == "vcf: Must have FORMAT header if sample columns exist.\n"
+    assert error == (
+        "vcf: Must have these headers: CHROM, POS, ID, REF, ALT, QUAL, FILTER, INFO, FORMAT.\n"
+        "vcf: Must have at least 10 columns. "
+        "If the vcf represents a single sample, then it's missing a tumor sample column. "
+        "If the vcf represents a matched tumor normal, then it's missing both normal sample and tumor sample columns.\n"
+    )
     assert warning == ""
 
 
@@ -194,7 +201,7 @@ def test_validation_invalid_two_samples_normal(vcf_class):
 def test_validation_invalid_white_space(vcf_class):
     vcfDf = pd.DataFrame(
         {
-            "#CHROMM": ["2", "9", "12"],
+            "#CHROM": ["2", "9", "12"],
             "POS": [69688533, 99401860, 53701241],
             "ID": ["AAK1", "AAED1", "AAAS"],
             "REF": ["AANT", "AACG", "AAAN"],
@@ -202,13 +209,12 @@ def test_validation_invalid_white_space(vcf_class):
             "QUAL": ["AAK1", "AAED1", "AAAS"],
             "FILTER": ["AAK1", "AA ED1", "AAAS"],
             "INFO": ["AAK1", "AAED1", "AAAS"],
+            "FORMAT": ["AG", "AG", "AG"],
+            "GENIE-SAGE-1-1": ["AG", "AG", "AG"],
         }
     )
     error, warning = vcf_class._validate(vcfDf)
-    expectedError = (
-        "vcf: Must have these headers: CHROM, POS, ID, REF, "
-        "ALT, QUAL, FILTER, INFO.\n"
-    )
+    expectedError = ""
     expectedWarning = "vcf: Should not have any white spaces in any of the columns.\n"
     assert error == expectedError
     assert warning == expectedWarning
@@ -226,6 +232,8 @@ def test_validation_invalid_content(vcf_class):
             "QUAL": ["AAK1", "AAED1", "AAAS", "AAK1"],
             "FILTER": ["AAK1", "AAED1", "AAAS", "AAK1"],
             "INFO": ["AAK1", "AAED1", "AAAS", "AAK1"],
+            "FORMAT": ["AG", "AG", "AG", "AG"],
+            "GENIE-SAGE-1-1": ["AG", "AG", "AG", "AG"],
         }
     )
     error, warning = vcf_class._validate(vcfDf)
@@ -250,7 +258,7 @@ def test_validation_more_than_11_cols(vcf_class):
     larger_df = pd.DataFrame(columns=list(range(0, 12)))
     error, warning = vcf_class._validate(larger_df)
     assert error == (
-        "vcf: Must have these headers: CHROM, POS, ID, REF, ALT, QUAL, FILTER, INFO.\n"
+        "vcf: Must have these headers: CHROM, POS, ID, REF, ALT, QUAL, FILTER, INFO, FORMAT.\n"
         "vcf: Should not have more than 11 columns. "
         "Only single sample or matched tumor normal vcf files are accepted.\n"
     )
@@ -325,3 +333,160 @@ def test_that__get_dataframe_uses_correct_columns_to_replace(
             values_to_replace=["NA", "nan", "NaN"],
             columns_to_convert=expected_columns,
         )
+
+
+@pytest.mark.parametrize(
+    "columns, data, expected_in_error",
+    [
+        # Case 1: only 9 columns — invalid
+        (
+            ["#CHROM", "POS", "ID", "REF", "ALT", "QUAL", "FILTER", "INFO", "FORMAT"],
+            [[1, 2, 3, 4, 5, 6, 7, 8, 9]],
+            "vcf: Must have at least 10 columns. "
+            "If the vcf represents a single sample, then it's missing a tumor sample column. "
+            "If the vcf represents a matched tumor normal, then it's missing both normal sample and tumor sample columns.\n",
+        ),
+        # Case 2: 10 columns, last is TUMOR — valid (no error)
+        (
+            [
+                "#CHROM",
+                "POS",
+                "ID",
+                "REF",
+                "ALT",
+                "QUAL",
+                "FILTER",
+                "INFO",
+                "FORMAT",
+                "TUMOR",
+            ],
+            [[1, 2, 3, 4, 5, 6, 7, 8, 9, "X"]],
+            "",
+        ),
+        # Case 3: 10 columns, non-TUMOR sample name — should call validate_genie_identifier
+        (
+            [
+                "#CHROM",
+                "POS",
+                "ID",
+                "REF",
+                "ALT",
+                "QUAL",
+                "FILTER",
+                "INFO",
+                "FORMAT",
+                "GENIE-TEST-1-1",
+            ],
+            [[1, 2, 3, 4, 5, 6, 7, 8, 9, "X"]],
+            "vcf: tumor sample column must start with GENIE-SAGE if vcf represents a single sample and TUMOR is not the sample column header.\n",
+        ),
+        # Case 4: same but sample col has NA — should include missing value error
+        (
+            [
+                "#CHROM",
+                "POS",
+                "ID",
+                "REF",
+                "ALT",
+                "QUAL",
+                "FILTER",
+                "INFO",
+                "FORMAT",
+                "GENIE-SAGE-1-1",
+            ],
+            [[1, 2, 3, 4, 5, 6, 7, 8, 9, None]],
+            "vcf: Must not have missing values in GENIE-SAGE-1-1 column.\n",
+        ),
+        # Case 5: 11 columns (tumor-normal) — valid
+        (
+            [
+                "#CHROM",
+                "POS",
+                "ID",
+                "REF",
+                "ALT",
+                "QUAL",
+                "FILTER",
+                "INFO",
+                "FORMAT",
+                "GENIE-SAGE-1-1-normal",
+                "GENIE-SAGE-1-1-tumor",
+            ],
+            [[1, 2, 3, 4, 5, 6, 7, 8, 9, "a", "b"]],
+            "",  # no missing values
+        ),
+        # Case 6: 11 columns, tumor column has NA
+        (
+            [
+                "#CHROM",
+                "POS",
+                "ID",
+                "REF",
+                "ALT",
+                "QUAL",
+                "FILTER",
+                "INFO",
+                "FORMAT",
+                "GENIE-SAGE-1-1-normal",
+                "GENIE-SAGE-1-1-tumor",
+            ],
+            [[1, 2, 3, 4, 5, 6, 7, 8, 9, "a", None]],
+            "vcf: Must not have missing values in GENIE-SAGE-1-1-tumor column.\n",
+        ),
+        # Case 7: 11 columns, wrong normal/tumor naming
+        (
+            [
+                "#CHROM",
+                "POS",
+                "ID",
+                "REF",
+                "ALT",
+                "QUAL",
+                "FILTER",
+                "INFO",
+                "FORMAT",
+                "GENIE-SAGE-1-1-tumor",
+                "random_column",
+            ],
+            [[1, 2, 3, 4, 5, 6, 7, 8, 9, "x", "y"]],
+            "vcf: normal sample column must start with GENIE-SAGE\n",
+        ),
+        # Case 8: More than 11 columns
+        (
+            [
+                "#CHROM",
+                "POS",
+                "ID",
+                "REF",
+                "ALT",
+                "QUAL",
+                "FILTER",
+                "INFO",
+                "FORMAT",
+                "GENIE-SAGE-1-1-normal",
+                "GENIE-SAGE-1-1-tumor",
+                "extra_column",
+            ],
+            [[1, 2, 3, 4, 5, 6, 7, 8, 9, "x", "y", "z"]],
+            (
+                "vcf: Should not have more than 11 columns. Only "
+                "single sample or matched tumor normal vcf files are accepted.\n"
+            ),
+        ),
+    ],
+    ids=[
+        "only_nine_cols",
+        "valid_tumor_sample",
+        "invalid_tumor_sample_name",
+        "tumor_sample_col_has_nas",
+        "valid_matched_tumor_normal",
+        "invalid_normal_sample_name",
+        "more_than_11_cols",
+    ],
+)
+def test_validate_tumor_and_normal_sample_columns_exist(
+    columns, data, expected_in_error, vcf_class
+):
+    df = pd.DataFrame(data, columns=columns)
+    result = vcf_class.validate_tumor_and_normal_sample_columns_exist(df)
+    assert expected_in_error == result


### PR DESCRIPTION
# **Problem:**
We need to add VCF validation for:
- expected `FORMAT` column
- expected tumor/sample columns given the number of columns present in the VCF itself
- expecting NO NAs in the `FORMAT` or tumor/sample columns

JIRA Ticket: https://sagebionetworks.jira.com/browse/GEN-2324
# **Solution:**
New `validate_tumor_and_normal_sample_columns_exist` function to do all of the above. Because the validation of the tumor/sample columns are very coupled together with validating their actual values, it was easier to keep the validation together in one function.

# **Testing:**
- [x] - Unit tests pass
- [x] - Integration tests pass
- [x] - Add new input vcf data that would fail and produce certain errors

Data modified:

Added missing value to `GENIE-SAGE-1-1` column, got expected validation error message
```
You have invalid files! Here are the reasons why:

Filenames: GENIE-SAGE-1-1.vcf, Errors:
 ----------------ERRORS----------------
vcf: Must not have missing values in GENIE-SAGE-1-1 column.
```
Made the `FORMAT` column called `FORMAT2` in input data, got expected validation error message
```
You have invalid files! Here are the reasons why:

Filenames: GENIE-TEST-1-1.vcf, Errors:
 ----------------ERRORS----------------
vcf: Must have these headers: CHROM, POS, ID, REF, ALT, QUAL, FILTER, INFO, FORMAT.
```