### PR TITLE
Add CLAUDE.md files for AI-assisted development

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,101 @@
+<!-- Last reviewed: 2026-03 -->
+
+## Project
+
+AACR Project GENIE (Genomics, Evidence, Neoplasia, Information, Exchange) ETL pipeline.
+Validates, processes, and releases genomic cancer data submitted by participating centers.
+Data flows: center files → validation → Synapse tables → consortium release → public release.
+Published as `aacrgenie` on PyPI. Jira project: GEN.
+
+## Stack
+
+- Python >=3.10, <3.12 (primary)
+- R 4.3.3 (analytics, renv-managed)
+- Synapse (data repository and table backend via `synapseclient`)
+- Docker (ubuntu:jammy base with Python, R, Java 21, cBioPortal, bedtools)
+- pytest (testing), black ~23.12 (formatting), flake8 (linting)
+- GitHub Actions CI/CD, published to ghcr.io and PyPI
+
+## Commands
+
+```bash
+# Run tests with coverage
+pytest tests/ --cov=genie --cov=genie_registry --cov-report=html
+
+# Format code
+black ./
+
+# Build package
+python -m build
+
+# Install for development
+pip install -e .
+
+# Local file validation
+genie validate <file> <center> [--filetype TYPE] [--skip-database-checks]
+```
+
+## Data Models
+
+The pipeline uses a plugin registry pattern for file formats:
+
+- **`FileTypeFormat`** (`genie/example_filetype_format.py`) — abstract base class (ABCMeta). All file formats inherit from it. Defines the contract: `_validateFilename()`, `_get_dataframe()`, `_validate()`, `_cross_validate()`, `process_steps()`.
+- **`ValidationResults`** (dataclass) — holds `errors: str`, `warnings: str`, `detailed: Optional[str]`. Empty `errors` string = valid.
+- **13 format classes** in `genie_registry/` — each sets `_fileType`, `_validation_kwargs`, `_process_kwargs`. Discovered at runtime via `genie/config.py` using `__subclasses__()` reflection.
+- **Config registry** (`genie/config.py`) — `collect_format_types(package_names)` imports packages and finds all `FileTypeFormat` subclasses. Extensible via `--format_registry_packages` CLI arg.
+
+Data flows through pandas DataFrames. All column names are uppercased on read. Files are TSV with `comment="#"` support. Synapse tables store processed data via `synapseclient.tableQuery()`.
+
+## Conventions
+
+- **Validation error message format**: `<filename>: <description>. <valid values if applicable>. You have N row(s) where <rule fails>. The row(s) this occurs in are: <indices>. Please correct.` — per Confluence SOP.
+- **Cross-file validation always goes in `clinical.py`** `_cross_validate()` — because clinical is the source of truth for cross-file checks.
+- **Clinical files come as pairs** — two files merged together. See the HACK comment in `genie/extract.py` around line 64.
+- **Validation functions need detailed docstrings** with examples of passing and failing data — this is a Confluence-documented requirement.
+- **Branch naming**: `gen-XXXX-short-description` (lowercase, Jira ticket prefix).
+- **Commit messages**: `[GEN-XXXX] Brief description (#PR_number)`.
+- **PR template**: Problem / Solution / Testing sections. Add label `run_integration_tests` to trigger integration test CI on feature branches.
+- **Test data in Synapse**: GOLD center files must PASS validation. TEST/SAGE center files should FAIL for new rules. Update Synapse files with version comments.
+- **`check_col_and_values()` returns `(warning, error)`** — reversed from all other validation functions that return `(errors, warnings)`. Do not "fix" this without updating all call sites.
+
+## Architecture
+
+```
+bin/ (CLI entry scripts)
+  → genie/ (core ETL: validate, extract, transform, load, process_mutation)
+    → genie_registry/ (pluggable file format classes)
+      → Synapse (data storage via synapseclient)
+
+Pipeline stages:
+1. input_to_database — validate center files, process valid ones, load to Synapse tables
+2. database_to_staging — consortium release: redact PHI, filter germline, format for cBioPortal
+3. consortium_to_public — public release: filter to approved samples
+```
+
+Plugin discovery: `genie/config.py` uses `importlib.import_module()` + `__subclasses__()` to find all `FileTypeFormat` subclasses at runtime. Add new formats by creating a class in a new package — no core changes needed.
+
+## Constraints
+
+- **Never expose PHI.** Ages >89 are masked, pediatric <18 redacted, germline variants filtered (gnomAD AF >0.01). This is a compliance requirement — because GENIE handles real patient genomic data.
+- **New validation rules require 6-month advance notice to sites before release.** Exceptions: urgent, <3 sites affected, or low-complexity fix. This is documented in Confluence SOP.
+- **Synapse auth via `SYNAPSE_AUTH_TOKEN` env var.** Never commit tokens. The `.synapseConfig` file is an alternative for local dev.
+- **Version lives in `genie/__init__.py`** — single source of truth. `setup.cfg` reads it via `attr:`. Update only there.
+- **Gitflow workflow.** All features merge to `develop` first. Release branches merge to `main`. Never push directly to `main` except doc/CI patches.
+
+## Testing
+
+- pytest with session-scoped fixtures for `syn` (mocked Synapse client) and `genie_config` (config dict).
+- Mock pattern: `from unittest.mock import patch` then `patch.object(MODULE, "FUNC", return_value=...)`.
+- Test parametrization via `@pytest.mark.parametrize` — include ALL pass/fail cases for validation rules.
+- Integration tests triggered by `run_integration_tests` label on PRs. Run against test Synapse project `syn7208886`.
+- R tests via `testthat`: `Rscript -e "testthat::test_dir('R/tests/testthat/')"`.
+
+## Related Systems
+
+- **nf-genie** (Sage-Bionetworks-Workflows/nf-genie) — Nextflow pipeline that orchestrates GENIE runs on Seqera Platform (Nextflow Tower).
+- **annotation-tools** (Sage-Bionetworks/annotation-tools) — Genome Nexus annotation wrapper. Built as `annotator.jar` (Java 21). Used for MAF/VCF re-annotation.
+- **Synapse** (`synapseclient`) — all data stored in Synapse projects. Production: `syn3380222`. Test: `syn7208886`.
+- **cBioPortal** (v5.3.19) — output format target for releases. Case lists and gene matrices generated for it.
+- **Confluence space APGD** — "AACR Project GENIE Documentation". Contains SOPs, validation rule docs, troubleshooting.
+- **Jira project GEN** — all tickets prefixed `GEN-`. Board at sagebionetworks.jira.com.
+- **R scripts** (`R/`) use the same three hardcoded dbMapping Synapse IDs as `bin/` scripts (test: `syn11600968`, staging: `syn12094210`, prod: `syn10967259`). When updating IDs, grep across both Python and R.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,7 @@ Published as `aacrgenie` on PyPI. Jira project: GEN.
 - R 4.3.3 (analytics, renv-managed)
 - Synapse (data repository and table backend via `synapseclient`)
 - Docker (ubuntu:jammy base with Python, R, Java 21, cBioPortal, bedtools)
