### PR TITLE
[GEN-2407] Add to genie cli to skip all validation rules requiring internal database access for local validator

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,10 +103,16 @@ Running validator on clinical file
 genie validate data_clinical_supp_SAGE.txt SAGE
 ```
 
-Running validator on cna file. **Note** that the flag `--nosymbol-check` is **REQUIRED** when running the validator for cna files because you would need access to an internal bed database table without it. For DEVELOPERS this is not required.
+Running validator on cna file. **Note** that the flag `--skip-database-checks` is **REQUIRED** when running the validator for cna and assay information files because you would need access to internal bed and clinical database tables respectively without it. For DEVELOPERS this is not required.
 
 ```
-genie validate data_cna_SAGE.txt SAGE --nosymbol-check
+genie validate data_cna_SAGE.txt SAGE --skip-database-checks
+```
+
+Running validator on assay_information file.
+
+```
+genie validate assay_information.yaml SAGE --skip-database-checks
 ```
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -13,9 +13,6 @@
 - [Documentation](#documentation)
 - [Dependencies](#dependencies)
 - [File Validator](#file-validator)
-  - [Setting up your environment](#setting-up-your-environment)
-  - [Running the validator](#running-the-validator)
-  - [Example commands](#example-commands)
 - [Contributing](#contributing)
 - [Sage Bionetworks Only](#sage-bionetworks-only)
   - [Running locally](#running-locally)
@@ -57,63 +54,7 @@ This package contains both R, Python and cli tools.  These are tools or packages
 
 ## File Validator
 
-One of the features of the `aacrgenie` package is that is provides a local validation tool that GENIE data contributors and install and use to validate their files locally prior to uploading to Synapse.
-
-
-### Setting up your environment
-
-These instructions will install all the necessary components for you to run the validator locally on all of your files, including the Synapse client.
-
-1. Create a virtual environment using package manager of your choice (e.g: `conda`, `pipenv`, `pip`)
-
-Example of creating a simple python environment
-
-```
-python3 -m venv <env_name>
-source <env_name>/bin/activate
-```
-
-2. Install the genie package
-
-```
-pip install aacrgenie
-```
-
-3. Verify the installation
-
-```
-genie -v
-```
-
-4. Set up authentication with Synapse through the [local .synapseConfig](https://python-docs.synapse.org/tutorials/authentication/#use-synapseconfig) or using an [environment variable](https://python-docs.synapse.org/tutorials/authentication/#use-environment-variable)
-
-### Running the validator
-
-Get help of all available commands
-
-```
-genie validate -h
-```
-
-### Example commands
-
-Running validator on clinical file
-
-```
-genie validate data_clinical_supp_SAGE.txt SAGE
-```
-
-Running validator on cna file. **Note** that the flag `--skip-database-checks` is **REQUIRED** when running the validator for cna and assay information files because you would need access to internal bed and clinical database tables respectively without it. For DEVELOPERS this is not required.
-
-```
-genie validate data_cna_SAGE.txt SAGE --skip-database-checks
-```
-
-Running validator on assay_information file.
-
-```
-genie validate assay_information.yaml SAGE --skip-database-checks
-```
+Please see the [local file validation tutorial](/docs/tutorials/local_file_validation.md) for more information on this and how to use it.
 
 ## Contributing
 

--- a/docs/tutorials/local_file_validation.md
+++ b/docs/tutorials/local_file_validation.md
@@ -2,12 +2,39 @@
 
 One of the features of the `aacrgenie` package is that is provides a local validation tool that GENIE data contributors and install and use to validate their files locally prior to uploading to Synapse.
 
+## Setting up your environment
+
+These instructions will install all the necessary components for you to run the validator locally on all of your files, including the Synapse client.
+
+1. Create a virtual environment using package manager of your choice (e.g: `conda`, `pipenv`, `pip`)
+
+Example of creating a simple python environment
+
+```bash
+python3 -m venv <env_name>
+source <env_name>/bin/activate
 ```
+
+1. Install the genie package
+
+```bash
 pip install aacrgenie
