### PR TITLE
Update `requests >= 2.34.0` due to security vulnerabilities

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-# known working version 4.0.0
-chardet>=3.0.4
+# locked down chardet due to encoding issues with newer versions
+chardet>=3.0.4, <=5.2.0
 # known working version 0.20.4
 httplib2>=0.11.3
 pyranges==0.1.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,5 @@ pyranges==0.1.4
 PyYAML>=5.1
 synapseclient[pandas]>=4.8.0, <5.0.0
 opentelemetry-semantic-conventions==0.56b0
+# upgrade to 2.34.0 to fix security vulnerabilities in versions <2.34.0
+requests>=2.34.0,<3.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,11 +34,10 @@ install_requires =
     # pandas>=2.0.0, <3.0.0
     httplib2>=0.11.3
     PyYAML>=5.1
-    chardet>=3.0.4
-    # numpy<=1.22.2
-    requests>=2.34.0,<3.0
     # locked down chardet due to encoding issues with newer versions
     chardet>=3.0.4, <=5.2.0
+    # numpy<=1.22.2
+    requests>=2.34.0,<3.0
 python_requires = >=3.10, <3.12
 include_package_data = True
 zip_safe = False

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,6 +36,7 @@ install_requires =
     PyYAML>=5.1
     chardet>=3.0.4
     # numpy<=1.22.2
+    requests>=2.34.0,<3.0
 python_requires = >=3.10, <3.12
 include_package_data = True
 zip_safe = False

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,6 +37,8 @@ install_requires =
     chardet>=3.0.4
     # numpy<=1.22.2
     requests>=2.34.0,<3.0
+    # locked down chardet due to encoding issues with newer versions
+    chardet>=3.0.4, <=5.2.0
 python_requires = >=3.10, <3.12
 include_package_data = True
 zip_safe = False

--- a/tests/test_process_functions.py
+++ b/tests/test_process_functions.py
@@ -1,11 +1,9 @@
 import datetime
+import json
 import uuid
-from unittest.mock import Mock, patch
+from unittest.mock import call, Mock, patch
 
 import pandas as pd
