### PR TITLE
[GEN-2631] Increase determine data type limit for mutation files

### DIFF
--- a/genie/process_mutation.py
+++ b/genie/process_mutation.py
@@ -16,6 +16,9 @@ from . import extract, load, process_functions
 
 logger = logging.getLogger(__name__)
 
+# Change this nrows to 10000 so that it better encapsulates the types
+MAX_ROWS_TO_DETERMINE_DTYPE = 10000
+
 # TODO: add to constants.py
 # Some columns are already capitalized, so they aren't included here
 MAF_COL_MAPPING = {
@@ -134,8 +137,9 @@ def _convert_to_str_dtype(column_types, known_string_cols):
 # TODO Add to utils
 def determine_dtype(path: str):
     """Reads in a dataframe partially and determines the dtype of columns"""
-    # Change this nrows to 5000 so that it better encapsulates the types
-    subset_df = pd.read_csv(path, nrows=5000, sep="\t", comment="#")
+    subset_df = pd.read_csv(
+        path, nrows=MAX_ROWS_TO_DETERMINE_DTYPE, sep="\t", comment="#"
+    )
     column_types = subset_df.dtypes.to_dict()
     return column_types
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-# known working version 4.0.0
-chardet>=3.0.4
+# locked down chardet due to encoding issues with newer versions
+chardet>=3.0.4, <=5.2.0
 # known working version 0.20.4
 httplib2>=0.11.3
 pyranges==0.1.4

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,7 +34,8 @@ install_requires =
     # pandas>=2.0.0, <3.0.0
     httplib2>=0.11.3
     PyYAML>=5.1
-    chardet>=3.0.4
+    # locked down chardet due to encoding issues with newer versions
+    chardet>=3.0.4, <=5.2.0
     # numpy<=1.22.2
 python_requires = >=3.10, <3.12
 include_package_data = True

--- a/tests/test_process_mutation.py
+++ b/tests/test_process_mutation.py
@@ -54,6 +54,38 @@ class TestDtype:
             col_types = process_mutation.determine_dtype("test.csv")
             assert col_types == self.column_types
 
+    def test_determine_dtype_with_around_9000_nas_still_detects_dtype(self, tmp_path):
+        """Test dtype inference still works when many leading rows are NA."""
+        mutation_file = tmp_path / "test_mutation.tsv"
+
+        test_df = pd.DataFrame(
+            {
+                "mostly_na_then_string": [float("nan")] * 9000 + ["variant"],
+                "mostly_na_then_int": [float("nan")] * 9000 + [1],
+            }
+        )
+        test_df.to_csv(mutation_file, sep="\t", index=False)
+
+        col_types = process_mutation.determine_dtype(str(mutation_file))
+
+        assert col_types["mostly_na_then_string"] == "object"
+        assert col_types["mostly_na_then_int"] == "float64"
+
+    def test_determine_dtype_only_uses_first_10000_rows(self, tmp_path):
+        """Rows after 10,000 should not affect inferred dtype."""
+        mutation_file = tmp_path / "test_mutation.tsv"
+
+        test_df = pd.DataFrame(
+            {
+                "mixed_after_limit": list(range(10000)) + ["not_an_int"],
+            }
+        )
+        test_df.to_csv(mutation_file, sep="\t", index=False)
+
+        col_types = process_mutation.determine_dtype(str(mutation_file))
+
+        assert col_types["mixed_after_limit"] == "int64"
+
     @pytest.mark.parametrize(
         "input_columns_types, known_str_cols, expected_new_column_types",
         [


### PR DESCRIPTION
# **Problem:**
See JIRA ticket for more info but we ran into ` ValueError: Integer column has NA values in column 5` error due to the following columns having NAs past the 5000 row limit (NAs starting around ~7000 rows) used 

- t_alt_count
- t_depth
- t_ref_count

JIRA Ticket: https://sagebionetworks.jira.com/browse/GEN-2631

# **Solution:**
Increase this row limit to 10,000 in determining data type to support mutation files that have more than 5000 rows of non-NA values

# **Testing:**
- [x] Test pipeline runs
- [x] Comparsion report yields the same results before and after
- [x] Unit tests added