+```
+
+1. Verify the installation
+
+```bash
 genie -v
 ```
 
-This will install all the necessary components for you to run the validator locally on all of your files, including the Synapse client.  Please view the help to see how to run to validator.
+1. Set up authentication with Synapse through the [local .synapseConfig](https://python-docs.synapse.org/tutorials/authentication/#use-synapseconfig) or using an [environment variable](https://python-docs.synapse.org/tutorials/authentication/#use-environment-variable)
+
+
+This will install all the necessary components for you to run the validator locally on all of your files, including the Synapse client.
+
+## Running the validator
+
+Please view the help to see how to run the validator.
 
 ```
 genie validate -h
@@ -17,4 +44,23 @@ Validate a file
 
 ```
 genie validate data_clinical_supp_SAGE.txt SAGE
+```
+
+### Special Consideration
+
+The flag `--skip-database-checks` is **REQUIRED** when running the validator for cna and assay information files because you would need access to internal bed and clinical database tables respectively without it. Without the flag, you will hit an Synapse `READ access` error.
+
+
+#### Examples
+
+Running validator on cna file.
+
+```
+genie validate data_cna_SAGE.txt SAGE --skip-database-checks
+```
+
+Running validator on assay_information file.
+
+```
+genie validate assay_information.yaml SAGE --skip-database-checks
 ```

