### PR TITLE
[GEN-2537] Storing processed maf file first then upload to maf db

### DIFF
--- a/genie/process_mutation.py
+++ b/genie/process_mutation.py
@@ -497,10 +497,11 @@ def split_and_store_maf(
         narrow_maf_chunk = maf_chunk[narrow_maf_cols]
         append_or_createdf(narrow_maf_chunk, annotation_paths.narrow_maf_path)
 
-    load.store_table(
-        syn=syn, filepath=annotation_paths.narrow_maf_path, tableid=maf_tableid
-    )
     # Store MAF flat file into synapse
     load.store_file(
         syn=syn, filepath=annotation_paths.full_maf_path, parentid=flatfiles_synid
+    )
+    
+    load.store_table(
+        syn=syn, filepath=annotation_paths.narrow_maf_path, tableid=maf_tableid
     )

--- a/genie/process_mutation.py
+++ b/genie/process_mutation.py
@@ -501,7 +501,7 @@ def split_and_store_maf(
     load.store_file(
         syn=syn, filepath=annotation_paths.full_maf_path, parentid=flatfiles_synid
     )
-    
+
     load.store_table(
         syn=syn, filepath=annotation_paths.narrow_maf_path, tableid=maf_tableid
     )

--- a/genie/process_mutation.py
+++ b/genie/process_mutation.py
@@ -247,12 +247,6 @@ def process_mutation_workflow(
         center=center,
         input_dir=annotation_paths.error_dir,
     )
-    check_annotation_error_reports(
-        syn=syn,
-        maf_table_synid=maf_tableid,
-        full_error_report=full_error_report,
-        center=center,
-    )
     store_annotation_error_reports(
         full_error_report=full_error_report,
         full_error_report_path=annotation_paths.full_error_report_path,

--- a/tests/test_process_mutation.py
+++ b/tests/test_process_mutation.py
@@ -226,8 +226,6 @@ def test_process_mutation_workflow(syn, genie_config, annotation_paths):
         "concat_annotation_error_reports",
         return_value=sample_error_report,
     ) as patch_concat_error, patch.object(
-        process_mutation, "check_annotation_error_reports"
-    ) as patch_check_error, patch.object(
         process_mutation, "store_annotation_error_reports"
     ) as patch_store_error:
         maf = process_mutation.process_mutation_workflow(
@@ -251,12 +249,6 @@ def test_process_mutation_workflow(syn, genie_config, annotation_paths):
         patch_concat_error.assert_called_once_with(
             center=center,
             input_dir=annotation_paths.error_dir,
-        )
-        patch_check_error.assert_called_once_with(
-            syn=syn,
-            maf_table_synid=maf_table_id,
-            full_error_report=sample_error_report,
-            center=center,
         )
         patch_store_error.assert_called_once_with(
             full_error_report=sample_error_report,


### PR DESCRIPTION
# **Problem:**
Often we run into the maf data hitting schema limitation errors but without the data saved to troubleshoot, it makes it a lot harder especially with centers that have hundreds or thousands of mutation data.

JIRA: https://sagebionetworks.jira.com/browse/GEN-2537

# **Solution:**
We want to save the center maf file first before uploading the maf database. 

Extra: Remove call to `check_annotation_error_reports` because that is a big query call / reduce time and the failed annotations in the annotation report and what is in the maf database may not match up because sometimes there are additional failures that would not be recorded in the failed annotations report generated by genome nexus. 

# **Testing:**
- Unit tests pass
- Integration tests pass