-import pytest
-import synapseclient
-from genie import process_functions
 from pandas.api.types import (
     is_bool_dtype,
     is_float_dtype,
@@ -13,6 +11,11 @@ from pandas.api.types import (
     is_string_dtype,
 )
 from pandas.testing import assert_frame_equal
+import pytest
+import requests
+import synapseclient
+
+from genie import process_functions
 
 DATABASE_DF = pd.DataFrame(
     {
@@ -1132,3 +1135,138 @@ def test_add_columns_to_data_gene_matrix(
 
     # check the output
     pd.testing.assert_frame_equal(output, expected_output)
+
+
+def test_retry_get_url_uses_requests_session_with_retries():
+    mock_response = Mock(status_code=200, text="ok")
+    mock_session = Mock()
+    mock_session.get.return_value = mock_response
+
+    with patch.object(
+        process_functions.requests, "Session", return_value=mock_session
+    ) as patch_session, patch.object(
+        process_functions, "HTTPAdapter"
+    ) as patch_http_adapter, patch.object(
+        process_functions, "Retry"
+    ) as patch_retry:
+        patch_retry.return_value = "mock_retry"
+        patch_http_adapter.return_value = "mock_adapter"
+
+        response = process_functions.retry_get_url("https://example.org/test")
+
+        patch_session.assert_called_once_with()
+        patch_retry.assert_called_once_with(total=5, backoff_factor=1)
+        assert mock_session.mount.call_args_list == [
+            call("http://", "mock_adapter"),
+            call("https://", "mock_adapter"),
+        ]
+        patch_http_adapter.assert_has_calls(
+            [
+                call(max_retries="mock_retry"),
+                call(max_retries="mock_retry"),
+            ]
+        )
+        mock_session.get.assert_called_once_with(
+            "https://example.org/test", timeout=3
+        )
+        assert response == mock_response
+
+
+def test_checkUrl_passes_when_status_code_is_200():
+    mock_response = Mock(status_code=200)
+
+    with patch.object(
+        process_functions, "retry_get_url", return_value=mock_response
+    ) as patch_retry_get_url:
+        process_functions.checkUrl("https://example.org")
+
+        patch_retry_get_url.assert_called_once_with("https://example.org")
+
+
+def test_checkUrl_raises_assertion_error_when_status_code_is_not_200():
+    mock_response = Mock(status_code=500)
+
+    with patch.object(
+        process_functions, "retry_get_url", return_value=mock_response
+    ) as patch_retry_get_url:
+        with pytest.raises(AssertionError, match="https://example.org site is down"):
+            process_functions.checkUrl("https://example.org")
+
+        patch_retry_get_url.assert_called_once_with("https://example.org")
+
+
+def test_get_gdc_data_dictionary_returns_response_json():
+    expected_response = {
+        "properties": {
+            "disease_type": {
+                "enum": ["Disease A", "Disease B"],
+            }
+        }
+    }
+    mock_response = Mock(text=json.dumps(expected_response))
+
+    with patch.object(
+        process_functions, "retry_get_url", return_value=mock_response
+    ) as patch_retry_get_url:
+        result = process_functions.get_gdc_data_dictionary("case")
+
+        patch_retry_get_url.assert_called_once_with(
+            "https://api.gdc.cancer.gov/v0/submission/_dictionary/case"
+        )
+        assert result == expected_response
+
+
+def test_get_oncotree_code_mappings_uses_retry_get_url_and_parses_mapping():
+    oncotree_response = {
+        "TISSUE": {
+            "children": {
+                "LUNG": {
+                    "level": 1,
+                    "mainType": "Lung Cancer",
+                    "name": "Lung Cancer",
+                    "children": {
+                        "LUAD": {
+                            "level": 2,
+                            "mainType": "Lung Adenocarcinoma",
+                            "name": "Lung Adenocarcinoma",
+                            "children": {},
+                        }
+                    },
+                }
+            }
+        }
+    }
+    mock_response = Mock(text=json.dumps(oncotree_response))
+
+    with patch.object(
+        process_functions, "retry_get_url", return_value=mock_response
+    ) as patch_retry_get_url:
+        result = process_functions.get_oncotree_code_mappings(
+            "https://oncotree.example.org/api/tumorTypes"
+        )
+
+        patch_retry_get_url.assert_called_once_with(
+            "https://oncotree.example.org/api/tumorTypes"
+        )
+        assert result["LUNG"] == {
+            "CANCER_TYPE": "Lung Cancer",
+            "CANCER_TYPE_DETAILED": "Lung Cancer",
+            "ONCOTREE_PRIMARY_NODE": "LUNG",
+            "ONCOTREE_SECONDARY_NODE": "",
+        }
+        assert result["LUAD"] == {
+            "CANCER_TYPE": "Lung Adenocarcinoma",
+            "CANCER_TYPE_DETAILED": "Lung Adenocarcinoma",
+            "ONCOTREE_PRIMARY_NODE": "LUNG",
+            "ONCOTREE_SECONDARY_NODE": "LUAD",
+        }
+
+     
+def test_retry_get_url_propagates_request_exception():
+    with patch.object(
+        process_functions.requests, "Session"
+    ) as patch_session:
+        patch_session.return_value.get.side_effect = requests.Timeout()
+
+        with pytest.raises(requests.Timeout):
+            process_functions.retry_get_url("https://example.org")

--- a/tests/test_process_functions.py
+++ b/tests/test_process_functions.py
@@ -1166,9 +1166,7 @@ def test_retry_get_url_uses_requests_session_with_retries():
                 call(max_retries="mock_retry"),
             ]
         )
-        mock_session.get.assert_called_once_with(
-            "https://example.org/test", timeout=3
-        )
+        mock_session.get.assert_called_once_with("https://example.org/test", timeout=3)
         assert response == mock_response
 
 
@@ -1261,11 +1259,9 @@ def test_get_oncotree_code_mappings_uses_retry_get_url_and_parses_mapping():
             "ONCOTREE_SECONDARY_NODE": "LUAD",
         }
 
-     
+
 def test_retry_get_url_propagates_request_exception():
-    with patch.object(
-        process_functions.requests, "Session"
-    ) as patch_session:
+    with patch.object(process_functions.requests, "Session") as patch_session:
         patch_session.return_value.get.side_effect = requests.Timeout()
 
         with pytest.raises(requests.Timeout):


### PR DESCRIPTION
# **Problem:**
Currently our `requests` library is not anchored to a specific version and seems to be currently ~2.32
See security issues brought up via this PR: https://github.com/Sage-Bionetworks/synapsePythonClient/pull/1385

# **Solution:**
Lock down `requests` to be >= 2.34 or higher

Note: This ticket also locks down `chardet` to the current working version that's in our main genie production image due to an issue raised here with newer versions of chardet: https://sagebionetworks.jira.com/browse/GEN-2592

# **Testing:**
- [x]  Test run of pipeline still works with newly built docker image with higher `requests`
- [x] Additional tests that tests functions that use `requests` 