### PR TITLE
[GEN-2328] Update `SAMPLE_CLASS` and `SAMPLE_TYPE` validation

### DIFF
--- a/genie_registry/clinical.py
+++ b/genie_registry/clinical.py
@@ -728,7 +728,7 @@ class Clinical(FileTypeFormat):
 
             | SAMPLE_TYPE  | SAMPLE_CLASS |
             | ------------ | -------------|
-            | 8            | cfDNA        |
+            | 8            | NaN          |
             | 2            | cfDNA        |
 
         Args:
@@ -746,38 +746,35 @@ class Clinical(FileTypeFormat):
         allowed_sample_class_val = sampletype_mapping.loc[
             sampletype_mapping["CODE"] == allowed_sample_type_val, "CBIO_LABEL"
         ].iloc[0]
-        invalid_types_for_class = sorted(
-            df.loc[df["SAMPLE_CLASS"] == allowed_sample_class_val, "SAMPLE_TYPE"]
-            .dropna()
-            .unique()
-        )
-        invalid_types_for_class = [
-            str(t) for t in invalid_types_for_class if t != allowed_sample_type_val
-        ]
-        invalid_types_for_class = ", ".join(invalid_types_for_class)
 
-        invalid_classes = sorted(
-            df.loc[df["SAMPLE_TYPE"] == allowed_sample_type_val, "SAMPLE_CLASS"]
-            .dropna()
-            .unique()
-        )
-        invalid_classes = [c for c in invalid_classes if c != allowed_sample_class_val]
-        invalid_classes = ", ".join(invalid_classes)
+        # Normalize SAMPLE_TYPE to numeric (handles "8", blanks, etc.)
+        df["SAMPLE_TYPE"] = pd.to_numeric(df["SAMPLE_TYPE"], errors="coerce")
 
-        if invalid_types_for_class:
+        # Check 1: SAMPLE_CLASS == cfDNA -> SAMPLE_TYPE must be 8
+        invalid_type_check = (df["SAMPLE_CLASS"] == allowed_sample_class_val) & (
+            df["SAMPLE_TYPE"] != allowed_sample_type_val
+        )
+
+        if invalid_type_check.any():
             errors += (
-                f"Sample Clinical File: Invalid SAMPLE_TYPE values detected for SAMPLE_CLASS = '{allowed_sample_class_val}'. "
-                f"Found: {invalid_types_for_class}. "
-                f"When SAMPLE_CLASS is '{allowed_sample_class_val}', SAMPLE_TYPE must be {allowed_sample_type_val}.\n"
+                f"Sample Clinical File: Invalid SAMPLE_TYPE values detected for "
+                f"SAMPLE_CLASS = '{allowed_sample_class_val}'. "
+                f"When SAMPLE_CLASS is '{allowed_sample_class_val}', "
+                f"SAMPLE_TYPE must be {allowed_sample_type_val}.\n"
             )
 
-        if invalid_classes:
-            errors += (
-                f"Sample Clinical File: Invalid SAMPLE_CLASS values detected for SAMPLE_TYPE = {allowed_sample_type_val}. "
-                f"Found: {invalid_classes}. "
-                f"When SAMPLE_CLASS is '{allowed_sample_class_val}', SAMPLE_TYPE must be {allowed_sample_type_val}.\n"
-            )
+        # Check 2: SAMPLE_TYPE == 8 -> SAMPLE_CLASS must be cfDNA
+        invalid_class_check = (df["SAMPLE_TYPE"] == allowed_sample_type_val) & (
+            df["SAMPLE_CLASS"] != allowed_sample_class_val
+        )
 
+        if invalid_class_check.any():
+            errors += (
+                f"Sample Clinical File: Invalid SAMPLE_CLASS values detected for "
+                f"SAMPLE_TYPE = {allowed_sample_type_val}. "
+                f"When SAMPLE_TYPE is {allowed_sample_type_val}, "
+                f"SAMPLE_CLASS must be '{allowed_sample_class_val}'.\n"
+            )
         return errors
 
     # VALIDATION

