### PR TITLE
[GEN-2330] Remove `includeInPanel` from our genie releases

### DIFF
--- a/genie/database_to_staging.py
+++ b/genie/database_to_staging.py
@@ -1802,7 +1802,7 @@ def stagingToCbio(
     bedDf = extract.get_syntabledf(
         syn,
         "SELECT Chromosome,Start_Position,End_Position,Hugo_Symbol,ID,"
-        "SEQ_ASSAY_ID,Feature_Type,includeInPanel,clinicalReported FROM"
+        "SEQ_ASSAY_ID,Feature_Type,clinicalReported FROM"
         f" {bedSynId} where CENTER in ('{center_query_str}')",
     )
 

--- a/genie_registry/bed.py
+++ b/genie_registry/bed.py
@@ -516,8 +516,8 @@ class bed(FileTypeFormat):
         seq_assay_id = seq_assay_id.replace("_", "-")
 
         # add in placeholder includeInPanel column and value if it doesn't exits
-        if len(beddf.columns == 4):
-            beddf[len(beddf.columns)-1] = True
+        if len(beddf.columns) == 4:
+            beddf[4] = True
         
         # Add in 6th column which is the clinicalReported
         if len(beddf.columns) > 5:

--- a/genie_registry/bed.py
+++ b/genie_registry/bed.py
@@ -456,9 +456,12 @@ class bed(FileTypeFormat):
         """
         LOGGER.info("CREATING GENE PANEL")
         if not beddf.empty:
-            exonsdf = beddf[beddf["Feature_Type"] == "exon"]
+            # exonsdf = beddf[beddf["Feature_Type"] == "exon"]
             # Only include genes that should be included in the panels
-            include_exonsdf = exonsdf[exonsdf["includeInPanel"]]
+            #include_exonsdf = exonsdf[exonsdf["includeInPanel"]]
+            
+            # Include all genes in the panels
+            include_exonsdf =  beddf[beddf["Feature_Type"] == "exon"]
             # Write gene panel
             null_genes = include_exonsdf["Hugo_Symbol"].isnull()
             unique_genes = set(include_exonsdf["Hugo_Symbol"][~null_genes])
@@ -631,11 +634,11 @@ class bed(FileTypeFormat):
             "Start_Position",
             "End_Position",
             "Hugo_Symbol",
-            "includeInPanel",
+            #"includeInPanel",
         ]
         if len(beddf.columns) < len(newcols):
             total_error += (
-                "BED file: Must at least have five columns in this "
+                "BED file: Must at least have four columns in this "
                 "order: {}. Make sure there are "
                 "no headers.\n".format(", ".join(newcols))
             )
@@ -675,15 +678,15 @@ class bed(FileTypeFormat):
                     "Hugo_Symbol column, not the strand column\n"
                 )
 
-            warn, error = process_functions.check_col_and_values(
-                beddf,
-                "includeInPanel",
-                [True, False],
-                filename="BED file",
-                required=True,
-            )
-            warning += warn
-            total_error += error
+            #warn, error = process_functions.check_col_and_values(
+            #    beddf,
+            #    "includeInPanel",
+            #    [True, False],
+            #    filename="BED file",
+            #    required=True,
+            #)
+            #warning += warn
+            #total_error += error
 
             if to_validate_symbol:
                 gene_position_table = self.syn.tableQuery("SELECT * FROM syn11806563")

--- a/genie_registry/bed.py
+++ b/genie_registry/bed.py
@@ -392,6 +392,7 @@ def remap_symbols(row, gene_positiondf):
                 row["Hugo_Symbol"] = symbol
     return row
 
+
 class bed(FileTypeFormat):
     """GENIE bed format"""
 
@@ -457,10 +458,10 @@ class bed(FileTypeFormat):
         if not beddf.empty:
             # exonsdf = beddf[beddf["Feature_Type"] == "exon"]
             # Only include genes that should be included in the panels
-            #include_exonsdf = exonsdf[exonsdf["includeInPanel"]]
-            
+            # include_exonsdf = exonsdf[exonsdf["includeInPanel"]]
+
             # Include all genes in the panels
-            include_exonsdf =  beddf[beddf["Feature_Type"] == "exon"]
+            include_exonsdf = beddf[beddf["Feature_Type"] == "exon"]
             # Write gene panel
             null_genes = include_exonsdf["Hugo_Symbol"].isnull()
             unique_genes = set(include_exonsdf["Hugo_Symbol"][~null_genes])
@@ -515,10 +516,10 @@ class bed(FileTypeFormat):
         seq_assay_id = seq_assay_id.upper()
         seq_assay_id = seq_assay_id.replace("_", "-")
 
-        # add in placeholder includeInPanel column and value if it doesn't exits
+        # add in placeholder includeInPanel column and value if it doesn't exist
         if len(beddf.columns) == 4:
             beddf[4] = True
-        
+
         # Add in 6th column which is the clinicalReported
         if len(beddf.columns) > 5:
             if all(beddf[5].apply(lambda x: x in [True, False])):
@@ -535,7 +536,7 @@ class bed(FileTypeFormat):
         exon_gtf_path, gene_gtf_path = create_gtf(process_functions.SCRIPT_DIR)
         LOGGER.info("REMAPPING {}".format(seq_assay_id))
         # bedname = seq_assay_id + ".bed"
-        
+
         beddf.columns = [
             "Chromosome",
             "Start_Position",
@@ -638,7 +639,7 @@ class bed(FileTypeFormat):
             "Start_Position",
             "End_Position",
             "Hugo_Symbol",
-            #"includeInPanel",
+            # "includeInPanel",
         ]
         if len(beddf.columns) < len(newcols):
             total_error += (
@@ -682,15 +683,15 @@ class bed(FileTypeFormat):
                     "Hugo_Symbol column, not the strand column\n"
                 )
 
-            #warn, error = process_functions.check_col_and_values(
+            # warn, error = process_functions.check_col_and_values(
             #    beddf,
             #    "includeInPanel",
             #    [True, False],
             #    filename="BED file",
             #    required=True,
-            #)
-            #warning += warn
-            #total_error += error
+            # )
+            # warning += warn
+            # total_error += error
 
             if to_validate_symbol:
                 gene_position_table = self.syn.tableQuery("SELECT * FROM syn11806563")

--- a/genie_registry/bed.py
+++ b/genie_registry/bed.py
@@ -392,7 +392,6 @@ def remap_symbols(row, gene_positiondf):
                 row["Hugo_Symbol"] = symbol
     return row
 
-
 class bed(FileTypeFormat):
     """GENIE bed format"""
 
@@ -516,6 +515,10 @@ class bed(FileTypeFormat):
         seq_assay_id = seq_assay_id.upper()
         seq_assay_id = seq_assay_id.replace("_", "-")
 
+        # add in placeholder includeInPanel column and value if it doesn't exits
+        if len(beddf.columns == 4):
+            beddf[len(beddf.columns)-1] = True
+        
         # Add in 6th column which is the clinicalReported
         if len(beddf.columns) > 5:
             if all(beddf[5].apply(lambda x: x in [True, False])):
@@ -532,6 +535,7 @@ class bed(FileTypeFormat):
         exon_gtf_path, gene_gtf_path = create_gtf(process_functions.SCRIPT_DIR)
         LOGGER.info("REMAPPING {}".format(seq_assay_id))
         # bedname = seq_assay_id + ".bed"
+        
         beddf.columns = [
             "Chromosome",
             "Start_Position",

--- a/templates/dashboardTemplate.Rmd
+++ b/templates/dashboardTemplate.Rmd
@@ -645,7 +645,7 @@ A user of the GENIE data pointed out that the expected gene count numbers in the
 
 ```{r genepanel_diff, echo=F}
 if (!is.null(assay_infodf) & !is.null(this_bed)) {
-  gene_panel_bed = this_bed[this_bed$Feature_Type == "exon" & this_bed$includeInPanel == "True" & this_bed$Hugo_Symbol != "", ]
+  gene_panel_bed = this_bed[this_bed$Feature_Type == "exon" & this_bed$Hugo_Symbol != "", ]
   # Get count of symbols per panel
   symbol_count_per_panel = table(gene_panel_bed$Hugo_Symbol, gene_panel_bed$SEQ_ASSAY_ID)
   # Get whether or not a panel contains a certain symbol

--- a/tests/test_bed.py
+++ b/tests/test_bed.py
@@ -157,7 +157,8 @@ def test__process_input_contains_includeinpanel(bed_class):
         assert_frame_equal(
             expected_beddf, new_beddf[expected_beddf.columns], check_dtype=False
         )
-        
+
+
 def test__process_input_does_not_contain_includeinpanel(bed_class):
     """
     Make sure placeholder includeInPanel column is created

--- a/tests/test_bed.py
+++ b/tests/test_bed.py
@@ -309,9 +309,9 @@ def test_missingcols_failure__validate(bed_class):
     emptydf = pd.DataFrame()
     error, warning = bed_class._validate(emptydf)
     expected_errors = (
-        "BED file: Must at least have five columns in this order: "
-        "Chromosome, Start_Position, End_Position, Hugo_Symbol, "
-        "includeInPanel. Make sure there are no headers.\n"
+        "BED file: Must at least have four columns in this order: "
+        "Chromosome, Start_Position, End_Position, Hugo_Symbol. "
+        "Make sure there are no headers.\n"
     )
     assert error == expected_errors
     assert warning == ""
@@ -353,8 +353,6 @@ def test_badinputs_failure__validate(bed_class):
         "Make sure there are no headers.\n"
         "BED file: The End_Position column must only be integers. "
         "Make sure there are no headers.\n"
-        "BED file: Please double check your includeInPanel column.  "
-        "This column must only be these values: True, False\n"
         "BED file: Please double check your Chromosome column.  "
         "This column must only be these values: {possible_vals}\n".format(
             possible_vals=", ".join(validate.ACCEPTED_CHROMOSOMES)


### PR DESCRIPTION
# **Problem:**
We want to deprecate `includeInPanel` from our genie releases - public and consortium. We will still keep it in our internal tables but we will no long require it from sites.

Related PRs: https://github.com/Sage-Bionetworks-Workflows/nf-genie/pull/50
JIRA TIcket: https://sagebionetworks.jira.com/browse/GEN-2330

# **Solution:**
- Remove `includeInPanel` from our gene panel creation, our validation requirement and our exported fields in the bed file in our releases (genomic_information.txt). 
- Also remove the filtering we do in our dashboarding and gene panels so that we include all genes (do not filter on `includeInPanel` anymore)
- Create placeholder `includeInPanel` in our processing when it isn't present.

# **Testing:**
- Unit tests
- Integration tests pass
   - When uploading a bed file without a `includeInPanel` column, validation still passes and bed file gets processed all the way through
   - When uploading a bed file with a `includeInPanel` column, validation still passes and bed file gets processed all the way through
   -  Final consortium released bed file contains no `includeInPanel` column
   - Final public released bed file contains no `includeInPanel` column