-- pytest (testing), black ~23.12 (formatting), flake8 (linting)
+- pytest (testing), black (formatting), ruff + flake8 (linting)
 - GitHub Actions CI/CD, published to ghcr.io and PyPI
 
 ## Commands
@@ -41,7 +41,7 @@ The pipeline uses a plugin registry pattern for file formats:
 
 - **`FileTypeFormat`** (`genie/example_filetype_format.py`) — abstract base class (ABCMeta). All file formats inherit from it. Defines the contract: `_validateFilename()`, `_get_dataframe()`, `_validate()`, `_cross_validate()`, `process_steps()`.
 - **`ValidationResults`** (dataclass) — holds `errors: str`, `warnings: str`, `detailed: Optional[str]`. Empty `errors` string = valid.
-- **13 format classes** in `genie_registry/` — each sets `_fileType`, `_validation_kwargs`, `_process_kwargs`. Discovered at runtime via `genie/config.py` using `__subclasses__()` reflection.
+- **Format classes** in `genie_registry/` — each sets `_fileType`, `_validation_kwargs`, `_process_kwargs`. Discovered at runtime via `genie/config.py` using `__subclasses__()` reflection.
 - **Config registry** (`genie/config.py`) — `collect_format_types(package_names)` imports packages and finds all `FileTypeFormat` subclasses. Extensible via `--format_registry_packages` CLI arg.
 
 Data flows through pandas DataFrames. All column names are uppercased on read. Files are TSV with `comment="#"` support. Synapse tables store processed data via `synapseclient.tableQuery()`.