--- a/docs/tutorials/local_file_validation.md
+++ b/docs/tutorials/local_file_validation.md
@@ -15,19 +15,19 @@ python3 -m venv <env_name>
 source <env_name>/bin/activate
 ```
 
-1. Install the genie package
+2. Install the genie package
 
 ```bash
 pip install aacrgenie
 ```
 
-1. Verify the installation
+3. Verify the installation
 
 ```bash
 genie -v
 ```
 
-1. Set up authentication with Synapse through the [local .synapseConfig](https://python-docs.synapse.org/tutorials/authentication/#use-synapseconfig) or using an [environment variable](https://python-docs.synapse.org/tutorials/authentication/#use-environment-variable)
+4. Set up authentication with Synapse through the [local .synapseConfig](https://python-docs.synapse.org/tutorials/authentication/#use-synapseconfig) or using an [environment variable](https://python-docs.synapse.org/tutorials/authentication/#use-environment-variable)
 
 
 This will install all the necessary components for you to run the validator locally on all of your files, including the Synapse client.

--- a/genie/__main__.py
+++ b/genie/__main__.py
@@ -95,10 +95,9 @@ def build_parser():
     )
 
     parser_validate.add_argument(
-        "--nosymbol-check",
+        "--skip-database-checks",
         action="store_true",
-        help="Ignores specific post-processing validation criteria related to HUGO symbols "
-        "in the structural variant and cna files.",
+        help="Ignores validation checks that require internal database access",
     )
 
     # TODO: remove this default when private genie project is ready

--- a/genie/input_to_database.py
+++ b/genie/input_to_database.py
@@ -349,7 +349,7 @@ def validatefile(
         #    validator.entitylist = [syn.get(entity) for entity in entities]
 
         valid_cls, message = validator.validate_single_file(
-            oncotree_link=genie_config["oncotreeLink"], nosymbol_check=False
+            oncotree_link=genie_config["oncotreeLink"], skip_database_checks=False
         )
 
         logger.info("VALIDATION COMPLETE")

--- a/genie/validate.py
+++ b/genie/validate.py
@@ -132,7 +132,7 @@ class ValidationHelper(object):
 class GenieValidationHelper(ValidationHelper):
     """A validator helper class for AACR Project Genie."""
 
-    _validate_kwargs = ["nosymbol_check"]
+    _validate_kwargs = ["skip_database_checks"]
 
 
 # TODO: Currently only checks if a user has READ permissions
@@ -249,7 +249,7 @@ def _perform_validate(syn, args):
         genie_config=genie_config,
     )
     mykwargs = dict(
-        nosymbol_check=args.nosymbol_check,
+        skip_database_checks=args.skip_database_checks,
         project_id=args.project_id,
     )
     valid, message = validator.validate_single_file(**mykwargs)

--- a/genie_registry/assay.py
+++ b/genie_registry/assay.py
@@ -381,11 +381,14 @@ class Assayinfo(FileTypeFormat):
         """Validates that all SEQ_ASSAY_IDs in the clinical sample database
             for that center exists in the assay information file for that center.
 
-            Breakdown:
-            - Assay information file has more SEQ_ASSAY_IDs than in clinical database -> PASS
-            - Assay information file has the same SEQ_ASSAY_IDs as in clinical database -> PASS
-            - Assay information file has less SEQ_ASSAY_IDs than in clinical database -> FAIL
+        **Conditions**
 
+        | Condition | Result |
+        |---|:---:|
+        | Assay information file has more SEQ_ASSAY_IDs than in clinical database | ✅ PASS |
+        | Assay information file has the same SEQ_ASSAY_IDs as in clinical database | ✅ PASS |
+        | Assay information file has less SEQ_ASSAY_IDs than in clinical database | ❌ FAIL |
+        
         Args:
             all_seq_assays (dict): list of all the SEQ_ASSAY_IDs in
                 the assay information file

--- a/genie_registry/assay.py
+++ b/genie_registry/assay.py
@@ -388,7 +388,7 @@ class Assayinfo(FileTypeFormat):
         | Assay information file has more SEQ_ASSAY_IDs than in clinical database | ✅ PASS |
         | Assay information file has the same SEQ_ASSAY_IDs as in clinical database | ✅ PASS |
         | Assay information file has less SEQ_ASSAY_IDs than in clinical database | ❌ FAIL |
-        
+
         Args:
             all_seq_assays (dict): list of all the SEQ_ASSAY_IDs in
                 the assay information file

--- a/genie_registry/assay.py
+++ b/genie_registry/assay.py
@@ -1,6 +1,7 @@
 """Assay information class"""
 
 import os
+from typing import Tuple
 
 import pandas as pd
 import yaml
@@ -127,15 +128,19 @@ class Assayinfo(FileTypeFormat):
             all_panel_info = pd.concat([all_panel_info, assay_finaldf])
         return all_panel_info
 
-    def _validate(self, assay_info_df, skip_database_checks):
+    def _validate(
+        self, assay_info_df: pd.DataFrame, skip_database_checks: bool
+    ) -> Tuple[str, str]:
         """
         Validates the values of assay information file
 
         Args:
-            assay_info_df: assay information dataframe
+            assay_info_df (pd.DataFrame): input assay information dataframe
+            skip_database_checks (bool): Whether to skip certain validation checks
+                since they requires access to the internal database tables
 
         Returns:
-            tuple: error and warning
+            Tuple[str, str]: complete error and warning messages
         """
 
         total_error = ""

--- a/genie_registry/cna.py
+++ b/genie_registry/cna.py
@@ -241,9 +241,9 @@ class cna(FileTypeFormat):
         self, cnvDF: pd.DataFrame, skip_database_checks: bool
     ) -> str:
         """Validates that there are no duplicated Hugo_Symbol values
-            after remapping the previous Hugo_Symbol column using the 
-            bed database table. See validateSymbol for more details 
-            on the remapping method. 
+            after remapping the previous Hugo_Symbol column using the
+            bed database table. See validateSymbol for more details
+            on the remapping method.
 
         Args:
             skip_database_checks (bool): Whether to skip this validation check

--- a/genie_registry/cna.py
+++ b/genie_registry/cna.py
@@ -114,7 +114,7 @@ class cna(FileTypeFormat):
 
     _process_kwargs = ["newPath"]
 
-    _validation_kwargs = ["nosymbol_check"]
+    _validation_kwargs = ["skip_database_checks"]
 
     # VALIDATE FILENAME
     def _validateFilename(self, filePath):
@@ -175,7 +175,7 @@ class cna(FileTypeFormat):
             self.syn.store(synapseclient.File(newPath, parent=centerMafSynId))
         return newPath
 
-    def _validate(self, cnvDF, nosymbol_check):
+    def _validate(self, cnvDF, skip_database_checks):
         total_error = ""
         warning = ""
         cnvDF.columns = [col.upper() for col in cnvDF.columns]
@@ -220,7 +220,7 @@ class cna(FileTypeFormat):
             )
         else:
             cnvDF["HUGO_SYMBOL"] = keepSymbols
-            if haveColumn and not nosymbol_check:
+            if haveColumn and not skip_database_checks:
                 bedSynId = self.genie_config["bed"]
                 bed = self.syn.tableQuery(
                     f"select Hugo_Symbol, ID from {bedSynId} "

--- a/genie_registry/cna.py
+++ b/genie_registry/cna.py
@@ -1,6 +1,6 @@
 import logging
 import os
-from typing import Union
+from typing import Tuple, Union
 
 import pandas as pd
 import synapseclient
@@ -175,7 +175,18 @@ class cna(FileTypeFormat):
             self.syn.store(synapseclient.File(newPath, parent=centerMafSynId))
         return newPath
 
-    def _validate(self, cnvDF, skip_database_checks):
+    def _validate(self, cnvDF: pd.DataFrame, skip_database_checks: bool) -> Tuple:
+        """
+        Validates the values of the input cna file
+
+        Args:
+            cnvDF (pd.DataFrame): input CNA file
+            skip_database_checks (bool): Whether to skip this validation check
+                since it requires access to the internal clinical sample database
+
+        Returns:
+            Tuple: complete error and warning messages
+        """
         total_error = ""
         warning = ""
         cnvDF.columns = [col.upper() for col in cnvDF.columns]
@@ -230,14 +241,16 @@ class cna(FileTypeFormat):
         self, cnvDF: pd.DataFrame, skip_database_checks: bool
     ) -> str:
         """Validates that there are no duplicated Hugo_Symbol values
-            after remapping the previous Hugo_Symbol column using the
-            gene symv
+            after remapping the previous Hugo_Symbol column using the 
+            bed database table. See validateSymbol for more details 
+            on the remapping method. 
 
         Args:
-            skip_database_checks (bool): _description_
+            skip_database_checks (bool): Whether to skip this validation check
+                since it requires access to the internal bed database
 
         Returns:
-            str: _description_
+            str: error message
         """
         error = ""
         if not skip_database_checks:

--- a/genie_registry/structural_variant.py
+++ b/genie_registry/structural_variant.py
@@ -12,7 +12,7 @@ logger = logging.getLogger(__name__)
 class StructuralVariant(FileTypeFormat):
     _fileType = "sv"
 
-    # _validation_kwargs = ["nosymbol_check", "project_id"]
+    # _validation_kwargs = ["skip_database_checks", "project_id"]
 
     # VALIDATE FILENAME
     def _validateFilename(self, filePath):
@@ -60,7 +60,7 @@ class StructuralVariant(FileTypeFormat):
         sv_df.to_csv(newPath, sep="\t", index=False)
         return newPath
 
-    # def _validate(self, sv_df, nosymbol_check, project_id):
+    # def _validate(self, sv_df, skip_database_checks, project_id):
     def _validate(self, sv_df):
         total_error = StringIO()
         total_warning = StringIO()

--- a/tests/test_input_to_database.py
+++ b/tests/test_input_to_database.py
@@ -417,7 +417,7 @@ def test_valid_validatefile(syn, genie_config):
 
         assert expected_results == validate_results
         patch_validate.assert_called_once_with(
-            oncotree_link=oncotree_link, nosymbol_check=False
+            oncotree_link=oncotree_link, skip_database_checks=False
         )
         patch_check.assert_called_once_with(
             validation_statusdf, error_trackerdf, entities
@@ -496,7 +496,7 @@ def test_invalid_validatefile(syn, genie_config):
 
         assert expected_results == validate_results
         patch_validate.assert_called_once_with(
-            oncotree_link=oncotree_link, nosymbol_check=False
+            oncotree_link=oncotree_link, skip_database_checks=False
         )
         patch_check.assert_called_once_with(
             validation_statusdf, error_trackerdf, entities

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -147,7 +147,9 @@ def test_valid_validate_single_file(syn, genie_config):
         mock_determine_ftype.assert_called_once_with()
 
         mock_genie_class.assert_called_once_with(
-            filePathList=[CLIN_ENT.path], skip_database_checks=False, project_id="syn1234"
+            filePathList=[CLIN_ENT.path],
+            skip_database_checks=False,
+            project_id="syn1234",
         )
 
         mock_determine.assert_called_once_with()

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -138,7 +138,7 @@ def test_valid_validate_single_file(syn, genie_config):
             format_registry={"clinical": FileFormat},
             genie_config=genie_config,
         )
-        valid_cls, message = validator.validate_single_file(nosymbol_check=False)
+        valid_cls, message = validator.validate_single_file(skip_database_checks=False)
 
         assert valid_cls == results
         assert message == expected_message
@@ -147,7 +147,7 @@ def test_valid_validate_single_file(syn, genie_config):
         mock_determine_ftype.assert_called_once_with()
 
         mock_genie_class.assert_called_once_with(
-            filePathList=[CLIN_ENT.path], nosymbol_check=False, project_id="syn1234"
+            filePathList=[CLIN_ENT.path], skip_database_checks=False, project_id="syn1234"
         )
 
         mock_determine.assert_called_once_with()
@@ -422,7 +422,7 @@ class argparser:
     filetype = None
     center = "try"
     filepath = ["path.csv"]
-    nosymbol_check = False
+    skip_database_checks = False
     format_registry_packages = ["genie"]
     project_id = "syn1234"
 
@@ -461,7 +461,7 @@ def test_perform_validate(syn, genie_config):
         patch_check_center.assert_called_once_with(arg.center, ["SAGE", "TEST", "GOLD"])
         patch_get_onco.assert_called_once()
         patch_validate.assert_called_once_with(
-            nosymbol_check=arg.nosymbol_check, project_id=arg.project_id
+            skip_database_checks=arg.skip_database_checks, project_id=arg.project_id
         )
         patch_syn_upload.assert_called_once_with(
             syn=syn, filepaths=arg.filepath, parentid=arg.parentid


### PR DESCRIPTION
# **Problem:**
There was an [issue brought up by a collaborator](https://github.com/Sage-Bionetworks/Genie/issues/626) where they tried to validate their assay information file using the local validator but that required access to an internal clinical sample database table so they ran into a `READ access` error.

JIRA Ticket: https://sagebionetworks.jira.com/browse/GEN-2407

# **Solution:**
We add a new parameter `--skip-database-checks` to the aacrgenie cli that will skip all current and future validation checks that require use of an internal database table for just local validation. This means the old `--nosymbol-check` used just to skip the cna validation check that requires use of an internal database table has been deprecated.

Developers with access can still run the validation without this flag. This does not affect the overall validation that runs twice a day.

**Extras**

Also included in this PR update:

- Added to this validation rule's docstring
<img width="964" height="382" alt="image" src="https://github.com/user-attachments/assets/a4589511-db9f-4563-a744-e977091a1219" />

- Updated the local validation doc and migrated it from the README
<img width="1277" height="723" alt="image" src="https://github.com/user-attachments/assets/c61b1aa7-6037-40ea-b797-f6c275acfc1c" />


# **Testing:**
- Unit tests pass
- Tested on test pipeline that the database checks for cna and assay still run when run internally
- Assay information file test:
   - Ran without `--skip-database-checks` and got `ERROR:genie.example_filetype_format:Assay_information.yaml: You are missing SEQ_ASSAY_IDs: ...`
   - Ran with `--skip-database-checks` and didn't get the SEQ_ASSAY_IDs message

- CNA file test:
   - Ran without `--skip-database-checks` and got `ERROR:genie.example_filetype_format:Your CNA file has duplicated Hugo_Symbols ...`
   - Ran with `--skip-database-checks` and didn't get the HUGO_SYMBOL messages

- Tested on local validator (installed with this branch's updates) that `--skip-database-checks` throws no READ access errors (this is our validation for this branch)