--- a/tests/test_clinical.py
+++ b/tests/test_clinical.py
@@ -625,10 +625,10 @@ def test_nonull__validate(clin_class):
             ],
             AGE_AT_SEQ_REPORT=[100000, "Unknown", 20000, float("nan"), 100000],
             ONCOTREE_CODE=["AMPCA", "AMPCA", "Unknown", "AMPCA", "AMPCA"],
-            SAMPLE_TYPE=[1, 8, 8, 8, float("nan")],
+            SAMPLE_TYPE=[1, 8, None, 8, None],
             SEQ_ASSAY_ID=["SAGE-1-1", "SAGE-SAGE-1", "SAGE-1", "SAGE-1", "SAGE-1"],
             SEQ_DATE=["Jan-2013", "ApR-2013", "Jul-2013", "Oct-2013", "release"],
-            SAMPLE_CLASS=["Tumor", "cfDNA", "cfDNA", "cfDNA", float("nan")],
+            SAMPLE_CLASS=["Tumor", "cfDNA", "cfDNA", None, None],
         )
     )
 
@@ -669,6 +669,10 @@ def test_nonull__validate(clin_class):
             "YEAR_DEATH, INT_DOD.\n"
             "Sample Clinical File: Please double check your SAMPLE_CLASS column.  "
             "This column must only be these values: Tumor, cfDNA\n"
+            "Sample Clinical File: Invalid SAMPLE_TYPE values detected for SAMPLE_CLASS = 'cfDNA'. "
+            "When SAMPLE_CLASS is 'cfDNA', SAMPLE_TYPE must be 8.\n"
+            "Sample Clinical File: Invalid SAMPLE_CLASS values detected for SAMPLE_TYPE = 8. "
+            "When SAMPLE_TYPE is 8, SAMPLE_CLASS must be 'cfDNA'.\n"
             "Sample Clinical File: SAMPLE_CLASS column must be 'Tumor', or 'cfDNA'\n"
             "Patient Clinical File: Please double check your PRIMARY_RACE "
             "column.  This column must only be these values: 1, 2, 3, 4, 99\n"
@@ -749,7 +753,7 @@ def test_errors__validate(clin_class):
             ],
             AGE_AT_SEQ_REPORT=[10, 100000, ">doo", 100000, 100000],
             ONCOTREE_CODE=["AMPCAD", "TESTIS", "AMPCA", "AMPCA", "UCEC"],
-            SAMPLE_TYPE=[1, 2, 3, 4, 6],
+            SAMPLE_TYPE=[1, 2, 88, 4, 8],
             SEQ_ASSAY_ID=[float("nan"), "Sage-1", "SAGE-1", "S-SAGE-1", "SAGE-1"],
             SEQ_DATE=["Jane-2013", "Jan-2013", "Jan-2013", "Jan-2013", "Jan-2013"],
             YEAR_DEATH=["Unknown", "Not Collected", "Not Applicable", 19930, 1990],
@@ -757,7 +761,7 @@ def test_errors__validate(clin_class):
             INT_CONTACT=[">32485", "<6570", 1990, "Not Collected", ">foobar"],
             INT_DOD=[">32485", "<6570", 1911, "Not Collected", "<dense"],
             DEAD=[1, False, "Unknown", "Not Collected", "Not Applicable"],
-            SAMPLE_CLASS=["Tumor", "Tumor", "Tumor", "Tumor", "Tumor"],
+            SAMPLE_CLASS=["Tumor", "Tumor", "Tumor", "cfDNA", "Tumor"],
         )
     )
 
@@ -841,6 +845,10 @@ def test_errors__validate(clin_class):
             "YEAR_DEATH, INT_DOD.\n"
             "Patient Clinical File: DEAD value is inconsistent with "
             "INT_DOD for at least one patient.\n"
+            "Sample Clinical File: Invalid SAMPLE_TYPE values detected for SAMPLE_CLASS = 'cfDNA'. "
+            "When SAMPLE_CLASS is 'cfDNA', SAMPLE_TYPE must be 8.\n"
+            "Sample Clinical File: Invalid SAMPLE_CLASS values detected for SAMPLE_TYPE = 8. "
+            "When SAMPLE_TYPE is 8, SAMPLE_CLASS must be 'cfDNA'.\n"
             "Patient Clinical File: Please double check your PRIMARY_RACE "
             "column.  This column must only be these values: 1, 2, 3, 4, 99\n"
             "Patient Clinical File: Please double check your SECONDARY_RACE "