@@ -99,3 +99,13 @@ Plugin discovery: `genie/config.py` uses `importlib.import_module()` + `__subcla
 - **Confluence space APGD** — "AACR Project GENIE Documentation". Contains SOPs, validation rule docs, troubleshooting.
 - **Jira project GEN** — all tickets prefixed `GEN-`. Board at sagebionetworks.jira.com.
 - **R scripts** (`R/`) use the same three hardcoded dbMapping Synapse IDs as `bin/` scripts (test: `syn11600968`, staging: `syn12094210`, prod: `syn10967259`). When updating IDs, grep across both Python and R.
+
+## Anti-Patterns — Do NOT
+
+- **Do NOT simplify validation error messages.** Error messages must include the specific invalid values found (e.g., "Found: 2, 3"). A revert (7135f18) happened when error detail was removed — because sites use these messages to debug their data submissions.
+- **Do NOT deprecate a feature without full cleanup in the same PR.** When deprecating validation/processing for a field, remove ALL related test cases, docstrings, and processing functions together (PR #638/#639 lesson).
+- **Do NOT refactor `DataFrame.append()` to `pd.concat()` without extensive testing.** A previous attempt was reverted (da18b5f) because it broke subtle dataframe ordering behavior in dashboard_table_updater.py.
+- **Do NOT use bare `set()` for DataFrame column/index construction.** Use `sorted(set(...))` — because set ordering is non-deterministic and broke tests (PR #621, GEN-2377).
+- **Do NOT hardcode Synapse IDs inline.** They are already scattered across Python and R files. When adding new ID references, add them near existing ones and document the duplication.
+- **Do NOT declare Python version support without CI coverage.** Python 3.12 is in setup.cfg range but fails CI — this was flagged in PR #559 review.
+- **Do NOT add dependency version upper bounds without documenting why.** Reviewer asked "Is there a reason <4.0.0?" in PR #559 — unclear bounds create unnecessary conflicts.

--- a/bin/CLAUDE.md
+++ b/bin/CLAUDE.md
@@ -1,0 +1,39 @@
+<!-- Last reviewed: 2026-03 -->
+
+## Project
+
+Three CLI scripts mapping to the three GENIE pipeline stages: `input_to_database.py` (validation + ingestion), `database_to_staging.py` (consortium release), `consortium_to_public.py` (public release). Each wraps core `genie/` functions with argparse.
+
+## Argument Naming
+
+CLI arguments use camelCase (`--onlyValidate`, `--deleteOld`, `--createNewMafDatabase`). argparse stores them as-is on the namespace, but `main()` functions receive snake_case parameter names. Match existing naming conventions when adding new arguments.
+
+## Concurrency Lock
+
+`input_to_database.py` uses an `isProcessing` annotation on the `centerMapping` Synapse entity as a mutex lock. Flow: check if True → raise if locked → set True → process → set False. If the script crashes mid-run, the lock stays True and must be manually reset in Synapse. This prevents parallel pipeline runs from corrupting data.
+
+## Hardcoded Database Mapping IDs
+
+Three dbMapping Synapse IDs are duplicated across `database_to_staging.py`, `consortium_to_public.py`, all R scripts, and `dashboard_table_updater.py`:
+- Test: `syn11600968`
+- Staging: `syn12094210`
+- Production: `syn10967259`
+
+When updating these IDs, grep the entire repo (Python AND R files). There is no single constant.
+
+## Environment Routing
+
+`database_to_staging.py` and `consortium_to_public.py` use mutually exclusive `--test` and `--staging` flags to select the dbMapping ID. Production is the default (neither flag). `input_to_database.py` uses `--project_id` instead.
+
+## cBioPortal Validator Hack
+
+Both `database_to_staging.py` and `consortium_to_public.py` append `"; exit 0"` to the cBioPortal validator shell command. This forces a success exit code so `subprocess.check_output()` captures output even when the validator reports errors. Do not remove this without changing the subprocess handling.
+
+## Process Tracking
+
+`load.update_process_trackingdf()` is called only in production — never in test or staging mode. Condition: `if not args.test and not args.staging`. Do not add process tracking calls without this guard.
+
+## Constraints
+
+- R scripts are invoked via `subprocess` calls to `Rscript` (e.g., dashboard generation). Templates in `/templates/` are parameterized via Python string replacement BEFORE being passed to R.
+- The data guide template (`data_guide_template.Rnw`) uses LaTeX/Sweave. Underscore characters in template values must be escaped as `\_` for LaTeX.

--- a/bin/CLAUDE.md
+++ b/bin/CLAUDE.md
@@ -37,3 +37,9 @@ Both `database_to_staging.py` and `consortium_to_public.py` append `"; exit 0"` 
 
 - R scripts are invoked via `subprocess` calls to `Rscript` (e.g., dashboard generation). Templates in `/templates/` are parameterized via Python string replacement BEFORE being passed to R.
 - The data guide template (`data_guide_template.Rnw`) uses LaTeX/Sweave. Underscore characters in template values must be escaped as `\_` for LaTeX.
+
+## Do NOT
+
+- **Do NOT remove the `"; exit 0"` from cBioPortal validator subprocess calls.** Both `database_to_staging.py` and `consortium_to_public.py` append this to force success exit code so `subprocess.check_output()` captures output even when the validator reports errors.
+- **Do NOT add process tracking calls without the production guard.** `load.update_process_trackingdf()` runs only when `not args.test and not args.staging`. Adding it in test/staging mode would corrupt tracking data.
+- **Do NOT manually reset the `isProcessing` lock without checking if a pipeline run is active.** The concurrency lock on centerMapping can get stuck on crash — but clearing it while a run is active would allow concurrent corruption.

--- a/genie/CLAUDE.md
+++ b/genie/CLAUDE.md
@@ -1,0 +1,54 @@
+<!-- Last reviewed: 2026-03 -->
+
+## Project
+
+Core ETL pipeline modules for GENIE. Handles validation, extraction, transformation, loading, and mutation processing. All file format logic lives in `genie_registry/` — this package provides the framework and orchestration.
+
+## Template Method Pattern
+
+- `validate()` in `example_filetype_format.py` calls `_validate()` first. Cross-validation via `_cross_validate()` runs ONLY if `_validate()` returned no errors AND `self.ancillary_files` is a non-empty list. Do not assume `_cross_validate()` always runs.
+- `process()` reads the file differently by `_fileType`: clinical receives the raw `filePath` list, vcf/maf/mafSP/md receive the filepath string directly (no read), all others receive `read_file([filePath])` with path wrapped in a list. Match the convention for your file type.
+- `_validation_kwargs` and `_process_kwargs` are enforced via `assert required_parameter in kwargs.keys()`. Missing kwargs crash with AssertionError — not a graceful error. Always register required kwargs in the class attribute.
+
+## Return Conventions
+
+- `_validate()` and `_cross_validate()` return `(errors: str, warnings: str)`. Empty string = valid. NOT booleans.
+- `check_col_and_values()` in `process_functions.py` returns `(warning, error)` — **reversed order** from all other validation functions. Always destructure carefully.
+- `checkColExist()` returns `bool`, not a tuple.
+- `ValidationResults.is_valid()` checks `errors == ""` — use this method, not truthiness checks.
+
+## Reusable Utilities — Do Not Reinvent
+
+Use these existing functions instead of writing new ones:
+
+- `process_functions.checkColExist(df, col)` — column existence check.
+- `process_functions.check_col_and_values(df, col, possible_values, filename, ...)` — column existence + allowed values. Returns `(warning, error)`.
+- `process_functions.validate_genie_identifier(identifiers, center, filename, col)` — validate GENIE-{CENTER}-... ID format.
+- `process_functions.get_clinical_dataframe(filePathList)` — read and merge clinical file pair on PATIENT_ID.
+- `process_functions.get_row_indices_for_invalid_column_values(df, col, possible_values)` — returns pd.Index of invalid rows.
+- `process_functions.get_message_for_invalid_column_value(df, col, possible_values, filename)` — generates Confluence-format error message with row indices.
+- `extract.get_syntabledf(syn, query_string)` — query Synapse table, return DataFrame.
+- `validate._validate_chromosome(df, col, fileformat)` — chromosome validation with automatic "chr" prefix removal.
+- `validate.check_values_between_two_df(df1, df2, col, ...)` — cross-file ID existence check with auto-uppercasing.
+- `validate.get_invalid_allele_rows(df, col, allowed_comb_alleles, ...)` — allele validation with regex.
+
+## DataFrame Conventions
+
+- Use `fillna("")` before string comparisons on columns that may contain NAs — the primary key generation in `load.py` depends on this.
+- Use `pd.Int64Dtype()` for nullable integer columns — pandas casts int columns with NAs to float otherwise.
+- The `.0` stripping hack in `load.store_database()` does `.replace(".0,", ",").replace(".0\n", "\n")` on CSV output before Synapse upload. Do not introduce column values that legitimately end in `.0`.
+- Column order matters: `load._reorder_new_dataset()` forces new data to match existing Synapse table column order. Never assume column order is arbitrary.
+- All column names are uppercased on read: `df.columns = [col.upper() for col in df.columns]`.
+- `pd.options.mode.chained_assignment = None` is set globally in `process_functions.py`.
+
+## Synapse Interaction Patterns
+
+- `load.store_file()` auto-adds GitHub tag provenance via `executed=f"https://github.com/Sage-Bionetworks/Genie/tree/v{__version__}"`. Do not add separate provenance.
+- `load.store_table()` catches `SynapseTimeoutError` silently — intentional because timeout occurs during indexing, not actual failure.
+- `load.update_table()` generates a `UNIQUE_KEY` column by space-joining primary key columns. This is the primary key convention for all table comparisons.
+- Set `syn.table_query_timeout = 50000` before large table queries (done in `process_mutation.py` but not universally).
+
+## Constraints
+
+- `config.py` discovers subclasses via `importlib.import_module()` + `__subclasses__()`. Subclasses are NOT found unless their module is imported first. If adding a new format package, it must be passed via `--format_registry_packages`.
+- The concurrency lock in `bin/input_to_database.py` uses `isProcessing` annotation on the centerMapping entity. If the script crashes, the lock stays True and must be manually reset in Synapse.

--- a/genie/CLAUDE.md
+++ b/genie/CLAUDE.md
@@ -52,3 +52,14 @@ Use these existing functions instead of writing new ones:
 
 - `config.py` discovers subclasses via `importlib.import_module()` + `__subclasses__()`. Subclasses are NOT found unless their module is imported first. If adding a new format package, it must be passed via `--format_registry_packages`.
 - The concurrency lock in `bin/input_to_database.py` uses `isProcessing` annotation on the centerMapping entity. If the script crashes, the lock stays True and must be manually reset in Synapse.
+
+## Do NOT Change These Patterns
+
+- **Do NOT remove the `.0` stripping hack in `load.store_database()`.** The `.replace(".0,", ",").replace(".0\n", "\n")` handles pandas float-casting of nullable int columns. Do not introduce column values that legitimately end in `.0`.
+- **Do NOT remove the `SynapseTimeoutError` silent catch in `load.store_table()`.** The timeout occurs during table indexing, not actual failure. Logging it as an error would create false alerts.
+- **Do NOT remove `pd.options.mode.chained_assignment = None` from `process_functions.py`.** It is set globally to suppress warnings for intentional assignment patterns used throughout the pipeline.
+- **Do NOT skip `fillna("")` before string comparisons.** Primary key generation in `load.py` depends on empty strings, not NaN. A bug fix (PR #601, GEN-998) was specifically for this.
+- **Do NOT assume `_cross_validate()` always runs.** It only executes if `_validate()` returned no errors AND `self.ancillary_files` is a non-empty list.
+- **Do NOT forget `syn.table_query_timeout = 50000` for new large table queries.** Without it, queries time out silently. Currently set in `process_mutation.py` and `database_to_staging.py` but not universally.
+- **Do NOT use `set()` for DataFrame index/column construction.** Always `sorted(set(...))` — non-deterministic set ordering caused production failures (GEN-2377).
+- **Do NOT allow pandas to auto-cast integer columns with NAs to float.** Explicitly use `pd.Int64Dtype()` for nullable integer columns — a runtime crash (GEN-2285, PR #615) was caused by dtype confusion from auto-casting.

--- a/genie_registry/CLAUDE.md
+++ b/genie_registry/CLAUDE.md
@@ -16,6 +16,14 @@ Pluggable file format registry for the GENIE pipeline. Each file defines a forma
 
 ## Constraints
 
-- Do not rename `_fileType` values — they are used as registry keys and referenced throughout the pipeline and in Synapse table mappings.
-- `patientRetraction` inherits from `sampleRetraction`, not directly from `FileTypeFormat`. Preserve this chain.
 - Validation error messages must follow the format documented in root CLAUDE.md — because sites receive these messages directly.
+
+## Do NOT
+
+- **Do NOT replace `assert` statements in `_validateFilename()` with `raise ValueError`.** The pipeline catches `AssertionError` to try the next file format in the plugin registry. Changing to ValueError breaks format discovery.
+- **Do NOT put cross-file validation in format classes other than `clinical.py`.** All cross-file checks go in `clinical.py._cross_validate()` — because clinical is the source of truth.
+- **Do NOT rename `_fileType` values.** They are registry keys referenced throughout the pipeline and in Synapse table mappings.
+- **Do NOT "fix" the `patientRetraction` → `sampleRetraction` inheritance chain.** `patientRetraction` intentionally inherits from `sampleRetraction`, not directly from `FileTypeFormat`.
+- **Do NOT write custom column existence checks.** Use `process_functions.checkColExist()` — reviewer explicitly flagged this in PR #622.
+- **Do NOT omit specific invalid values from error messages.** Messages must include "Found: <values>" — a revert happened when this was removed (sites need it for debugging).
+- **Do NOT skip NA/empty string edge cases in validation tests.** Reviewer required NA test cases in PR #622 and PR #634. Always test: NA values, empty strings, and empty columns.

--- a/genie_registry/CLAUDE.md
+++ b/genie_registry/CLAUDE.md
@@ -1,0 +1,21 @@
+<!-- Last reviewed: 2026-03 -->
+
+## Project
+
+Pluggable file format registry for the GENIE pipeline. Each file defines a format class that inherits from `FileTypeFormat` and implements validation and processing logic for one genomic data format.
+
+## Conventions
+
+- Every class must set `_fileType` (string identifier), `_validation_kwargs`, and `_process_kwargs` class attributes.
+- Override `_validateFilename()` using `assert` — the pipeline catches `AssertionError` to try the next format.
+- Override `_validate()` to return `(error_string, warning_string)`. Empty error string = valid.
+- Override `_cross_validate()` only if this format needs cross-file checks. Cross-validation for clinical data stays in `clinical.py`.
+- Override `process_steps()` for processing logic. Call `preprocess()` for setup.
+- Default file reading is TSV via `pd.read_csv(path, sep="\t", comment="#")`. Override `_get_dataframe()` only if format differs (e.g., YAML for assay).
+- Class naming is inconsistent (lowercase `bed`, `maf`, `cna` vs PascalCase `Clinical`, `StructuralVariant`). Match the existing convention for the class you're modifying.
+
+## Constraints
+
+- Do not rename `_fileType` values — they are used as registry keys and referenced throughout the pipeline and in Synapse table mappings.
+- `patientRetraction` inherits from `sampleRetraction`, not directly from `FileTypeFormat`. Preserve this chain.
+- Validation error messages must follow the format documented in root CLAUDE.md — because sites receive these messages directly.

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -1,0 +1,51 @@
+<!-- Last reviewed: 2026-03 -->
+
+## Project
+
+pytest test suite for `genie` and `genie_registry` packages. Tests mirror source modules: `test_clinical.py` tests `genie_registry/clinical.py`, etc.
+
+## Fixtures (conftest.py)
+
+- `syn` — `mock.create_autospec(synapseclient.Synapse)`. Session-scoped. Shared across all tests. Do not modify its default state in tests — add `side_effect` or `return_value` per test instead.
+- `genie_config` — dict mapping table type names to Synapse IDs, with `center_config` containing SAGE/TEST/GOLD centers. Session-scoped.
+- Format class fixtures: instantiate as `FormatClass(syn, "SAGE")` for validation-only, or `FormatClass(syn, "SAGE", genie_config)` when config is needed. Some accept `ancillary_files` as fourth arg for cross-validation.
+
+## Mock Table Pattern
+
+`createMockTable(dataframe)` is copy-pasted across test files (test_clinical.py, test_cna.py, test_bed.py, etc.) — it is NOT in conftest.py. Pattern:
+```python
+def createMockTable(dataframe):
+    table = mock.create_autospec(synapseclient.table.CsvFileTable)
+    table.asDataFrame.return_value = dataframe
+    return table
+```
+
+Use with query dispatch:
+```python
+table_query_results_map = {
+    ("select * from syn123",): createMockTable(some_df),
+    ("select * from syn456",): createMockTable(other_df),
+}
+syn.tableQuery.side_effect = lambda *args: table_query_results_map[args]
+```
+
+## Test Data
+
+- Create inline using `pd.DataFrame(dict(COL1=[...], COL2=[...]))` with **UPPERCASE** column names — because the pipeline uppercases on read.
+- No external test data fixture files. All test data lives in the test module.
+- Module-level DataFrames are fine for read-only test data shared across functions.
+- Synapse entities: `synapseclient.File(name="...", path="...", parentId="syn123")` with attributes set after creation.
+
+## Naming Conventions
+
+- Format class validation: `test_<adjective>_<method>` (e.g., `test_perfect__validate`, `test_missingcols__validate`). Double underscore before private method names.
+- Behavior-driven: `test_that_<behavior>` (e.g., `test_that_to_unix_epoch_time_utc_gives_expected_time`).
+- Always use `ids=` parameter with `@pytest.mark.parametrize` for clear test output.
+- Include ALL pass and fail cases in the same parametrize block.
+
+## Mock Pattern
+
+- Prefer `with patch.object(module, "function_name") as mock_fn:` — place assertions INSIDE the `with` block.
+- For multiple mocks: chain in single `with` statement: `with patch.object(...) as m1, patch.object(...) as m2:`.
+- For Synapse queries, use `syn.tableQuery.side_effect` pointing to a dispatch function, not `return_value`.
+- Verify calls with `assert_called_once_with()` or `assert_has_calls()`.

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -12,7 +12,7 @@ pytest test suite for `genie` and `genie_registry` packages. Tests mirror source
 
 ## Mock Table Pattern
 
-`createMockTable(dataframe)` is copy-pasted across test files (test_clinical.py, test_cna.py, test_bed.py, etc.) — it is NOT in conftest.py. Pattern:
+`createMockTable(dataframe)` is copy-pasted across test files (test_clinical.py, test_cna.py, test_filters.py, test_mutations_in_cis.py) — it is NOT in conftest.py. Pattern:
 ```python
 def createMockTable(dataframe):
     table = mock.create_autospec(synapseclient.table.CsvFileTable)
