### PR TITLE
[GEN-2538] Fix dockerbuild with missing module `pkg_resources`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -64,11 +64,14 @@ WORKDIR /root/Genie
 # a long time and unless there are changes to the actual
 # R packages used.  So the only files copied over are
 # renv/ renv.lock and the installation R script
-# Make a dedicated venv for reticulate
+# Make a dedicated venv for reticulate and force the pinning of setuptools
 ENV RETICULATE_PYTHON=/opt/reticulate-venv/bin/python
+
 RUN python3.10 -m venv /opt/reticulate-venv \
- && /opt/reticulate-venv/bin/python -m pip install --no-cache-dir --upgrade pip setuptools wheel \
- && /opt/reticulate-venv/bin/python -c "import pkg_resources; print('pkg_resources OK in venv')"
+ && /opt/reticulate-venv/bin/python -m pip install --no-cache-dir --upgrade "pip<26" wheel \
+ && /opt/reticulate-venv/bin/python -m pip install --no-cache-dir "setuptools>=80.9.0,<82.0.0" \
+ && /opt/reticulate-venv/bin/python -c "import pkg_resources, setuptools; print('setuptools', setuptools.__version__)"
+
 COPY R/install_packages.R R/install_packages.R
 COPY renv/ renv/
 COPY renv.lock renv.lock

--- a/Dockerfile
+++ b/Dockerfile
@@ -60,18 +60,18 @@ RUN dpkg -i pandoc-3.0.1-1-amd64.deb
 # Only copy most recent changes in code are always installed
 # Do not build from local computer
 WORKDIR /root/Genie
+
+# Force the pinning of setuptools in the reticulate python virtual env
+# due to pkg_resources being removed in setuptools >= 82
+ENV RETICULATE_PYTHON=/opt/reticulate-venv/bin/python
+RUN python3.10 -m venv /opt/reticulate-venv \
+ && /opt/reticulate-venv/bin/python -m pip install --no-cache-dir --upgrade "pip<26" wheel \
+ && /opt/reticulate-venv/bin/python -m pip install --no-cache-dir "setuptools>=80.9.0,<82.0.0"
+
 # Copy install packages first, because R installation takes
 # a long time and unless there are changes to the actual
 # R packages used.  So the only files copied over are
 # renv/ renv.lock and the installation R script
-# Make a dedicated venv for reticulate and force the pinning of setuptools
-ENV RETICULATE_PYTHON=/opt/reticulate-venv/bin/python
-
-RUN python3.10 -m venv /opt/reticulate-venv \
- && /opt/reticulate-venv/bin/python -m pip install --no-cache-dir --upgrade "pip<26" wheel \
- && /opt/reticulate-venv/bin/python -m pip install --no-cache-dir "setuptools>=80.9.0,<82.0.0" \
- && /opt/reticulate-venv/bin/python -c "import pkg_resources, setuptools; print('setuptools', setuptools.__version__)"
-
 COPY R/install_packages.R R/install_packages.R
 COPY renv/ renv/
 COPY renv.lock renv.lock

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,8 @@ RUN apt-get update && apt-get install -y --allow-unauthenticated --no-install-re
 		python3 \
 		python3-pip \
 		python3-dev \
+		python3-setuptools \
+        python3-wheel \
 		git \
 		r-base-core=4.3.3-1.2204.0 \
 		r-base-dev=4.3.3-1.2204.0 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,8 +23,6 @@ RUN apt-get update && apt-get install -y --allow-unauthenticated --no-install-re
 		python3 \
 		python3-pip \
 		python3-dev \
-		python3-setuptools \
-        python3-wheel \
 		git \
 		r-base-core=4.3.3-1.2204.0 \
 		r-base-dev=4.3.3-1.2204.0 \
@@ -66,6 +64,11 @@ WORKDIR /root/Genie
 # a long time and unless there are changes to the actual
 # R packages used.  So the only files copied over are
 # renv/ renv.lock and the installation R script
+# Make a dedicated venv for reticulate
+ENV RETICULATE_PYTHON=/opt/reticulate-venv/bin/python
+RUN python3.10 -m venv /opt/reticulate-venv \
+ && /opt/reticulate-venv/bin/python -m pip install --no-cache-dir --upgrade pip setuptools wheel \
+ && /opt/reticulate-venv/bin/python -c "import pkg_resources; print('pkg_resources OK in venv')"
 COPY R/install_packages.R R/install_packages.R
 COPY renv/ renv/
 COPY renv.lock renv.lock

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,5 +7,3 @@ pyranges==0.1.4
 PyYAML>=5.1
 synapseclient[pandas]>=4.8.0, <5.0.0
 opentelemetry-semantic-conventions==0.56b0
-# for synapser
-setuptools

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,5 @@ pyranges==0.1.4
 PyYAML>=5.1
 synapseclient[pandas]>=4.8.0, <5.0.0
 opentelemetry-semantic-conventions==0.56b0
+# for synapser
+setuptools


### PR DESCRIPTION
# **Problem:**
Docker build from scratch is running into a `ModuleNotFoundError: No module named 'pkg_resources'` during `synapser` installation when building the renv part of the docker build. This is due to version 82 of `setuptools` removing `pkg_resources`: https://github.com/pypa/setuptools/issues/5174

JIRA: https://sagebionetworks.jira.com/browse/GEN-2538

Note this bug will only affect new docker builds not `develop` or `main` builds as those are cached (if it's only code changes) so it will prevent feature branch docker builds

# **Solution:**
Force the reticulate python environment to install `setuptools` to a pinned version before restoring the R packages. `pkg_resources` is used by `synapser`. 

# **Testing:**
- Integration tests pass
- Comparison reports between develop and this feature branch run yield no differences