### PR TITLE
[GEN-2368] Deprecate meta_fusions.txt

### DIFF
--- a/genie/consortium_to_public.py
+++ b/genie/consortium_to_public.py
@@ -5,7 +5,6 @@ import os
 import sys
 
 import pandas as pd
-import synapseclient
 import synapseutils
 from genie import (
     create_case_lists,
@@ -14,15 +13,14 @@ from genie import (
     load,
     process_functions,
 )
+from genie.load import _copyRecursive
 
 logger = logging.getLogger(__name__)
 stdout_handler = logging.StreamHandler(stream=sys.stdout)
 stdout_handler.setLevel(logging.INFO)
 logger.addHandler(stdout_handler)
-from typing import Dict
 
-from genie.load import _copyRecursive
-
+DEPRECATED_PUBLIC_RELEASE_FILES = ["data_fusions.txt", "meta_fusions.txt"]
 
 # TODO: Add to transform.py
 def commonVariantFilter(mafDf):
@@ -213,7 +211,7 @@ def consortiumToPublic(
     )
     genePanelEntities = []
     for entName, entId in consortiumRelease[2]:
-        is_deprecated_file = entName in ["data_fusions.txt"]
+        is_deprecated_file = entName in DEPRECATED_PUBLIC_RELEASE_FILES
         # skip files to convert
         if (
             entName.startswith("data_linear")

--- a/genie/consortium_to_public.py
+++ b/genie/consortium_to_public.py
@@ -22,6 +22,7 @@ logger.addHandler(stdout_handler)
 
 DEPRECATED_PUBLIC_RELEASE_FILES = ["data_fusions.txt", "meta_fusions.txt"]
 
+
 # TODO: Add to transform.py
 def commonVariantFilter(mafDf):
     """

--- a/genie/database_to_staging.py
+++ b/genie/database_to_staging.py
@@ -104,6 +104,7 @@ FULL_MAF_RELEASE_COLUMNS = [
 
 DEPRECATED_CONSORTIUM_RELEASE_FILES = ["data_fusions.txt", "meta_fusions.txt"]
 
+
 # TODO: Add to transform.py
 def _to_redact_interval(df_col: pd.Series) -> Tuple[pd.Series, pd.Series]:
     """

--- a/genie/database_to_staging.py
+++ b/genie/database_to_staging.py
@@ -102,6 +102,7 @@ FULL_MAF_RELEASE_COLUMNS = [
     "mutationInCis_Flag",
 ]
 
+DEPRECATED_CONSORTIUM_RELEASE_FILES = ["data_fusions.txt", "meta_fusions.txt"]
 
 # TODO: Add to transform.py
 def _to_redact_interval(df_col: pd.Series) -> Tuple[pd.Series, pd.Series]:
@@ -1978,7 +1979,7 @@ def revise_metadata_files(syn, consortiumid, genie_version=None):
             i["id"], downloadLocation=GENIE_RELEASE_DIR, ifcollision="overwrite.local"
         )
         for i in release_files
-        if "meta" in i["name"] and i["name"] != "meta_fusions.txt"
+        if "meta" in i["name"] and i["name"] not in DEPRECATED_CONSORTIUM_RELEASE_FILES
     ]
 
     for meta_ent in meta_file_ents:
@@ -2091,7 +2092,7 @@ def create_link_version(
             release_file["name"] != "data_clinical.txt" or release_type == "consortium"
         )
         is_gene_panel = release_file["name"].startswith("data_gene_panel")
-        is_deprecated_file = release_file["name"] in ["data_fusions.txt"]
+        is_deprecated_file = release_file["name"] in DEPRECATED_CONSORTIUM_RELEASE_FILES
 
         if not_folder and not_public and not is_gene_panel and not is_deprecated_file:
             syn.store(


### PR DESCRIPTION
# **Problem:**
Outstanding item from [old epic to depreciate fusions fileformats](https://sagebionetworks.jira.com/browse/GEN-471). Forgot to deprecate the metadata file for the fusions fileformat (deprecated).

JIRA Ticket: https://sagebionetworks.jira.com/browse/GEN-2368

# **Solution:**
Note that this will prevent links from being created in future releases that point to the deprecated `meta_fusions.txt` file. The original file will remain but mainly for historical purposes.

# **Testing:**
Our test project only has one release version that we work off of. 

In the consortium release, the link to the `meta_fusions.txt` is not updated on 12/18
<img width="1032" height="72" alt="image" src="https://github.com/user-attachments/assets/6d221d0c-8d5a-4540-ae44-73817b025efc" />

Similar with public release:
<img width="1110" height="75" alt="image" src="https://github.com/user-attachments/assets/fb6a2ce3-7d7b-4c8a-aad6-a9a60a930a54" />