@@ -40,7 +40,6 @@ syn.tableQuery.side_effect = lambda *args: table_query_results_map[args]
 
 - Format class validation: `test_<adjective>_<method>` (e.g., `test_perfect__validate`, `test_missingcols__validate`). Double underscore before private method names.
 - Behavior-driven: `test_that_<behavior>` (e.g., `test_that_to_unix_epoch_time_utc_gives_expected_time`).
-- Always use `ids=` parameter with `@pytest.mark.parametrize` for clear test output.
 - Include ALL pass and fail cases in the same parametrize block.
 
 ## Mock Pattern
@@ -49,3 +48,11 @@ syn.tableQuery.side_effect = lambda *args: table_query_results_map[args]
 - For multiple mocks: chain in single `with` statement: `with patch.object(...) as m1, patch.object(...) as m2:`.
 - For Synapse queries, use `syn.tableQuery.side_effect` pointing to a dispatch function, not `return_value`.
 - Verify calls with `assert_called_once_with()` or `assert_has_calls()`.
+
+## Do NOT
+
+- **Do NOT swap or reuse test IDs without verifying they match the scenario.** PR #638 had swapped test IDs that silently passed but validated wrong scenarios — required a follow-up fix PR #639.
+- **Do NOT write tests that only cover the happy path.** Reviewers require: (a) data passes unchanged, (b) empty inputs, (c) all data filtered, (d) no matches found (PR #587 review).
+- **Do NOT duplicate test cases that overlap with parametrized tests.** Reviewer flagged redundant tests in PR #622 — use parametrize for similar scenarios.
+- **Do NOT leave deprecated feature tests in place.** When a feature is deprecated, remove ALL related test cases in the same PR (PR #638 lesson).
+- **Do NOT consolidate `createMockTable()` into conftest.py.** It is intentionally copy-pasted across test files (test_clinical.py, test_cna.py, test_filters.py, test_mutations_in_cis.py). This is a known pattern, not technical debt.


### PR DESCRIPTION
## Summary
- Add 5 CLAUDE.md files (root, genie/, genie_registry/, tests/, bin/) documenting non-obvious project conventions for AI-assisted development
- Root file covers project overview, stack, commands, data models, validation error format, architecture, PHI constraints, and related systems
- Module-level files cover: template method pattern and reusable utilities (genie/), plugin registry conventions (genie_registry/), fixture and mock patterns (tests/), CLI argument naming and concurrency lock gotchas (bin/)
- Total 266 lines across all files, each under 150-line limit

## Test plan
- [ ] Verify no code changes — only new `.md` files added
- [ ] Spot-check referenced functions exist (e.g., `checkColExist`, `createMockTable`, `check_col_and_values`)
- [ ] Confirm conventions match team's actual practices

🤖 Generated with [Claude Code](https://claude.com/claude-code)