@@ -1761,8 +1769,7 @@ def test_preprocess(clin_class, newpath=None):
             ),
             (
                 "Sample Clinical File: Invalid SAMPLE_CLASS values detected for SAMPLE_TYPE = 8. "
-                "Found: tissue, tumor. "
-                "When SAMPLE_CLASS is 'cfDNA', SAMPLE_TYPE must be 8.\n"
+                "When SAMPLE_TYPE is 8, SAMPLE_CLASS must be 'cfDNA'.\n"
             ),
         ),
         (
@@ -1774,7 +1781,6 @@ def test_preprocess(clin_class, newpath=None):
             ),
             (
                 "Sample Clinical File: Invalid SAMPLE_TYPE values detected for SAMPLE_CLASS = 'cfDNA'. "
-                "Found: 2, 3. "
                 "When SAMPLE_CLASS is 'cfDNA', SAMPLE_TYPE must be 8.\n"
             ),
         ),
@@ -1796,15 +1802,33 @@ def test_preprocess(clin_class, newpath=None):
             ),
             (
                 "Sample Clinical File: Invalid SAMPLE_TYPE values detected for SAMPLE_CLASS = 'cfDNA'. "
-                "Found: 2, 3. "
                 "When SAMPLE_CLASS is 'cfDNA', SAMPLE_TYPE must be 8.\n"
                 "Sample Clinical File: Invalid SAMPLE_CLASS values detected for SAMPLE_TYPE = 8. "
-                "Found: other. "
+                "When SAMPLE_TYPE is 8, SAMPLE_CLASS must be 'cfDNA'.\n"
+            ),
+        ),
+        (
+            pd.DataFrame(
+                {
+                    "SAMPLE_TYPE": [2, None, 8, 8],
+                    "SAMPLE_CLASS": ["cfDNA", "cfDNA", None, "other"],
+                }
+            ),
+            (
+                "Sample Clinical File: Invalid SAMPLE_TYPE values detected for SAMPLE_CLASS = 'cfDNA'. "
                 "When SAMPLE_CLASS is 'cfDNA', SAMPLE_TYPE must be 8.\n"
+                "Sample Clinical File: Invalid SAMPLE_CLASS values detected for SAMPLE_TYPE = 8. "
+                "When SAMPLE_TYPE is 8, SAMPLE_CLASS must be 'cfDNA'.\n"
             ),
         ),
     ],
-    ids=["invalid_sample_class", "invalid_sample_type", "valid", "both_errors"],
+    ids=[
+        "invalid_sample_class",
+        "invalid_sample_type",
+        "valid",
+        "both_errors",
+        "has_nas",
+    ],
 )
 def test__validate_sample_class_and_type_cases(clin_class, clinicaldf, expected_error):
     result = clin_class._validate_sample_class_and_type(clinicaldf, sample_type_df)


### PR DESCRIPTION
# **Problem:**
This is a revision of #632. There is a complication of the original validation rule which didn't account for when values would be `NA` or `<blank>`. We also do some processing on the clinical data like filling all NAs with "" prior to even running most of the clinical validation rules. This makes it difficult to output validation messages with the actual invalid values the original dataset had.

JIRA Ticket: https://sagebionetworks.jira.com/browse/GEN-2328

Depends on #632, #633 

# **Solution:**
We omit part of the error message that outputs the invalid `SAMPLE_CLASS` or `SAMPLE_TYPE` values to reduce confusion and instead just focus on letting the data uploader know that they have values that are invalid in `SAMPLE_CLASS` and/or `SAMPLE_TYPE` and what the valid values should be. 

# **Testing:**
- Unit tests pass
- Integration tests pass
- Expected error messages: 
```
Sample Clinical File: Invalid SAMPLE_TYPE values detected for SAMPLE_CLASS = 'cfDNA'. When SAMPLE_CLASS is 'cfDNA', SAMPLE_TYPE must be 8.
Sample Clinical File: Invalid SAMPLE_CLASS values detected for SAMPLE_TYPE = 8. When SAMPLE_TYPE is 8, SAMPLE_CLASS must be 'cfDNA'.
```