### PR TITLE
[GEN-2326] Centralize where error reports get saved in Genie

### DIFF
--- a/genie/write_invalid_reasons.py
+++ b/genie/write_invalid_reasons.py
@@ -30,20 +30,19 @@ def write(
     center_errors = get_center_invalid_errors(syn, error_tracker_synid)
     for center in center_mapping_df["center"]:
         logger.info(center)
+        center_errors_report_name = f"{center}_validation_errors.txt"
         errors_synid = center_mapping_df["errorsSynId"][
             center_mapping_df["center"] == center
         ][0]
-        with open(center + "_validation_errors.txt", "w") as errorfile:
+        with open(center_errors_report_name, "w") as errorfile:
             if center not in center_errors:
                 errorfile.write("No errors!")
             else:
                 errorfile.write(center_errors[center])
 
-        ent = synapseclient.File(
-            center + "_validation_errors.txt", parentId=errors_synid
-        )
+        ent = synapseclient.File(center_errors_report_name, parentId=errors_synid)
         syn.store(ent)
-        os.remove(center + "_validation_errors.txt")
+        os.remove(center_errors_report_name)
 
 
 def _combine_center_file_errors(

--- a/genie/write_invalid_reasons.py
+++ b/genie/write_invalid_reasons.py
@@ -13,14 +13,14 @@ logger = logging.getLogger(__name__)
 
 def write(
     syn: synapseclient.Synapse, center_mapping_synid: str, error_tracker_synid: str
-):
-    """Write center errors to a file and save in the 
-        errors folder in the center's folder
+) -> None:
+    """Write center errors to a file called {center}_validation_errors.txt and
+        save it to the errors folder in the center's folder
 
     Args:
         syn (synapseclient.Synapse): Synapse connection
-        center_mapping_synid (str): Center mapping Synapse id
-        error_tracker_synid (str): Error tracking Synapse id
+        center_mapping_synid (str): Center mapping table's synapse id
+        error_tracker_synid (str): Error tracking table's synapse id
 
     """
     center_mapping_df = extract.get_syntabledf(
@@ -39,7 +39,9 @@ def write(
             else:
                 errorfile.write(center_errors[center])
 
-        ent = synapseclient.File(center + "_validation_errors.txt", parentId=errors_synid)
+        ent = synapseclient.File(
+            center + "_validation_errors.txt", parentId=errors_synid
+        )
         syn.store(ent)
         os.remove(center + "_validation_errors.txt")
 

--- a/genie/write_invalid_reasons.py
+++ b/genie/write_invalid_reasons.py
@@ -14,7 +14,8 @@ logger = logging.getLogger(__name__)
 def write(
     syn: synapseclient.Synapse, center_mapping_synid: str, error_tracker_synid: str
 ):
-    """Write center errors to a file
+    """Write center errors to a file and save in the 
+        errors folder in the center's folder
 
     Args:
         syn (synapseclient.Synapse): Synapse connection
@@ -29,7 +30,7 @@ def write(
     center_errors = get_center_invalid_errors(syn, error_tracker_synid)
     for center in center_mapping_df["center"]:
         logger.info(center)
-        staging_synid = center_mapping_df["stagingSynId"][
+        errors_synid = center_mapping_df["errorsSynId"][
             center_mapping_df["center"] == center
         ][0]
         with open(center + "_errors.txt", "w") as errorfile:
@@ -38,7 +39,7 @@ def write(
             else:
                 errorfile.write(center_errors[center])
 
-        ent = synapseclient.File(center + "_errors.txt", parentId=staging_synid)
+        ent = synapseclient.File(center + "_errors.txt", parentId=errors_synid)
         syn.store(ent)
         os.remove(center + "_errors.txt")
 

--- a/genie/write_invalid_reasons.py
+++ b/genie/write_invalid_reasons.py
@@ -33,15 +33,15 @@ def write(
         errors_synid = center_mapping_df["errorsSynId"][
             center_mapping_df["center"] == center
         ][0]
-        with open(center + "_errors.txt", "w") as errorfile:
+        with open(center + "_validation_errors.txt", "w") as errorfile:
             if center not in center_errors:
                 errorfile.write("No errors!")
             else:
                 errorfile.write(center_errors[center])
 
-        ent = synapseclient.File(center + "_errors.txt", parentId=errors_synid)
+        ent = synapseclient.File(center + "_validation_errors.txt", parentId=errors_synid)
         syn.store(ent)
-        os.remove(center + "_errors.txt")
+        os.remove(center + "_validation_errors.txt")
 
 
 def _combine_center_file_errors(

--- a/tests/test_write_invalid_reasons.py
+++ b/tests/test_write_invalid_reasons.py
@@ -100,17 +100,17 @@ def test_write_writes_no_errors_and_correct_errors_and_uses_correct_parent_ids(m
             )
 
     # assertions: open + writes
-    m_open.assert_any_call("A_errors.txt", "w")
-    m_open.assert_any_call("B_errors.txt", "w")
+    m_open.assert_any_call("A_validation_errors.txt", "w")
+    m_open.assert_any_call("B_validation_errors.txt", "w")
 
-    file_handles["A_errors.txt"].write.assert_called_once_with("A had errors")
-    file_handles["B_errors.txt"].write.assert_called_once_with("No errors!")
+    file_handles["A_validation_errors.txt"].write.assert_called_once_with("A had errors")
+    file_handles["B_validation_errors.txt"].write.assert_called_once_with("No errors!")
 
     # assertions: correct Synapse folder IDs used (parentId)
-    m_file_cls.assert_any_call("A_errors.txt", parentId="synErrA")
-    m_file_cls.assert_any_call("B_errors.txt", parentId="synErrB")
+    m_file_cls.assert_any_call("A_validation_errors.txt", parentId="synErrA")
+    m_file_cls.assert_any_call("B_validation_errors.txt", parentId="synErrB")
 
     # Synapse store + cleanup
     assert syn.store.call_args_list == [mock.call(ent_a), mock.call(ent_b)]
-    m_remove.assert_any_call("A_errors.txt")
-    m_remove.assert_any_call("B_errors.txt")
+    m_remove.assert_any_call("A_validation_errors.txt")
+    m_remove.assert_any_call("B_validation_errors.txt")

--- a/tests/test_write_invalid_reasons.py
+++ b/tests/test_write_invalid_reasons.py
@@ -7,19 +7,21 @@ from unittest.mock import patch
 
 from genie import write_invalid_reasons
 
+
 @pytest.fixture
 def mock_centers_mapping():
     df = pd.DataFrame(
         {
             "center": ["A", "B"],
             "errorsSynId": ["synErrA", "synErrB"],
-            "stagingSynId":["synStageA", "synStageB"],
-            "inputSynId":["synInputA", "synInputB"],
+            "stagingSynId": ["synStageA", "synStageB"],
+            "inputSynId": ["synInputA", "synInputB"],
         },
     )
     df.index = ["0_1", "1_1"]
     return df
-    
+
+
 CENTER_ERRORSDF = pd.DataFrame(
     {
         "id": ["syn1234", "syn2345"],
@@ -67,15 +69,23 @@ def test_get_center_invalid_errors(syn):
         assert patch_combine.call_count == 2
 
 
-def test_write_writes_no_errors_and_correct_errors_and_uses_correct_parent_ids(mock_centers_mapping):
+def test_write_writes_no_errors_and_correct_errors_and_uses_correct_parent_ids(
+    mock_centers_mapping,
+):
     syn = mock.Mock()
     center_errors = {"A": "A had errors"}  # no errors for center B
 
-    with mock.patch.object(write_invalid_reasons.extract, "get_syntabledf", return_value=mock_centers_mapping), \
-         mock.patch.object(write_invalid_reasons, "get_center_invalid_errors", return_value=center_errors), \
-         mock.patch.object(write_invalid_reasons.synapseclient, "File") as m_file_cls, \
-         mock.patch.object(write_invalid_reasons.os, "remove") as m_remove:
-
+    with mock.patch.object(
+        write_invalid_reasons.extract,
+        "get_syntabledf",
+        return_value=mock_centers_mapping,
+    ), mock.patch.object(
+        write_invalid_reasons, "get_center_invalid_errors", return_value=center_errors
+    ), mock.patch.object(
+        write_invalid_reasons.synapseclient, "File"
+    ) as m_file_cls, mock.patch.object(
+        write_invalid_reasons.os, "remove"
+    ) as m_remove:
         # Make open() return a different handle per file so we can assert per-center writes
         file_handles = {}
 
@@ -103,7 +113,9 @@ def test_write_writes_no_errors_and_correct_errors_and_uses_correct_parent_ids(m
     m_open.assert_any_call("A_validation_errors.txt", "w")
     m_open.assert_any_call("B_validation_errors.txt", "w")
 
-    file_handles["A_validation_errors.txt"].write.assert_called_once_with("A had errors")
+    file_handles["A_validation_errors.txt"].write.assert_called_once_with(
+        "A had errors"
+    )
     file_handles["B_validation_errors.txt"].write.assert_called_once_with("No errors!")
 
     # assertions: correct Synapse folder IDs used (parentId)

--- a/tests/test_write_invalid_reasons.py
+++ b/tests/test_write_invalid_reasons.py
@@ -1,12 +1,25 @@
 """Test write invalid reasons module"""
-
+import pandas as pd
+import pytest
+import synapseclient
 from unittest import mock
 from unittest.mock import patch
 
 from genie import write_invalid_reasons
-import pandas as pd
-import synapseclient
 
+@pytest.fixture
+def mock_centers_mapping():
+    df = pd.DataFrame(
+        {
+            "center": ["A", "B"],
+            "errorsSynId": ["synErrA", "synErrB"],
+            "stagingSynId":["synStageA", "synStageB"],
+            "inputSynId":["synInputA", "synInputB"],
+        },
+    )
+    df.index = ["0_1", "1_1"]
+    return df
+    
 CENTER_ERRORSDF = pd.DataFrame(
     {
         "id": ["syn1234", "syn2345"],
@@ -52,3 +65,52 @@ def test_get_center_invalid_errors(syn):
         assert center_invalid == {"SAGE": "errors", "TEST": "errors"}
         patch_query.assert_called_once_with("SELECT * FROM syn3333")
         assert patch_combine.call_count == 2
+
+
+def test_write_writes_no_errors_and_correct_errors_and_uses_correct_parent_ids(mock_centers_mapping):
+    syn = mock.Mock()
+    center_errors = {"A": "A had errors"}  # no errors for center B
+
+    with mock.patch.object(write_invalid_reasons.extract, "get_syntabledf", return_value=mock_centers_mapping), \
+         mock.patch.object(write_invalid_reasons, "get_center_invalid_errors", return_value=center_errors), \
+         mock.patch.object(write_invalid_reasons.synapseclient, "File") as m_file_cls, \
+         mock.patch.object(write_invalid_reasons.os, "remove") as m_remove:
+
+        # Make open() return a different handle per file so we can assert per-center writes
+        file_handles = {}
+
+        def _open_side_effect(filename, mode):
+            fh = mock.Mock(name=f"handle_{filename}")
+            ctx = mock.Mock()
+            ctx.__enter__ = mock.Mock(return_value=fh)
+            ctx.__exit__ = mock.Mock(return_value=False)
+            file_handles[filename] = fh
+            return ctx
+
+        with mock.patch("builtins.open", side_effect=_open_side_effect) as m_open:
+            # Make File() return different objects so we can assert store calls too (optional)
+            ent_a = mock.Mock(name="ent_a")
+            ent_b = mock.Mock(name="ent_b")
+            m_file_cls.side_effect = [ent_a, ent_b]
+
+            write_invalid_reasons.write(
+                syn=syn,
+                center_mapping_synid="synCenterMap",
+                error_tracker_synid="synErrTrack",
+            )
+
+    # assertions: open + writes
+    m_open.assert_any_call("A_errors.txt", "w")
+    m_open.assert_any_call("B_errors.txt", "w")
+
+    file_handles["A_errors.txt"].write.assert_called_once_with("A had errors")
+    file_handles["B_errors.txt"].write.assert_called_once_with("No errors!")
+
+    # assertions: correct Synapse folder IDs used (parentId)
+    m_file_cls.assert_any_call("A_errors.txt", parentId="synErrA")
+    m_file_cls.assert_any_call("B_errors.txt", parentId="synErrB")
+
+    # Synapse store + cleanup
+    assert syn.store.call_args_list == [mock.call(ent_a), mock.call(ent_b)]
+    m_remove.assert_any_call("A_errors.txt")
+    m_remove.assert_any_call("B_errors.txt")


### PR DESCRIPTION
# **Problem:**
Originally, our validation error reports for sites were being saved to their center's staging folders. This is not a very intuitive place to save it as the validation step of the pipeline is earlier in the pipeline compared to staging which is later.

# **Solution:**
Our maf error reports get saved to an `errors` folder, we should have validation errors saved to that folder as well. We should also name the report as `_validation_errors.txt` instead of `_errors.txt` so it's clear what errors these are

# **Testing:**

- [x] Unit tests pass
- [x] Integration tests pass and now test sites' errors get saved to errors folder

Validation errors are saved successfully: 
<img width="1375" height="400" alt="image" src="https://github.com/user-attachments/assets/145347dc-0c71-4733-baab-b8d7a7b0c372" />

