### PR TITLE
[GEN-2380] Update docs

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,9 @@
 {
-    "image": "ghcr.io/sage-bionetworks/genie:develop",
-    "mounts": [
-        "source=${localEnv:HOME}/.synapseConfig,target=/root/.synapseConfig,type=bind,consistency=cached"
-    ]
+  "name": "genie-dev",
+  "image": "ghcr.io/sage-bionetworks/genie:${localEnv:BRANCH_NAME}",
+  "mounts": [
+    "source=${localEnv:HOME}/.synapseConfig,target=/root/.synapseConfig,type=bind,consistency=cached"
+  ],
+  "runArgs": ["--env", "BRANCH_NAME=${localEnv:BRANCH_NAME}"],
+  "workspaceFolder": "/workspace"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,9 +1,0 @@
-{
-  "name": "genie-dev",
-  "image": "ghcr.io/sage-bionetworks/genie:${localEnv:BRANCH_NAME}",
-  "mounts": [
-    "source=${localEnv:HOME}/.synapseConfig,target=/root/.synapseConfig,type=bind,consistency=cached"
-  ],
-  "runArgs": ["--env", "BRANCH_NAME=${localEnv:BRANCH_NAME}"],
-  "workspaceFolder": "/workspace"
-}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,6 +3,22 @@
 
 We welcome all contributions!  Please head to [issues](https://github.com/Sage-Bionetworks/Genie/issues) to either file any bugs/feature requests or find a task you want to assist with.  Make sure to assign yourself the task if you decide to work on it.
 
+## Table of Contents
+
+- [Coding Style](#coding-style)
+- [The Development Life Cycle](#the-development-life-cycle)
+  - [Fork and clone this repository](#fork-and-clone-this-repository)
+  - [Install development dependencies](#install-development-dependencies)
+  - [Developing](#developing)
+  - [Testing](#testing)
+    - [Running tests](#running-tests)
+      - [Tests in Python](#tests-in-python)
+      - [Tests in R](#tests-in-r)
+    - [Test Development](#test-development)
+      - [Mock Testing](#mock-testing)
+  - [Release Procedure (For Package Maintainers)](#release-procedure-for-package-maintainers)
+  - [Contributing to the docs](#contributing-to-the-docs)
+
 ## Coding Style
 
 This package uses `flake8` - it's settings are described in [setup.cfg](setup.cfg).  The code in this package is also automatically formatted by `black` for consistency.
@@ -26,7 +42,6 @@ This package uses `flake8` - it's settings are described in [setup.cfg](setup.cf
 This will install all the dependencies of the package including the active branch of `Genie`.  We highly recommend that you leverage some form of python version management like [pyenv](https://github.com/pyenv/pyenv) or [anaconda](https://www.anaconda.com/products/individual). Follow [dependencies installation instruction here](./README.md#running-locally)
 
 ### Developing
-
 
 The GENIE project follows the standard [git flow](https://www.atlassian.com/git/tutorials/comparing-workflows/gitflow-workflow) development strategy.
 > To ensure the most fluid development, try not to push to your `develop` or `main` branch.
@@ -78,46 +93,8 @@ The GENIE project follows the standard [git flow](https://www.atlassian.com/git/
 
 This package uses [semantic versioning](https://semver.org/) for releasing new versions. The version should be updated on the `develop` branch as changes are reviewed and merged in by a code maintainer. The version for the package is maintained in the [genie/__init__.py](genie/__init__.py) file.  A github release should also occur every time `develop` is pushed into `main` and it should match the version for the package.
 
-### Developing with Docker
-
-See [using `docker`](./README.md#using-docker-highly-recommended) for setting up the initial docker environment.
-
-A docker build will be created for your feature branch every time you have an open PR on github and add the label `run_integration_tests` to it.
-
-It is recommended to develop with docker. You can either write the code changes locally, push it to your remote and wait for docker to rebuild OR do the following:
-
-1. Make any code changes. These cannot be dependency changes - those would require a docker rebuild.
-1. Create a running docker container with the image that you pulled down or created earlier
-
-    ```
-    docker run -d <docker_image_name> /bin/bash -c "while true; do sleep 1; done"
-    ```
-
-1. Copy your code changes to the docker image:
-
-    ```
-    docker cp <folder or name of file> <docker_image_name>:/root/Genie/<folder or name of files>
-    ```
-
-1. Run your image in interactive mode:
-
-    ```
-    docker exec -it -e SYNAPSE_AUTH_TOKEN=$YOUR_SYNAPSE_TOKEN <docker_image_name> /bin/bash
-    ```
-
-1. Do any commands or tests you need to do
 
 ### Testing
-
-#### Running test pipeline
-
-Currently our Github Actions will run each of the [pipeline steps here](README.md#developing-locally) on the test pipeline. This is triggered by adding the Github label `run_integration_tests` on your open PR.
-
-To trigger `run_integration_tests`:
-
-- Add  `run_integration_tests` for the first time when you just open your PR
-- Remove `run_integration_tests` label and re-add it
-- Make any commit and pushes when the PR is still open
 
 #### Running tests
 
@@ -130,8 +107,6 @@ Here's how to run the test suite:
 ```shell
 pytest -vs tests/
 ```
-
-Tests in Python are also run automatically by Github Actions on any pull request and are required to pass before merging.
 
 ##### Tests in R
 
@@ -186,18 +161,6 @@ Follow gitflow best practices as linked above.
 11. Prior to pushing changes into `develop`, reset any [annotations on the test project](https://www.synapse.org/Synapse:syn11601248/tables/)/[rename maf database table](https://www.synapse.org/Synapse:syn7208886/tables/) as integration tests will run.
 12. Push changes in `develop`.
 13. Wait for the CI/CD to finish.
-
-### Modifying Docker
-
-Follow this section when modifying the [Dockerfile](https://github.com/Sage-Bionetworks/Genie/blob/main/Dockerfile):
-
-1. Have your synapse authentication token handy
-1. ```docker build -f Dockerfile -t <some_docker_image_name> .```
-1. ```docker run --rm -it -e SYNAPSE_AUTH_TOKEN=$YOUR_SYNAPSE_TOKEN <some_docker_image_name>```
-1. Run [test code](README.md#developing-locally) relevant to the dockerfile changes to make sure changes are present and working
-1. Once changes are tested, follow [genie contributing guidelines](#developing) for adding it to the repo
-1. Once deployed to main, make sure the CI/CD build successfully completed (our docker image gets automatically deployed via Github Actions CI/CD) [here](https://github.com/Sage-Bionetworks/Genie/actions/workflows/ci.yml)
-1. Check that your docker image got successfully deployed [here](https://github.com/Sage-Bionetworks/Genie/pkgs/container/genie)
 
 ### Contributing to the docs
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,18 +23,6 @@ This package uses `flake8` - it's settings are described in [setup.cfg](setup.cf
 
 This will install all the dependencies of the package including the active branch of `Genie`.  We highly recommend that you leverage some form of python version management like [pyenv](https://github.com/pyenv/pyenv) or [anaconda](https://www.anaconda.com/products/individual). There are two ways you can install the dependencies for this package.
 
-#### pip
-This is the more traditional way of installing dependencies. Follow instructions [here](https://pip.pypa.io/en/stable/installation/) to learn how to install pip.
-
-```
-pip install -r requirements-dev.txt
-pip install -r requirements.txt
-```
-
-#### pipenv
-`pipenv` is a Python package manager.  Learn more about [pipenv](https://pipenv.pypa.io/en/latest/) and how to install it.
-
-
 ### Developing
 
 The GENIE project follows the standard [git flow](https://www.atlassian.com/git/tutorials/comparing-workflows/gitflow-workflow) development strategy.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,32 +9,35 @@ This package uses `flake8` - it's settings are described in [setup.cfg](setup.cf
 
 ## The Development Life Cycle
 
-### Clone this repository
+### Fork and clone this repository
 
-1. [Clone the repository](https://help.github.com/articles/cloning-a-repository/) to your local machine so you can begin making changes.
+1. See the [Github docs](https://help.github.com/articles/fork-a-repo/) for how to make a copy (a fork) of a repository to your own Github account.
+1. Then, [clone the repository](https://help.github.com/articles/cloning-a-repository/) to your local machine so you can begin making changes.
+1. Add this repository as an [upstream remote](https://help.github.com/en/articles/configuring-a-remote-for-a-fork) on your local git repository so that you are able to fetch the latest commits.
 1. On your local machine make sure you have the latest version of the `develop` branch:
 
     ```
     git checkout develop
-    git pull
+    git pull upstream develop
     ```
 
 ### Install development dependencies
 
-This will install all the dependencies of the package including the active branch of `Genie`.  We highly recommend that you leverage some form of python version management like [pyenv](https://github.com/pyenv/pyenv) or [anaconda](https://www.anaconda.com/products/individual). There are two ways you can install the dependencies for this package.
+This will install all the dependencies of the package including the active branch of `Genie`.  We highly recommend that you leverage some form of python version management like [pyenv](https://github.com/pyenv/pyenv) or [anaconda](https://www.anaconda.com/products/individual). Follow [dependencies installation instruction here](./README.md#running-locally)
 
 ### Developing
+
 
 The GENIE project follows the standard [git flow](https://www.atlassian.com/git/tutorials/comparing-workflows/gitflow-workflow) development strategy.
 > To ensure the most fluid development, try not to push to your `develop` or `main` branch.
 
-1. Navigate to your cloned repository on your computer/server.
+1. (Assuming you have followed all 4 steps above in the "fork and clone this repository" section). Navigate to your cloned repository on your computer/server.
 1. Make sure your `develop` branch is up to date with the `Sage-Bionetworks/Genie` `develop` branch.
 
     ```
-    cd Genie
+    cd {your-github-username}/Genie
     git checkout develop
-    git pull
+    git pull upstream develop
     ```
 
 1. Create a feature branch which off the `develop` branch. If there is a GitHub/JIRA issue that you are addressing, name the branch after the issue with some more detail (like `{GH|GEN}-123-add-some-new-feature`).
@@ -44,10 +47,10 @@ The GENIE project follows the standard [git flow](https://www.atlassian.com/git/
     git checkout -b GEN-123-new-feature
     ```
 
-1. At this point, you have only created the branch locally, you need to push this to your fork on GitHub.
+1. At this point, you have only created the branch locally, you need to push this remotely to Github.
 
     ```
-    git push --set-upstream origin GEN-123-new-feature
+    git push
     ```
 
     You should now be able to see the branch on GitHub. Make commits as you deem necessary. It helps to provide useful commit messages - a commit message saying 'Update' is a lot less helpful than saying 'Remove X parameter because it was unused'.
@@ -69,17 +72,52 @@ The GENIE project follows the standard [git flow](https://www.atlassian.com/git/
     black ./
     ```
 
-1. Once you have completed all the steps above, in Github, create a pull request from the feature branch to the `develop` branch of Sage-Bionetworks/Genie.
+1. Once you have completed all the steps above, in Github, create a pull request from the feature branch of your fork to the `develop` branch of Sage-Bionetworks/Genie.
 
 > *A code maintainer must review and accept your pull request.* A code review ideally happens with both the contributor and the reviewer present, but is not strictly required for contributing. This can be performed remotely (e.g., Zoom, Hangout, or other video or phone conference).
 
 This package uses [semantic versioning](https://semver.org/) for releasing new versions. The version should be updated on the `develop` branch as changes are reviewed and merged in by a code maintainer. The version for the package is maintained in the [genie/__init__.py](genie/__init__.py) file.  A github release should also occur every time `develop` is pushed into `main` and it should match the version for the package.
 
+### Developing with Docker
+
+See [using `docker`](./README.md#using-docker-highly-recommended) for setting up the initial docker environment.
+
+A docker build will be created for your feature branch every time you have an open PR on github and add the label `run_integration_tests` to it.
+
+It is recommended to develop with docker. You can either write the code changes locally, push it to your remote and wait for docker to rebuild OR do the following:
+
+1. Make any code changes. These cannot be dependency changes - those would require a docker rebuild.
+1. Create a running docker container with the image that you pulled down or created earlier
+
+    ```
+    docker run -d <docker_image_name> /bin/bash -c "while true; do sleep 1; done"
+    ```
+
+1. Copy your code changes to the docker image:
+
+    ```
+    docker cp <folder or name of file> <docker_image_name>:/root/Genie/<folder or name of files>
+    ```
+
+1. Run your image in interactive mode:
+
+    ```
+    docker exec -it -e SYNAPSE_AUTH_TOKEN=$YOUR_SYNAPSE_TOKEN <docker_image_name> /bin/bash
+    ```
+
+1. Do any commands or tests you need to do
+
 ### Testing
 
 #### Running test pipeline
 
-Make sure to run each of the [pipeline steps here](README.md#developing-locally) on the test pipeline and verify that your pipeline runs as expected. This is __not__ automatically run by Github Actions and have to be manually run.
+Currently our Github Actions will run each of the [pipeline steps here](README.md#developing-locally) on the test pipeline. This is triggered by adding the Github label `run_integration_tests` on your open PR.
+
+To trigger `run_integration_tests`:
+
+- Add  `run_integration_tests` for the first time when you just open your PR
+- Remove `run_integration_tests` label and re-add it
+- Make any commit and pushes when the PR is still open
 
 #### Running tests
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,16 +9,14 @@ This package uses `flake8` - it's settings are described in [setup.cfg](setup.cf
 
 ## The Development Life Cycle
 
-### Fork and clone this repository
+### Clone this repository
 
-1. See the [Github docs](https://help.github.com/articles/fork-a-repo/) for how to make a copy (a fork) of a repository to your own Github account.
-1. Then, [clone the repository](https://help.github.com/articles/cloning-a-repository/) to your local machine so you can begin making changes.
-1. Add this repository as an [upstream remote](https://help.github.com/en/articles/configuring-a-remote-for-a-fork) on your local git repository so that you are able to fetch the latest commits.
+1. [Clone the repository](https://help.github.com/articles/cloning-a-repository/) to your local machine so you can begin making changes.
 1. On your local machine make sure you have the latest version of the `develop` branch:
 
     ```
     git checkout develop
-    git pull upstream develop
+    git pull
     ```
 
 ### Install development dependencies
@@ -36,35 +34,32 @@ pip install -r requirements.txt
 #### pipenv
 `pipenv` is a Python package manager.  Learn more about [pipenv](https://pipenv.pypa.io/en/latest/) and how to install it.
 
-```
-# Coming soon
-```
 
 ### Developing
 
 The GENIE project follows the standard [git flow](https://www.atlassian.com/git/tutorials/comparing-workflows/gitflow-workflow) development strategy.
 > To ensure the most fluid development, try not to push to your `develop` or `main` branch.
 
-1. (Assuming you have followed all 4 steps above in the "fork and clone this repository" section). Navigate to your cloned repository on your computer/server.
+1. Navigate to your cloned repository on your computer/server.
 1. Make sure your `develop` branch is up to date with the `Sage-Bionetworks/Genie` `develop` branch.
 
     ```
-    cd {your-github-username}/Genie
+    cd Genie
     git checkout develop
-    git pull upstream develop
+    git pull
     ```
 
-1. Create a feature branch which off the `develop` branch. If there is a GitHub/JIRA issue that you are addressing, name the branch after the issue with some more detail (like `{GH|JIRA}-123-add-some-new-feature`).
+1. Create a feature branch which off the `develop` branch. If there is a GitHub/JIRA issue that you are addressing, name the branch after the issue with some more detail (like `{GH|GEN}-123-add-some-new-feature`).
 
     ```
     git checkout develop
-    git checkout -b JIRA-123-new-feature
+    git checkout -b GEN-123-new-feature
     ```
 
 1. At this point, you have only created the branch locally, you need to push this to your fork on GitHub.
 
     ```
-    git push --set-upstream origin JIRA-123-new-feature
+    git push --set-upstream origin GEN-123-new-feature
     ```
 
     You should now be able to see the branch on GitHub. Make commits as you deem necessary. It helps to provide useful commit messages - a commit message saying 'Update' is a lot less helpful than saying 'Remove X parameter because it was unused'.
@@ -86,7 +81,7 @@ The GENIE project follows the standard [git flow](https://www.atlassian.com/git/
     black ./
     ```
 
-1. Once you have completed all the steps above, in Github, create a pull request from the feature branch of your fork to the `develop` branch of Sage-Bionetworks/Genie.
+1. Once you have completed all the steps above, in Github, create a pull request from the feature branch to the `develop` branch of Sage-Bionetworks/Genie.
 
 > *A code maintainer must review and accept your pull request.* A code review ideally happens with both the contributor and the reviewer present, but is not strictly required for contributing. This can be performed remotely (e.g., Zoom, Hangout, or other video or phone conference).
 

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ These are instructions on how you would develop and test the pipeline locally.
     pip install -r requirements-dev.txt
     ```
 
-    If you are having trouble with the above, try installing via `pipenv`
+    If you are having trouble with the above, try installing via [pipenv](https://pipenv.pypa.io/en/latest/installation.html)
 
     1. Specify a python version that is supported by this repo:
         ```pipenv --python <python_version>```

--- a/README.md
+++ b/README.md
@@ -97,6 +97,8 @@ These are instructions on how you would develop and test the pipeline locally.
 1. Make sure you have read through the [GENIE Onboarding Docs](https://sagebionetworks.jira.com/wiki/spaces/APGD/pages/2163344270/Onboarding) and have access to all of the required repositories, resources and synapse projects for Main GENIE.
 1. Be sure you are invited to the Synapse GENIE Admin team.
 1. Make sure you are a Synapse certified user: [Certified User - Synapse User Account Types](https://help.synapse.org/docs/Synapse-User-Account-Types.2007072795.html#SynapseUserAccountTypes-CertifiedUser)
+1. Be sure to clone the cbioportal repo: https://github.com/cBioPortal/cbioportal and `git checkout` the version of the repo pinned to the [Dockerfile](https://github.com/Sage-Bionetworks/Genie/blob/main/Dockerfile)
+1. Be sure to clone the annotation-tools repo: https://github.com/Sage-Bionetworks/annotation-tools and `git checkout` the version of the repo pinned to the [Dockerfile](https://github.com/Sage-Bionetworks/Genie/blob/main/Dockerfile).
 1. Clone this repo and install the package locally.
 
     ```
@@ -131,7 +133,7 @@ These are instructions on how you would develop and test the pipeline locally.
         synapse login
         ```
 
-1. Run the different pipelines on the test project.  The `--project_id syn7208886` points to the test project.
+1. Run the different steps of the pipeline on the test project.  The `--project_id syn7208886` points to the test project. You should always be using the test project when developing, testing and running locally.
 
     1. Validate all the files **excluding vcf files**:
 
@@ -151,7 +153,7 @@ These are instructions on how you would develop and test the pipeline locally.
         python bin/input_to_database.py main --project_id syn7208886 --deleteOld
         ```
 
-    1. Process the mutation data.  Be sure to clone this repo: https://github.com/Sage-Bionetworks/annotation-tools and `git checkout` the version of the repo pinned to the [Dockerfile](https://github.com/Sage-Bionetworks/Genie/blob/main/Dockerfile).  This repo houses the code that re-annotates the mutation data with genome nexus.  The `--createNewMafDatabase` will create a new mutation tables in the test project.  This flag is necessary for production data for two main reasons:
+    1. Process the mutation data. This command uses the `annotation-tools` repo that you cloned previously which houses the code that standardizes/merges the mutation (both maf and vcf) files and re-annotates the mutation data with genome nexus.  The `--createNewMafDatabase` will create a new mutation tables in the test project.  This flag is necessary for production data for two main reasons:
         * During processing of mutation data, the data is appended to the data, so without creating an empty table, there will be duplicated data uploaded.
         * By design, Synapse Tables were meant to be appended to.  When a Synapse Tables is updated, it takes time to index the table and return results. This can cause problems for the pipeline when trying to query the mutation table.  It is actually faster to create an entire new table than updating or deleting all rows and appending new rows when dealing with millions of rows.
         * If you run this more than once on the same day, you'll run into an issue with overwriting the narrow maf table as it already exists. Be sure to rename the current narrow maf database under `Tables` in the test synapse project and try again.
@@ -160,16 +162,16 @@ These are instructions on how you would develop and test the pipeline locally.
         python bin/input_to_database.py mutation --project_id syn7208886 --deleteOld --genie_annotation_pkg ../annotation-tools --createNewMafDatabase
         ```
 
-    1. Create a consortium release.  Be sure to add the `--test` parameter. Be sure to clone the cbioportal repo: https://github.com/cBioPortal/cbioportal and `git checkout` the version of the repo pinned to the [Dockerfile](https://github.com/Sage-Bionetworks/Genie/blob/main/Dockerfile). For consistency, the processingDate specified here should match the one used for TEST pipeline in [nf-genie.](https://github.com/Sage-Bionetworks-Workflows/nf-genie/blob/main/main.nf)
+    1. Create a consortium release.  Be sure to add the `--test` parameter. For consistency, the `processingDate` specified here should match the one used in the `consortium_map` for the `TEST` key [nf-genie.](https://github.com/Sage-Bionetworks-Workflows/nf-genie/blob/main/main.nf)
 
         ```
-        python bin/database_to_staging.py Jul-2022 ../cbioportal TEST --test
+        python bin/database_to_staging.py <processingDate> ../cbioportal TEST --test
         ```
 
-    1. Create a public release.  Be sure to add the `--test` parameter.  Be sure to clone the cbioportal repo: https://github.com/cBioPortal/cbioportal and `git checkout` the version of the repo pinned to the [Dockerfile](https://github.com/Sage-Bionetworks/Genie/blob/main/Dockerfile). For consistency, the processingDate specified here should match the one used for TEST pipeline in [nf-genie.](https://github.com/Sage-Bionetworks-Workflows/nf-genie/blob/main/main.nf)
+    1. Create a public release.  Be sure to add the `--test` parameter. For consistency, the `processingDate` specified here should match the one used in the `public_map` for the `TEST` key [nf-genie.](https://github.com/Sage-Bionetworks-Workflows/nf-genie/blob/main/main.nf)
 
         ```
-        python bin/consortium_to_public.py Jul-2022 ../cbioportal TEST --test
+        python bin/consortium_to_public.py <processingDate> ../cbioportal TEST --test
         ```
 
 ## Production


### PR DESCRIPTION
# **Problem:**
Some parts of our `README` and `CONTRIBUTING` docs are outdated/ could be reshuffled.

# **Solution:**
Main feature to the docs is adding developing with docker sections as that is our most reproducible method for testing and developing with the genie pipeline.

I also removed `devcontainers` because that's not currently very feasible with the R side of our environment and docker. See https://sagebionetworks.jira.com/browse/GEN-2380?focusedCommentId=272977 for more info on this.


# **Testing:**
Run through commands